### PR TITLE
Adding new Asyncapi 20 commands

### DIFF
--- a/src/main/java/io/apicurio/datamodels/asyncapi/v2/models/Aai20Components.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/v2/models/Aai20Components.java
@@ -29,7 +29,7 @@ import io.apicurio.datamodels.core.models.Node;
  */
 public class Aai20Components extends AaiComponents {
 
-    public Map<String, Aai20SchemaDefinition> schemas;
+    public Map<String, Aai20SchemaDefinition> schemas = new LinkedHashMap<>();
 
     /**
      * Constructor.

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaDefinitionCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaDefinitionCommand_Aai20.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Components;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat;
+import io.apicurio.datamodels.core.models.Document;
+
+/**
+ * A command used to add a new definition in a document. Source for the new
+ * definition must be provided. This source will be converted to an AAI
+ * definition object and then added to the data model.
+ * @author laurent.broudoux@gmail.com
+ */
+public class AddSchemaDefinitionCommand_Aai20 extends AbstractCommand {
+
+   public boolean _defExisted;
+   public String _newDefinitionName;
+   @JsonDeserialize(using= MarshallCompat.NullableJsonNodeDeserializer.class)
+   public Object _newDefinitionObj;
+
+   public boolean _nullComponents;
+
+   AddSchemaDefinitionCommand_Aai20() {
+   }
+
+   AddSchemaDefinitionCommand_Aai20(String definitionName) {
+      this._newDefinitionName = definitionName;
+   }
+
+   AddSchemaDefinitionCommand_Aai20(String definitionName, Object from) {
+      this._newDefinitionName = definitionName;
+      this._newDefinitionObj = from;
+   }
+
+   @Override
+   public void execute(Document document) {
+      LoggerCompat.info("[AddSchemaDefinitionCommand_Aai20] Executing.");
+
+      Aai20Document doc = (Aai20Document) document;
+
+      // Do nothing if the definition already exists.
+      if (this.defExists(doc)) {
+         LoggerCompat.info("[AddSchemaDefinitionCommand_Aai20] Definition with name %s already exists.", this._newDefinitionName);
+         this._defExisted = true;
+         return;
+      }
+
+      if (this.isNullOrUndefined(doc.components)) {
+         doc.components = doc.createComponents();
+         this._nullComponents = true;
+      } else {
+         this._nullComponents = false;
+      }
+
+      // Now create, initialize and attach the SchemaDefinition.
+      Aai20Components components = (Aai20Components) doc.components;
+      Aai20SchemaDefinition definition = components.createSchemaDefinition(this._newDefinitionName);
+      Library.readNode(this._newDefinitionObj, definition);
+      components.addSchemaDefinition(this._newDefinitionName, definition);
+   }
+
+   @Override
+   public void undo(Document document) {
+      LoggerCompat.info("[AddSchemaDefinitionCommand_Aai20] Reverting.");
+      if (this._defExisted) {
+         return;
+      }
+
+      Aai20Document doc = (Aai20Document) document;
+      if (this._nullComponents) {
+         doc.components = null;
+      }
+      ((Aai20Components) doc.components).removeSchemaDefinition(this._newDefinitionName);
+   }
+
+   private boolean defExists(Aai20Document document) {
+      if (this.isNullOrUndefined(document.components)) {
+         return false;
+      }
+      Aai20Components components = (Aai20Components)document.components;
+      return !this.isNullOrUndefined(components.getSchemaDefinition(this._newDefinitionName));
+   }
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -301,7 +301,10 @@ public class CommandFactory {
             { return new NewResponseDefinitionCommand_20(); }
             case "NewResponseDefinitionCommand_30":
             { return new NewResponseDefinitionCommand_30(); }
-            
+            case "NewChannelCommand":
+            case "NewChannelCommand_Aai20":
+            { return new NewChannelCommand(); }
+
             /** Rename Commands **/
             
             case "RenameParameterCommand":

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -18,6 +18,7 @@ package io.apicurio.datamodels.cmd.commands;
 
 import java.util.List;
 
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
 import io.apicurio.datamodels.cmd.ICommand;
 import io.apicurio.datamodels.cmd.models.SimplifiedParameterType;
 import io.apicurio.datamodels.cmd.models.SimplifiedPropertyType;
@@ -101,6 +102,8 @@ public class CommandFactory {
             case "AddChannelItemCommand":
             case "AddChannelItemCommand_Aai20":
             { return new AddChannelItemCommand(); }
+            case "AddSchemaDefinitionCommand_Aai20":
+            { return new AddSchemaDefinitionCommand_Aai20(); }
 
             /** Change Commands **/
             
@@ -304,6 +307,10 @@ public class CommandFactory {
             case "NewChannelCommand":
             case "NewChannelCommand_Aai20":
             { return new NewChannelCommand(); }
+            case "NewSchemaDefinitionCommand_Aai20":
+            { return new NewSchemaDefinitionCommand_Aai20(); }
+            case "NewSchemaPropertyCommand_Aai20":
+            { return new NewSchemaPropertyCommand_Aai20(); }
 
             /** Rename Commands **/
             
@@ -390,6 +397,9 @@ public class CommandFactory {
         if (docType == DocumentType.openapi3) {
             return new AddSchemaDefinitionCommand_30(definitionName, from);
         }
+        if (docType == DocumentType.asyncapi2) {
+            return new AddSchemaDefinitionCommand_Aai20(definitionName, from);
+        }
         throw new RuntimeException("Document type not supported by this command.");
     }
 
@@ -415,6 +425,10 @@ public class CommandFactory {
 
     public static final ICommand createAddChildSchemaCommand(OasSchema schema, OasSchema childSchema, String childType) {
         return new AddChildSchemaCommand(schema, childSchema, childType);
+    }
+
+    public static final ICommand createAddChannelItemCommand(String channelItemName, Object from) {
+        return new AddChannelItemCommand(channelItemName, from);
     }
 
     
@@ -657,7 +671,11 @@ public class CommandFactory {
     public static final ICommand createDeleteTagCommand(String tagName) {
         return new DeleteTagCommand(tagName);
     }
-    
+
+    public static final ICommand createDeleteChannelCommand(String channelName) {
+        return new DeleteChannelCommand(channelName);
+    }
+
     /** New Commands **/
     
     public static final ICommand createNewMediaTypeCommand(IOas30MediaTypeParent parent, String newMediaType) {
@@ -700,6 +718,9 @@ public class CommandFactory {
         if (docType == DocumentType.openapi3) {
             return new NewSchemaDefinitionCommand_30(definitionName, example, description);
         }
+        if (docType == DocumentType.asyncapi2) {
+            return new NewSchemaDefinitionCommand_Aai20(definitionName, example, description);
+        }
         throw new RuntimeException("Document type not supported by this command.");
     }
 
@@ -716,6 +737,9 @@ public class CommandFactory {
     
     public static final ICommand createNewSchemaPropertyCommand(Schema schema, String propertyName, 
             String description, SimplifiedPropertyType newType) {
+        if (schema instanceof AaiSchema) {
+            return new NewSchemaPropertyCommand_Aai20(schema, propertyName, description, newType);
+        }
         return new NewSchemaPropertyCommand(schema, propertyName, description, newType);
     }
 
@@ -736,6 +760,14 @@ public class CommandFactory {
     
     public static final ICommand createNewTagCommand(String name, String description) {
         return new NewTagCommand(name, description);
+    }
+
+    public static final ICommand createNewChannelCommand(String name) {
+        return new NewChannelCommand(name);
+    }
+
+    public static final ICommand createNewSchemaDefinitionCommand_Aai20(String name, Object example, String descriptioon) {
+        return new NewSchemaDefinitionCommand_Aai20(name, example, descriptioon);
     }
     
     /** Rename Commands **/

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewChannelCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewChannelCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.asyncapi.models.AaiChannelItem;
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.core.models.Document;
+
+/**
+ * A command used to create a new channel item in aa AsyncAPI document.
+ * @author laurent.broudoux@gmail.com
+ */
+public class NewChannelCommand extends AbstractCommand {
+
+   public String _newChannel;
+
+   public boolean _channelExisted;
+   public boolean _emptyChannels;
+
+   public NewChannelCommand() {
+   }
+
+   public NewChannelCommand(String newChannel) {
+      this._newChannel = newChannel;
+   }
+
+   @Override
+   public void execute(Document document) {
+      LoggerCompat.info("[NewChannelCommand] Executing.");
+      AaiDocument adoc = (AaiDocument) document;
+
+      if (adoc.channels != null && adoc.channels.isEmpty()) {
+         this._emptyChannels = true;
+      }
+      if (this.isNullOrUndefined(adoc.channels.get(this._newChannel))) {
+         AaiChannelItem channelItem = adoc.createChannelItem(this._newChannel);
+         adoc.addChannelItem(channelItem);
+         this._channelExisted = false;
+      } else {
+         this._channelExisted = true;
+      }
+   }
+
+   @Override
+   public void undo(Document document) {
+      LoggerCompat.info("[NewChannelCommand] Reverting.");
+      AaiDocument adoc = (AaiDocument) document;
+      if (this._channelExisted) {
+         LoggerCompat.info("[NewChannelCommand] channel already existed, nothing done so no rollback necessary.");
+         return;
+      }
+      if (this._emptyChannels) {
+         adoc.channels.clear();
+      } else {
+         adoc.channels.remove(this._newChannel);
+      }
+   }
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaDefinitionCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaDefinitionCommand_Aai20.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Components;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.core.factories.AaiSchemaFactory;
+import io.apicurio.datamodels.core.models.Document;
+
+/**
+ * @author laurent.broudoux@gmail.com
+ */
+public class NewSchemaDefinitionCommand_Aai20 extends NewSchemaDefinitionCommand {
+
+   public boolean _nullComponents;
+
+   NewSchemaDefinitionCommand_Aai20() {
+   }
+
+   NewSchemaDefinitionCommand_Aai20(String definitionName, Object example, String description) {
+      this._newDefinitionName = definitionName;
+      this._newDefinitionExample = example;
+      this._newDefinitionDescription = description;
+   }
+
+   @Override
+   public void execute(Document document) {
+      LoggerCompat.info("[NewSchemaDefinitionCommand_Aai20] Executing.");
+
+      Aai20Document doc20 = (Aai20Document) document;
+      if (this.isNullOrUndefined(doc20.components)) {
+         doc20.components = doc20.createComponents();
+         this._nullComponents = true;
+      }
+      this._nullComponents = false;
+
+      Aai20Components components = (Aai20Components) doc20.components;
+
+      if (this.isNullOrUndefined(components.getSchemaDefinition(this._newDefinitionName))) {
+         Aai20SchemaDefinition definition;
+
+         if (!this.isNullOrUndefined(this._newDefinitionExample)) {
+            definition = (Aai20SchemaDefinition) AaiSchemaFactory.createSchemaDefinitionFromExample(doc20,
+                  this._newDefinitionName, this._newDefinitionExample);
+            definition.example = this._newDefinitionExample;
+         } else {
+            definition = components.createSchemaDefinition(this._newDefinitionName);
+            definition.type = "object";
+         }
+         if (ModelUtils.isDefined(this._newDefinitionDescription)) {
+            definition.description = this._newDefinitionDescription;
+         }
+         components.addSchemaDefinition(this._newDefinitionName, definition);
+
+         this._defExisted = false;
+      } else {
+         this._defExisted = true;
+      }
+   }
+
+   @Override
+   public void undo(Document document) {
+      LoggerCompat.info("[NewSchemaDefinitionCommand_Aai20] Reverting.");
+
+      Aai20Document doc20 = (Aai20Document) document;
+
+      if (this._nullComponents) {
+         doc20.components = null;
+      }
+      if (this._defExisted) {
+         return;
+      }
+
+      ((Aai20Components) doc20.components).removeSchemaDefinition(this._newDefinitionName);
+   }
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand_Aai20.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.apicurio.datamodels.asyncapi.models.IAaiPropertySchema;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.cmd.models.SimplifiedPropertyType;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.cmd.util.SimplifiedTypeUtil;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.core.Constants;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.NodePath;
+import io.apicurio.datamodels.core.models.common.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to create a new schema property for AsyncAPI Schema
+ * @author laurent.broudoux@gmail.com
+ */
+public class NewSchemaPropertyCommand_Aai20 extends AbstractCommand {
+
+    public String _propertyName;
+    public NodePath _schemaPath;
+    public String _description;
+    public SimplifiedPropertyType _newType;
+
+    public boolean _created;
+    public boolean _nullRequired;
+
+    NewSchemaPropertyCommand_Aai20() {
+    }
+
+    NewSchemaPropertyCommand_Aai20(Schema schema, String propertyName, String description, SimplifiedPropertyType newType) {
+        this._schemaPath = Library.createNodePath(schema);
+        this._propertyName = propertyName;
+        this._description = description;
+        this._newType = newType;
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[NewSchemaPropertyCommand_Aai20] Executing.");
+
+        this._created = false;
+
+        AaiSchema schema = (AaiSchema) this._schemaPath.resolve(document);
+        if (this.isNullOrUndefined(schema)) {
+            LoggerCompat.info("[NewSchemaPropertyCommand_Aai20] Schema is null.");
+            return;
+        }
+
+        if (ModelUtils.isDefined(schema.getProperty(this._propertyName))) {
+            LoggerCompat.info("[NewSchemaPropertyCommand_Aai20] Property already exists.");
+            return;
+        }
+
+        AaiSchema property = schema.createPropertySchema(this._propertyName);
+        if (ModelUtils.isDefined(this._description)) {
+            property.description = this._description;
+        }
+        if (ModelUtils.isDefined(this._newType)) {
+            this._setPropertyType((IAaiPropertySchema) property);
+        }
+        schema.addProperty(this._propertyName, property);
+        LoggerCompat.info("[NewSchemaPropertyCommand_Aai20] Property [%s] created successfully.", this._propertyName);
+
+        this._created = true;
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[NewSchemaPropertyCommand_Aai20] Reverting.");
+        if (!this._created) {
+            return;
+        }
+
+        AaiSchema schema = (AaiSchema) this._schemaPath.resolve(document);
+        if (this.isNullOrUndefined(schema)) {
+            return;
+        }
+
+        if (this.isNullOrUndefined(schema.getProperty(this._propertyName))) {
+            return;
+        }
+
+        schema.removeProperty(this._propertyName);
+
+        // if the property was marked as required - need to remove it from the parent's "required" array
+        if (ModelUtils.isDefined(this._newType) && this._newType.required == Boolean.TRUE) {
+            List<String> required = schema.required;
+            required.remove(required.indexOf(this._propertyName));
+        }
+    }
+
+    /**
+     * Sets the property type.
+     * @param prop
+     */
+    protected void _setPropertyType(IAaiPropertySchema prop) {
+        // Update the schema's type
+        SimplifiedTypeUtil.setSimplifiedType((AaiSchema) prop, this._newType);
+        if (ModelUtils.isDefined(this._newType) && this._newType.required == Boolean.TRUE) {
+            AaiSchema parent = (AaiSchema) ((Node) prop).parent();
+            List<String> required = parent.required;
+            if (this.isNullOrUndefined(required)) {
+                required = new ArrayList<>();
+                NodeCompat.setProperty(parent, Constants.PROP_REQUIRED, required);
+                this._nullRequired = true;
+            }
+            required.add(prop.getPropertyName());
+        }
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/util/SetItemsTypeVisitor.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/util/SetItemsTypeVisitor.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.datamodels.cmd.util;
 
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.apicurio.datamodels.asyncapi.models.IAaiPropertySchema;
 import io.apicurio.datamodels.cmd.models.SimplifiedType;
 import io.apicurio.datamodels.combined.visitors.CombinedVisitorAdapter;
 import io.apicurio.datamodels.core.models.DocumentType;
@@ -118,4 +120,26 @@ public class SetItemsTypeVisitor extends CombinedVisitorAdapter {
         this.visitParameter((Parameter) node);
     }
 
+    /**
+     * @see io.apicurio.datamodels.combined.visitors.CombinedVisitorAdapter#visitPropertySchema(io.apicurio.datamodels.asyncapi.models.IAaiPropertySchema)
+     */
+    @Override
+    public void visitPropertySchema(IAaiPropertySchema node) {
+        this.visitAaiSchema((AaiSchema) node);
+    }
+
+    private void visitAaiSchema(AaiSchema node) {
+        AaiSchema schema = (AaiSchema) node;
+        schema.items = schema.createItemsSchema();
+        if (ModelUtils.isDefined(this.type.of)) {
+            // TODO Handle the case where "items" is actually a List of schemas.
+            AaiSchema items = (AaiSchema) schema.items;
+            if (this.type.of.isRef()) {
+                items.$ref = this.type.of.type;
+            } else {
+                items.type = this.type.of.type;
+                items.format = this.type.of.as;
+            }
+        }
+    }
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/util/SimplifiedTypeUtil.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/util/SimplifiedTypeUtil.java
@@ -18,6 +18,7 @@ package io.apicurio.datamodels.cmd.util;
 
 import java.util.ArrayList;
 
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
 import io.apicurio.datamodels.cmd.models.SimplifiedType;
 import io.apicurio.datamodels.core.util.VisitorUtil;
 import io.apicurio.datamodels.openapi.models.OasSchema;
@@ -29,6 +30,36 @@ import io.apicurio.datamodels.openapi.v2.models.Oas20Parameter;
 public class SimplifiedTypeUtil {
 
     public static void setSimplifiedType(OasSchema node, SimplifiedType type) {
+        node.$ref = null;
+        node.type = null;
+        node.enum_ = null;
+        node.format = null;
+        node.items = null;
+
+        if (type.isSimpleType()) {
+            node.type = type.type;
+            node.format = type.as;
+        }
+        if (type.isFileType()) {
+            node.type = type.type;
+        }
+        if (type.isEnum()) {
+            node.enum_ = new ArrayList<>();
+            type.enum_.forEach( v -> {
+                node.enum_.add(String.valueOf(v));
+            });
+        }
+        if (type.isRef()) {
+            node.$ref = type.type;
+        }
+        if (type.isArray()) {
+            node.type = "array";
+            SetItemsTypeVisitor viz = new SetItemsTypeVisitor(type);
+            VisitorUtil.visitNode(node, viz);
+        }
+    }
+
+    public static void setSimplifiedType(AaiSchema node, SimplifiedType type) {
         node.$ref = null;
         node.type = null;
         node.enum_ = null;

--- a/src/main/java/io/apicurio/datamodels/core/factories/AaiSchemaFactory.java
+++ b/src/main/java/io/apicurio/datamodels/core/factories/AaiSchemaFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.core.factories;
+
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Components;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.compat.JsonCompat;
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.compat.RegexCompat;
+import io.apicurio.datamodels.core.models.DocumentType;
+import io.apicurio.datamodels.core.models.common.IDefinition;
+
+import java.util.List;
+
+/**
+ * @author laurent.broudoux@gmail.com
+ */
+public class AaiSchemaFactory {
+
+   /**
+    * Creates a new definition schema from a given example.  This method will analyze the example
+    * object and create a new schema object that represents the example.  Note that this method
+    * does not support arbitrarily complicated examples, and should be used as a starting point
+    * for a schema, not a canonical one.
+    * @param document
+    * @param name
+    * @param example
+    */
+   public static IDefinition createSchemaDefinitionFromExample(AaiDocument document, String name, Object example) {
+      AaiSchema schema;
+
+      if (document.getDocumentType() == DocumentType.asyncapi2) {
+         Aai20Document doc = (Aai20Document) document;
+         if (ModelUtils.isNullOrUndefined(doc.components)) {
+            doc.components = doc.createComponents();
+         }
+         schema = ((Aai20Components) doc.components).createSchemaDefinition(name);
+      } else {
+         throw new RuntimeException("Only AsyncAPI 2 is currently supported.");
+      }
+
+      if (JsonCompat.isString(example)) {
+         example = JsonCompat.parseJSON(JsonCompat.toString(example));
+      }
+
+      resolveAll(example, schema);
+      schema.title = "Root Type for " + name;
+      schema.description = "The root of the " + name + " type's schema.";
+      return (IDefinition) schema;
+   }
+
+   private static void resolveAll(Object object, AaiSchema schema) {
+      resolveType(object, schema);
+      if (NodeCompat.equals(schema.type, "array")) {
+         schema.items = schema.createItemsSchema();
+         List<Object> list = JsonCompat.toList(object);
+         if (list.size() > 0) {
+            resolveAll(list.get(0), (AaiSchema) schema.items);
+         }
+      } else if (NodeCompat.equals(schema.type, "object")) {
+         schema.type = "object";
+         List<String> keys = JsonCompat.keys(object);
+         for (String propName : keys) {
+            AaiSchema pschema = schema.createPropertySchema(propName);
+            schema.addProperty(propName, pschema);
+            Object propValue = JsonCompat.getProperty(object, propName);
+            resolveAll(propValue, pschema);
+         }
+      }
+   }
+
+   private static void resolveType(Object thing, AaiSchema schema) {
+      if (JsonCompat.isNumber(thing)) {
+         Number value = JsonCompat.toNumber(thing);
+         boolean isInteger = ("" + value).indexOf(".") == -1;
+         if (isInteger) {
+            schema.type = "integer";
+            if (value.intValue() >= -2147483647 && value.intValue() <= 2147483647) {
+               schema.format = "int32";
+            } else if (value.longValue() >= -9223372036854775807l && value.longValue() <= 9223372036854775807l) {
+               schema.format = "int64";
+            }
+         } else {
+            schema.type = "number";
+            schema.format = "double";
+         }
+      } else if (JsonCompat.isBoolean(thing)) {
+         schema.type = "boolean";
+      } else if (JsonCompat.isArray(thing)) {
+         schema.type = "array";
+      } else if (JsonCompat.isObject(thing)) {
+         schema.type = "object";
+      } else if (JsonCompat.isString(thing)) {
+         String value = JsonCompat.toString(thing);
+         schema.type = "string";
+         if (RegexCompat.matches(value, "^(\\d{4})\\D?(0[1-9]|1[0-2])\\D?([12]\\d|0[1-9]|3[01])$")) {
+            schema.format = "date";
+         } else if (RegexCompat.matches(value, "^(\\d{4})\\D?(0[1-9]|1[0-2])\\D?([12]\\d|0[1-9]|3[01])(\\D?([01]\\d|2[0-3])\\D?([0-5]\\d)\\D?([0-5]\\d)?\\D?(\\d{3})?([zZ]|([\\+-])([01]\\d|2[0-3])\\D?([0-5]\\d)?)?)?$")) {
+            schema.format = "date-time";
+         }
+      } else if (JsonCompat.isNull(thing)) {
+         schema.type = "string";
+      }
+   }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.after.json
@@ -1,0 +1,25 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Channel example",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "newChannel": {}
+  },
+  "components": {
+    "messages": {
+      "testMessages": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.before.json
@@ -1,0 +1,22 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Channel example",
+    "version": "1.0.0"
+  },
+  "components": {
+    "messages": {
+      "testMessages": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-channel/asyncapi-2/new-channel.commands.json
@@ -1,0 +1,6 @@
+[
+  {
+    "__type": "NewChannelCommand",
+    "_newChannel": "newChannel"
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.after.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      },
+      "NewType": {
+        "type": "object",
+        "description": "Just a description of a new type."
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.before.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description.commands.json
@@ -1,0 +1,6 @@
+[{
+    "__type": "NewSchemaDefinitionCommand_Aai20",
+    "_newDefinitionName": "NewType",
+    "_newDefinitionExample": null,
+    "_newDefinitionDescription": "Just a description of a new type."
+}]

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.after.json
@@ -1,0 +1,60 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      },
+      "NewType": {
+        "title": "Root Type for NewType",
+        "description": "The root of the NewType type's schema.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "email": {
+            "type": "string"
+          },
+          "dob": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "example": {
+          "age": 46,
+          "dob": "1971-04-15",
+          "email": "jbourne@example.com",
+          "name": "Jason Bourne"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.before.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example.commands.json
@@ -1,0 +1,10 @@
+[{
+    "__type": "NewSchemaDefinitionCommand_Aai20",
+    "_newDefinitionName": "NewType",
+    "_newDefinitionExample": {
+        "name": "Jason Bourne",
+        "age": 46,
+        "email": "jbourne@example.com",
+        "dob": "1971-04-15"
+    }
+}]

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.after.json
@@ -1,0 +1,36 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      },
+      "NewType": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.before.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-definition/asyncapi-2/new-schema-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "NewSchemaDefinitionCommand_Aai20",
+    "_newDefinitionName": "NewType"
+}]

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.after.json
@@ -1,0 +1,41 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name", "newProperty"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "newProperty": {
+            "description": "Hello 3.0 world.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.before.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property-both.commands.json
@@ -1,0 +1,15 @@
+[{
+    "__type": "NewSchemaPropertyCommand_Aai20",
+    "_schemaPath": "/components/schemas[MySchema1]",
+    "_propertyName": "newProperty",
+    "_description": "Hello 3.0 world.",
+    "_newType": {
+        "type": "array",
+        "of": {
+            "type": "string",
+            "of": null,
+            "as": "date-time"
+        },
+        "required": true
+    }
+}]

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.after.json
@@ -1,0 +1,34 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "newProperty": {}
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.before.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "components": {
+    "schemas": {
+      "MySchema1" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "MySchema2": {
+        "type": "string",
+        "format": "email"
+      },
+      "RefSchema":{
+        "$ref": "#/other/Ref"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-schema-property/asyncapi-2/new-schema-property.commands.json
@@ -1,0 +1,6 @@
+[{
+    "__type": "NewSchemaPropertyCommand_Aai20",
+    "_schemaPath": "/components/schemas[MySchema1]",
+    "_propertyName": "newProperty",
+    "_newType": null
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -256,5 +256,6 @@
 
     { "name": "[AsyncAPI 2] {Add Channel Item} - Add Channel Item", "test": "commands/add-channel-item/asyncapi-2/add-channel-item" },
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
+    { "name": "[AsyncAPI 2] {New Channel} - New Channel", "test": "commands/new-channel/asyncapi-2/new-channel" },
     { "name": "[AsyncAPI 2] {Replace Document} - Replace Document", "test": "commands/replace-document/asyncapi-2/replace-document" }
 ]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -257,5 +257,10 @@
     { "name": "[AsyncAPI 2] {Add Channel Item} - Add Channel Item", "test": "commands/add-channel-item/asyncapi-2/add-channel-item" },
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
     { "name": "[AsyncAPI 2] {New Channel} - New Channel", "test": "commands/new-channel/asyncapi-2/new-channel" },
+    { "name": "[AsyncAPI 2] {New Schema Def} - New Schema Definition With Description", "test": "commands/new-schema-definition/asyncapi-2/new-schema-definition-with-description" },
+    { "name": "[AsyncAPI 2] {New Schema Def} - New Schema Definition With Example", "test": "commands/new-schema-definition/asyncapi-2/new-schema-definition-with-example" },
+    { "name": "[AsyncAPI 2] {New Schema Def} - New Schema Definition", "test": "commands/new-schema-definition/asyncapi-2/new-schema-definition" },
+    { "name": "[AsyncAPI 2] {New Schema Property} - New Schema Property Both", "test": "commands/new-schema-property/asyncapi-2/new-schema-property-both" },
+    { "name": "[AsyncAPI 2] {New Schema Property} - New Schema Property", "test": "commands/new-schema-property/asyncapi-2/new-schema-property" },
     { "name": "[AsyncAPI 2] {Replace Document} - Replace Document", "test": "commands/replace-document/asyncapi-2/replace-document" }
 ]


### PR DESCRIPTION
Adding this bunch of commands in order to progress on https://github.com/Apicurio/apicurio-studio/issues/447. 
All have been tested through Unit tests and integration tests from Studio.
We can now:
* Create new channel,
* Delete existing one,
* Create new Schema definition,
* Clone Schema definition,
* Edit properties within a schema definition.