### PR TITLE
AaiServers and SecuritySchemes part 2

### DIFF
--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiServer.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiServer.java
@@ -22,6 +22,8 @@ import java.util.List;
 import io.apicurio.datamodels.asyncapi.visitors.IAaiVisitor;
 import io.apicurio.datamodels.core.models.Node;
 import io.apicurio.datamodels.core.models.common.INamed;
+import io.apicurio.datamodels.core.models.common.ISecurityRequirementParent;
+import io.apicurio.datamodels.core.models.common.SecurityRequirement;
 import io.apicurio.datamodels.core.models.common.Server;
 import io.apicurio.datamodels.core.visitors.IVisitor;
 
@@ -31,12 +33,12 @@ import io.apicurio.datamodels.core.visitors.IVisitor;
  * @author eric.wittmann@gmail.com
  * @author Jakub Senko <jsenko@redhat.com>
  */
-public abstract class AaiServer extends Server implements INamed {
+public abstract class AaiServer extends Server implements INamed, ISecurityRequirementParent {
 
     public String _name;
     public String protocol;
     public String protocolVersion;
-    public List<AaiSecurityRequirement> security;
+    public List<SecurityRequirement> security;
     public AaiServerBindings bindings;
 
     /**
@@ -97,17 +99,22 @@ public abstract class AaiServer extends Server implements INamed {
         this._name = newName;
     }
 
-
+    @Override
+    public List<SecurityRequirement> getSecurityRequirements() {
+        return this.security;
+    }
+    
     /**
      * Adds a security requirement child.
      *
      * @param securityRequirement
      */
-    public AaiSecurityRequirement addSecurityRequirement(AaiSecurityRequirement securityRequirement) {
+    @Override
+    public SecurityRequirement addSecurityRequirement(SecurityRequirement securityRequirement) {
         if (this.security == null) {
             this.security = new ArrayList<>();
         }
-        this.security.add(securityRequirement);
+        this.security.add(((AaiSecurityRequirement) securityRequirement));
         return securityRequirement;
     }
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddSecurityRequirementCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddSecurityRequirementCommand.java
@@ -117,7 +117,20 @@ public class AddSecurityRequirementCommand extends AbstractCommand {
         }
         boolean rval = true;
         for (String name1 : names1) {
-            if (names2.indexOf(name1) == -1) {
+            if (names2.indexOf(name1) == -1 || !areScopesEqual(req1.getScopes(name1), req2.getScopes(name1))) {
+                rval = false;
+            }
+        }
+        return rval;
+    }
+
+    protected boolean areScopesEqual(List<String> scopes1, List<String> scopes2) {
+        if(scopes1.size() != scopes2.size()) {
+            return false;
+        }
+        boolean rval = true;
+        for (String scope1 : scopes1) {
+            if (scopes2.indexOf(scope1) == -1) {
                 rval = false;
             }
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllSecurityRequirementsCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllSecurityRequirementsCommand.java
@@ -33,7 +33,6 @@ import io.apicurio.datamodels.core.models.Node;
 import io.apicurio.datamodels.core.models.NodePath;
 import io.apicurio.datamodels.core.models.common.ISecurityRequirementParent;
 import io.apicurio.datamodels.core.models.common.SecurityRequirement;
-import io.apicurio.datamodels.openapi.models.OasSecurityRequirement;
 
 /**
  * A command used to delete all security requirements from a document or operation.
@@ -97,7 +96,7 @@ public class DeleteAllSecurityRequirementsCommand extends AbstractCommand {
             NodeCompat.setProperty(parent, Constants.PROP_SECURITY, requirements);
         }
         for (Object oldSecurityRequirement : this._oldSecurityRequirements) {
-            OasSecurityRequirement requirement = (OasSecurityRequirement) parent.createSecurityRequirement();
+            SecurityRequirement requirement = parent.createSecurityRequirement();
             Library.readNode(oldSecurityRequirement, requirement);
             requirements.add(requirement);
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllSecurityRequirementsCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllSecurityRequirementsCommand.java
@@ -48,7 +48,7 @@ public class DeleteAllSecurityRequirementsCommand extends AbstractCommand {
     }
     
     DeleteAllSecurityRequirementsCommand(ISecurityRequirementParent parent) {
-        Library.createNodePath((Node) parent);
+        this._parentPath = Library.createNodePath((Node) parent);
     }
     
     /**

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSecurityRequirementCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSecurityRequirementCommand.java
@@ -114,7 +114,20 @@ public class DeleteSecurityRequirementCommand extends AbstractCommand {
         }
         boolean rval = true;
         for (String name1 : names1) {
-            if (names2.indexOf(name1) == -1) {
+            if (names2.indexOf(name1) == -1 || !areScopesEqual(req1.getScopes(name1), req2.getScopes(name1))) {
+                rval = false;
+            }
+        }
+        return rval;
+    }
+    
+    protected boolean areScopesEqual(List<String> scopes1, List<String> scopes2) {
+        if(scopes1.size() != scopes2.size()) {
+            return false;
+        }
+        boolean rval = true;
+        for (String scope1 : scopes1) {
+            if (scopes2.indexOf(scope1) == -1) {
                 rval = false;
             }
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceSecurityRequirementCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceSecurityRequirementCommand.java
@@ -128,7 +128,20 @@ public class ReplaceSecurityRequirementCommand extends AbstractCommand {
         }
         boolean rval = true;
         for (String name1 : names1) {
-            if (names2.indexOf(name1) == -1) {
+            if (names2.indexOf(name1) == -1 || !areScopesEqual(req1.getScopes(name1), req2.getScopes(name1))) {
+                rval = false;
+            }
+        }
+        return rval;
+    }
+
+    protected boolean areScopesEqual(List<String> scopes1, List<String> scopes2) {
+        if(scopes1.size() != scopes2.size()) {
+            return false;
+        }
+        boolean rval = true;
+        for (String scope1 : scopes1) {
+            if (scopes2.indexOf(scope1) == -1) {
                 rval = false;
             }
         }

--- a/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.after.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.before.json
@@ -1,0 +1,30 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-requirement/asyncapi-2/add-security-requirement.commands.json
@@ -1,0 +1,10 @@
+[    {
+        "__type": "AddSecurityRequirementCommand",
+        "_parentPath" : "/servers/production",
+        "_requirement" : {
+            "oauth2Scheme": [
+                "write:pets"
+            ]
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.after.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.before.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+        }
+      }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        },
+        {
+          "UPScheme": []
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements.commands.json
@@ -1,0 +1,6 @@
+[    
+  {
+    "__type": "DeleteAllSecurityRequirementsCommand",
+    "_parentPath" : "/servers/production"
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.after.json
@@ -1,0 +1,9 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.before.json
@@ -1,0 +1,26 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+        }
+      }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes.commands.json
@@ -1,0 +1,5 @@
+[    
+  {
+    "__type": "DeleteAllSecuritySchemesCommand"
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.after.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "UPScheme": []
+        },
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.before.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+        }
+      }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "UPScheme": []
+        },
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched.commands.json
@@ -1,0 +1,11 @@
+[    
+  {
+    "__type": "DeleteSecurityRequirementCommand",
+    "_parentPath" : "/servers/production",
+    "_requirement": {
+      "oauth2Scheme": [
+        "read:pets"
+      ]
+    }
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.after.json
@@ -1,0 +1,38 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "UPScheme": []
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.before.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "UPScheme": {
+        "type": "userPassword"
+        }
+      }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "UPScheme": []
+        },
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-requirement/asyncapi-2/delete-security-requirement.commands.json
@@ -1,0 +1,11 @@
+[    
+  {
+    "__type": "DeleteSecurityRequirementCommand",
+    "_parentPath" : "/servers/production",
+    "_requirement": {
+      "oauth2Scheme": [
+        "write:pets"
+      ]
+    }
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.after.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.after.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "oauth2Scheme": [
+            "read:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.before.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.before.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": {
+    "production": {
+      "url": "prod.example.com",
+      "description": "my event railgun",
+      "protocol": "http",
+      "security": [
+        {
+          "oauth2Scheme": [
+            "write:pets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-security-requirement/asyncapi-2/replace-security-requirement.commands.json
@@ -1,0 +1,16 @@
+[    
+  {
+    "__type": "ReplaceSecurityRequirementCommand",
+    "_parentPath" : "/servers/production",
+    "_oldRequirement" : {
+      "oauth2Scheme": [
+          "write:pets"
+      ]
+    },
+    "_newRequirement": {
+      "oauth2Scheme": [
+        "read:pets"
+      ]
+    }
+  }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -258,6 +258,7 @@
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example", "test": "commands/add-message-example/asyncapi-2/add-message-example" },
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example JSON", "test": "commands/add-message-example/asyncapi-2/add-message-example-json" },
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example Exists", "test": "commands/add-message-example/asyncapi-2/add-message-example-exists" },
+    { "name": "[AsyncAPI 2] {Add Security Requirement} - Add Security Req", "test": "commands/add-security-requirement/asyncapi-2/add-security-requirement" },
     { "name": "[AsyncAPI 2] {Change Payload Ref} - Change Payload Ref", "test": "commands/change-payload-ref/asyncapi-2/change-payload-ref" },
     { "name": "[AsyncAPI 2] {Change Headers Ref} - Change Headers Ref", "test": "commands/change-headers-ref/asyncapi-2/change-headers-ref" },
     { "name": "[AsyncAPI 2] {Change Security Scheme} - Change Security Scheme", "test": "commands/change-security-scheme/asyncapi-2/change-security-scheme" },
@@ -265,12 +266,15 @@
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
     { "name": "[AsyncAPI 2] {Delete Operation} - Delete Operation", "test": "commands/delete-operation/asyncapi-2/delete-operation" },
     { "name": "[AsyncAPI 2] {Delete Security Scheme} - Delete Security Scheme", "test": "commands/delete-security-scheme/asyncapi-2/delete-security-scheme" },
+    { "name": "[AsyncAPI 2] {Delete Security Requirement} - Delete Security Requirement", "test": "commands/delete-security-requirement/asyncapi-2/delete-security-requirement" },
+    { "name": "[AsyncAPI 2] {Delete Security Requirement} - Delete Nonexistent Security Requirement", "test": "commands/delete-security-requirement/asyncapi-2/delete-security-requirement-unmatched" },
     { "name": "[AsyncAPI 2] {Delete Server} - Delete Server", "test": "commands/delete-server/asyncapi-2/delete-server" },
     { "name": "[AsyncAPI 2] {Delete Message Example} - Delete Message Example", "test": "commands/delete-message-example/asyncapi-2/delete-message-example" },
     { "name": "[AsyncAPI 2] {Delete Message Example} - Delete Message Example JSON", "test": "commands/delete-message-example/asyncapi-2/delete-message-example-json" },
     { "name": "[AsyncAPI 2] {Delete Message Example} - Delete Message Example Exists", "test": "commands/delete-message-example/asyncapi-2/delete-message-example-exists" },
     { "name": "[AsyncAPI 2] {Delete All Message Examples} - Delete All Message Examples", "test": "commands/delete-all-message-examples/asyncapi-2/delete-all-message-examples" },
     { "name": "[AsyncAPI 2] {Delete All Servers} - Delete All Servers", "test": "commands/delete-all-servers/asyncapi-2/delete-all-servers" },
+    { "name": "[AsyncAPI 2] {Delete All Security Requirements} - Delete All Security Requirements", "test": "commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements" },
     { "name": "[AsyncAPI 2] {New Channel} - New Channel", "test": "commands/new-channel/asyncapi-2/new-channel" },
     { "name": "[AsyncAPI 2] {New Operation} - New Operation", "test": "commands/new-operation/asyncapi-2/new-operation" },
     { "name": "[AsyncAPI 2] {New Security Scheme} - New Security Scheme", "test": "commands/new-security-scheme/asyncapi-2/new-security-scheme" },
@@ -303,5 +307,6 @@
     { "name": "[AsyncAPI 2] {Delete Message Def} - Delete Message Definition", "test": "commands/delete-message-definition/asyncapi-2/delete-message-definition" },
     { "name": "[AsyncAPI 2] {Delete Message Trait Def} - Delete Message Trait Definition", "test": "commands/delete-messagetrait-definition/asyncapi-2/delete-messagetrait-definition" },
     { "name": "[AsyncAPI 2] {Delete Operation Trait Def} - Delete Operation Trait Definition", "test": "commands/delete-operationtrait-definition/asyncapi-2/delete-operationtrait-definition" },
-    { "name": "[AsyncAPI 2] {Replace Document} - Replace Document", "test": "commands/replace-document/asyncapi-2/replace-document" }
+    { "name": "[AsyncAPI 2] {Replace Document} - Replace Document", "test": "commands/replace-document/asyncapi-2/replace-document" },
+    { "name": "[AsyncAPI 2] {Replace Security Requirement} - Replace Security Requirement", "test": "commands/replace-security-requirement/asyncapi-2/replace-security-requirement" }
 ]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -275,6 +275,7 @@
     { "name": "[AsyncAPI 2] {Delete All Message Examples} - Delete All Message Examples", "test": "commands/delete-all-message-examples/asyncapi-2/delete-all-message-examples" },
     { "name": "[AsyncAPI 2] {Delete All Servers} - Delete All Servers", "test": "commands/delete-all-servers/asyncapi-2/delete-all-servers" },
     { "name": "[AsyncAPI 2] {Delete All Security Requirements} - Delete All Security Requirements", "test": "commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements" },
+    { "name": "[AsyncAPI 2] {Delete All Security Schemes} - Delete All Security Schemes", "test": "commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes" },
     { "name": "[AsyncAPI 2] {New Channel} - New Channel", "test": "commands/new-channel/asyncapi-2/new-channel" },
     { "name": "[AsyncAPI 2] {New Operation} - New Operation", "test": "commands/new-operation/asyncapi-2/new-operation" },
     { "name": "[AsyncAPI 2] {New Security Scheme} - New Security Scheme", "test": "commands/new-security-scheme/asyncapi-2/new-security-scheme" },


### PR DESCRIPTION
Hi,

This PR follows https://github.com/Apicurio/apicurio-data-models/pull/252 with some ajustments around SecurityRequirements alongside some fixes.

The notable change is AaiServer joining OasDocument / OasOperation under the ISecurityRequirementParent interface since both specifications store them the same way (a list)

I should be able to send the teased studio part soon as well.