### PR TITLE
Add the missing ReplaceChannelItemCommand for Aai documents

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddChannelItemCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddChannelItemCommand.java
@@ -57,8 +57,8 @@ public class AddChannelItemCommand extends AbstractCommand {
          this._emptyChannelItems = true;
       }
 
-      if (!this.isNullOrUndefined(doc.channels.get(this._newChannelItemObj))) {
-         LoggerCompat.info("[AddPathItemCommand] AddChannelItemCommand with name %s already exists.", this._newChannelItemName);
+      if (!this.isNullOrUndefined(doc.channels.get(this._newChannelItemName))) {
+         LoggerCompat.info("[AddChannelItemCommand] AddChannelItemCommand with name %s already exists.", this._newChannelItemName);
          this._channelItemExists = true;
       } else {
          AaiChannelItem channelItem = doc.createChannelItem(this._newChannelItemName);

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -427,6 +427,8 @@ public class CommandFactory {
             case "ReplacePathItemCommand_30":
             case "ReplacePathItemCommand":
             { return new ReplacePathItemCommand(); }
+            case "ReplaceChannelItemCommand":
+            { return new ReplaceChannelItemCommand(); }
             case "ReplaceSchemaDefinitionCommand_20":
             { return new ReplaceSchemaDefinitionCommand_20(); }
             case "ReplaceSchemaDefinitionCommand_30":
@@ -1051,6 +1053,10 @@ public class CommandFactory {
     
     public static final ICommand createReplacePathItemCommand(OasPathItem old, OasPathItem replacement) {
         return new ReplacePathItemCommand(old, replacement);
+    }
+
+    public static final ICommand createReplaceChannelItemCommand(AaiChannelItem old, AaiChannelItem replacement) {
+        return new ReplaceChannelItemCommand(old, replacement);
     }
     
     public static final ICommand createReplaceSchemaDefinitionCommand(DocumentType docType,

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceChannelItemCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceChannelItemCommand.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiChannelItem;
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20NodeFactory;
+import io.apicurio.datamodels.core.models.Document;
+
+/**
+ * A command used to replace a channel item with a newer version.
+ * @author c.desc2@gmail.com
+ */
+public class ReplaceChannelItemCommand extends ReplaceNodeCommand<AaiChannelItem> {
+
+    public String _channelName;
+
+    ReplaceChannelItemCommand() {
+    }
+    
+    ReplaceChannelItemCommand(AaiChannelItem old, AaiChannelItem replacement) {
+        super(old, replacement);
+        this._channelName = replacement.getName();
+    }
+    
+    /**
+     * @see ReplaceNodeCommand#removeNode(Document, io.apicurio.datamodels.core.models.Node)
+     */
+    @Override
+    protected void removeNode(Document doc, AaiChannelItem node) {
+        AaiDocument aaiDocument = (AaiDocument) doc;
+        aaiDocument.channels.remove(node.getName());
+    }
+    
+    /**
+     * @see ReplaceNodeCommand#addNode(Document, io.apicurio.datamodels.core.models.Node)
+     */
+    @Override
+    protected void addNode(Document doc, AaiChannelItem node) {
+        final AaiDocument aaiDocument = (AaiDocument) doc;
+
+        node._ownerDocument = aaiDocument;
+        node._parent = aaiDocument;
+        aaiDocument.channels.put(this._channelName, node);
+    }
+    
+    /**
+     * @see ReplaceNodeCommand#readNode(Document, Object)
+     */
+    @Override
+    protected AaiChannelItem readNode(Document doc, Object node) {
+        final AaiDocument aaiDocument = (AaiDocument) doc;
+        AaiChannelItem channelItem = new Aai20NodeFactory().createChannelItem(aaiDocument, this._channelName);
+        Library.readNode(node, channelItem);
+        return channelItem;
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.after.json
@@ -1,0 +1,31 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Channel example",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "alreadyExists": {
+      "publish": {
+        "message": {
+          "$ref": "#/components/messages/testMessages"
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "testMessages": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.before.json
@@ -1,0 +1,31 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Channel example",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "alreadyExists": {
+      "publish": {
+        "message": {
+          "$ref": "#/components/messages/testMessages"
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "testMessages": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict.commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "__type": "AddChannelItemCommand",
+    "_newChannelItemName": "alreadyExists",
+    "_newChannelItemObj": {}
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.after.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.after.json
@@ -1,0 +1,70 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "test replace-channel-item",
+    "version": "0.1.0",
+    "description": "Sample AsyncAPI for user signedup events",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "fullName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "age": {
+                "type": "integer",
+                "minimum": 18
+              }
+            }
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.before.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.before.json
@@ -1,0 +1,45 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "test replace-channel-item",
+    "version": "0.1.0",
+    "description": "Sample AsyncAPI for user signedup events",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up"
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-channel-item/asyncapi-2/replace-channel-item.commands.json
@@ -1,0 +1,37 @@
+[{
+    "__type": "ReplaceChannelItemCommand",
+    "_nodePath": "/channels[user/signedup]",
+    "_new": {
+        "description": "The channel on which user signed up events may be consumed",
+        "subscribe": {
+            "operationId": "receivedUserSIgnedUp",
+            "summary": "Receive informations about user signed up",
+            "message": {
+                "description": "An event describing that a user just signed up.",
+                "payload": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "fullName": {
+                            "type": "string"
+                        },
+                        "email": {
+                            "type": "string",
+                            "format": "email"
+                        },
+                        "age": {
+                            "type": "integer",
+                            "minimum": 18
+                        }
+                    }
+                },
+                "traits": [
+                    {
+                        "$ref": "#/components/messageTraits/commonHeaders"
+                    }
+                ]
+            }
+        }
+    },
+    "_channelName": "user/signedup"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -261,6 +261,7 @@
     { "name": "[OpenAPI 3] {Set Extension} - Set Extension", "test": "commands/set-extension/openapi-3/set-extension" },
 
     { "name": "[AsyncAPI 2] {Add Channel Item} - Add Channel Item", "test": "commands/add-channel-item/asyncapi-2/add-channel-item" },
+    { "name": "[AsyncAPI 2] {Add Channel Item} - Add Channel Item With Conflict", "test": "commands/add-channel-item/asyncapi-2/add-channel-item-with-conflict" },
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example", "test": "commands/add-message-example/asyncapi-2/add-message-example" },
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example JSON", "test": "commands/add-message-example/asyncapi-2/add-message-example-json" },
     { "name": "[AsyncAPI 2] {Add Message Example} - Add Message Example Exists", "test": "commands/add-message-example/asyncapi-2/add-message-example-exists" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -319,5 +319,6 @@
     { "name": "[AsyncAPI 2] {Delete Message Trait Def} - Delete Message Trait Definition", "test": "commands/delete-messagetrait-definition/asyncapi-2/delete-messagetrait-definition" },
     { "name": "[AsyncAPI 2] {Delete Operation Trait Def} - Delete Operation Trait Definition", "test": "commands/delete-operationtrait-definition/asyncapi-2/delete-operationtrait-definition" },
     { "name": "[AsyncAPI 2] {Replace Document} - Replace Document", "test": "commands/replace-document/asyncapi-2/replace-document" },
-    { "name": "[AsyncAPI 2] {Replace Security Requirement} - Replace Security Requirement", "test": "commands/replace-security-requirement/asyncapi-2/replace-security-requirement" }
+    { "name": "[AsyncAPI 2] {Replace Security Requirement} - Replace Security Requirement", "test": "commands/replace-security-requirement/asyncapi-2/replace-security-requirement" },
+    { "name": "[AsyncAPI 2] {Replace Channel Item} - Replace Channel Item", "test": "commands/replace-channel-item/asyncapi-2/replace-channel-item" }
 ]


### PR DESCRIPTION
An Add command was used to replace channels in the studio (without calling Library.writeNode first which is probably the cause of [this one](https://github.com/Apicurio/apicurio-studio/issues/1626)).

This PR adds the missing Replace command for channels and fixes a typo in the Add command