### PR TITLE
fix regex to allow dot between parameters in path

### DIFF
--- a/src/main/java/io/apicurio/datamodels/core/validation/ValidationRule.java
+++ b/src/main/java/io/apicurio/datamodels/core/validation/ValidationRule.java
@@ -49,8 +49,8 @@ public abstract class ValidationRule extends CombinedAllNodeVisitor implements I
         }));
     };
 
-    private static String PATH_MATCH_REGEX = "^(\\/[^{}\\/]*(\\{[a-zA-Z_][0-9a-zA-Z_]*\\})?)+$";
-    private static String SEG_MATCH_REGEX = "\\/([^{}\\/]*)(\\{([a-zA-Z_][0-9a-zA-Z_]*)\\})?";
+    private static String PATH_MATCH_REGEX = "^(\\/[^{}\\/]*(\\{[a-zA-Z_][0-9a-zA-Z_]*\\})?(\\.\\{[a-zA-Z_][0-9a-zA-Z_]*\\})?)+$";
+    private static String SEG_MATCH_REGEX = "[\\/\\.]([^{}\\/]*)(\\{([a-zA-Z_][0-9a-zA-Z_]*)\\})?";
     private static String URL_MATCH_REGEX = "^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$";
     private static String EMAIL_MATCH_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
     private static String MIME_TYPE_MATCH_REGEX = "^.*\\/.*(;.*)?$";

--- a/src/test/resources/fixtures/validation/openapi/3.0/invalid-property-name.json
+++ b/src/test/resources/fixtures/validation/openapi/3.0/invalid-property-name.json
@@ -643,6 +643,72 @@
           }
         }
       }
+    },
+    "/pathstest28/{var1}.{var2}": {
+      "get": {
+        "description": "pathstest28 - path with dot (/pathstest28/{var1}.{var2}) - valid",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/var1"
+          },
+          {
+            "$ref": "#/components/parameters/var2"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest28/test.{var1}": {
+      "get": {
+        "description": "pathstest28 - path with dot (/pathstest28/test.{var1}) - valid",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/var1"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest28/{var1}.{var2}": {
+      "get": {
+        "description": "pathstest28 - path with dot (/pathstest28/{var1}.{var2}) - valid",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/var1"
+          },
+          {
+            "$ref": "#/components/parameters/var2"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest28/test.{var1}": {
+      "get": {
+        "description": "pathstest28 - path with dot (/pathstest28/test.{var1}) - valid",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/var1"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/test/resources/fixtures/validation/openapi/3.0/invalid-property-name.json
+++ b/src/test/resources/fixtures/validation/openapi/3.0/invalid-property-name.json
@@ -676,39 +676,6 @@
           }
         }
       }
-    },
-    "/pathstest28/{var1}.{var2}": {
-      "get": {
-        "description": "pathstest28 - path with dot (/pathstest28/{var1}.{var2}) - valid",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/var1"
-          },
-          {
-            "$ref": "#/components/parameters/var2"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "..."
-          }
-        }
-      }
-    },
-    "/pathstest28/test.{var1}": {
-      "get": {
-        "description": "pathstest28 - path with dot (/pathstest28/test.{var1}) - valid",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/var1"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "..."
-          }
-        }
-      }
     }
   },
   "components": {


### PR DESCRIPTION
Related issue: #157 

the SEG_MATCH_REGEX fix allows correct parsing of Path Segments in a path

the PATH_MATCH_REGEX fix allows correct validation for path format. The following will pass:
```
/resources/{fooId}/subresources/{barId}.{ext}
/resources/{fooId}/subresources/{barId}
/resources/{fooId}/subresources/report.{format}
```
but not
```
/resources/{fooId}/subresources/{barId}{ext}
```

Some references:
- https://github.com/go-swagger/go-swagger/issues/1050
- https://swagger.io/docs/specification/describing-parameters/