### PR TITLE
Fix DeleteProperty, DeleteAllProperties, ChangePropertyType commands for Aai documents

### DIFF
--- a/src/main/java/io/apicurio/datamodels/asyncapi/io/AaiDataModelReader.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/io/AaiDataModelReader.java
@@ -624,7 +624,7 @@ public abstract class AaiDataModelReader extends DataModelReader {
             List<String> propertyNames = JsonCompat.keys(properties);
             for (String propertyName : propertyNames) {
                 Object propertySchema = JsonCompat.consumeProperty(properties, propertyName);
-                AaiSchema propertySchemaModel = schema.createPropertySchema(propertyName);
+                Schema propertySchemaModel = schema.createPropertySchema(propertyName);
                 this.readSchema(propertySchema, propertySchemaModel);
                 schema.addProperty(propertyName, propertySchemaModel);
             }

--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
@@ -183,11 +183,15 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public List<String> getRequiredProperties() {
-        List<String> rval = new ArrayList<>();
-        if (this.required != null) {
-            rval.addAll(this.required);
-        }
-        return rval;
+        return this.required;
+    }
+
+    /**
+     * @see IPropertyParent#setRequiredProperties(List) 
+     */
+    @Override
+    public void setRequiredProperties(List<String> requiredProperties) {
+        this.required = requiredProperties;
     }
 
     /**

--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
@@ -24,13 +24,14 @@ import java.util.Map;
 import io.apicurio.datamodels.compat.NodeCompat;
 import io.apicurio.datamodels.core.models.common.ExternalDocumentation;
 import io.apicurio.datamodels.core.models.common.IExternalDocumentationParent;
+import io.apicurio.datamodels.core.models.common.IPropertyParent;
 import io.apicurio.datamodels.core.models.common.Schema;
 
 /** 
  * Models and AsyncAPI schema.
  * @author laurent.broudoux@gmail.com
  */
-public abstract class AaiSchema extends Schema implements IExternalDocumentationParent {
+public abstract class AaiSchema extends Schema implements IExternalDocumentationParent, IPropertyParent {
 
     public String format;
     public String title;
@@ -114,13 +115,15 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     public abstract AaiSchema createAdditionalPropertiesSchema();
 
     /**
-     * Creates a child schema model.
+     * @see IPropertyParent#createPropertySchema(String)
      */
-    public abstract AaiSchema createPropertySchema(String propertyName);
+    @Override
+    public abstract Schema createPropertySchema(String propertyName);
 
     /**
-     * Gets a list of all property names.
+     * @see IPropertyParent#getPropertyNames() 
      */
+    @Override
     public List<String> getPropertyNames() {
         List<String> rval = new ArrayList<>();
         if (this.properties != null) {
@@ -130,10 +133,11 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Gets a list of all the properties.
+     * @see IPropertyParent#getProperties() 
      */
-    public List<AaiSchema> getProperties() {
-        List<AaiSchema> rval = new ArrayList<>();
+    @Override
+    public List<Schema> getProperties() {
+        List<Schema> rval = new ArrayList<>();
         if (this.properties != null) {
             rval.addAll(this.properties.values());
         }
@@ -141,23 +145,22 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Add a property.
-     * @param propertyName
-     * @param schema
+     * @see IPropertyParent#addProperty(String, Schema) 
      */
-    public AaiSchema addProperty(String propertyName, AaiSchema schema) {
+    @Override
+    public Schema addProperty(String propertyName, Schema schema) {
         if (this.properties == null) {
             this.properties = new LinkedHashMap<>();
         }
-        this.properties.put(propertyName, schema);
+        this.properties.put(propertyName, ((AaiSchema) schema));
         return schema;
     }
 
     /**
-     * Removes a property by name.
-     * @param propertyName
+     * @see IPropertyParent#removeProperty(String) 
      */
-    public AaiSchema removeProperty(String propertyName) {
+    @Override
+    public Schema removeProperty(String propertyName) {
         if (this.properties != null) {
             return this.properties.remove(propertyName);
         }
@@ -165,14 +168,63 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Gets a single property.
-     * @param propertyName
+     * @see IPropertyParent#getProperty(String) 
      */
-    public AaiSchema getProperty(String propertyName) {
+    @Override
+    public Schema getProperty(String propertyName) {
         if (this.properties != null) {
             return this.properties.get(propertyName);
         }
         return null;
+    }
+
+    /**
+     * @see IPropertyParent#getRequiredProperties()
+     */
+    @Override
+    public List<String> getRequiredProperties() {
+        List<String> rval = new ArrayList<>();
+        if (this.required != null) {
+            rval.addAll(this.required);
+        }
+        return rval;
+    }
+
+    /**
+     * @see IPropertyParent#isPropertyRequired(String)
+     */
+    @Override
+    public boolean isPropertyRequired(String propertyName) {
+        if (this.required != null) {
+            return this.required.contains(propertyName);
+        }
+        return false;
+    }
+
+    /**
+     * @see IPropertyParent#setPropertyRequired(String)
+     */
+    @Override
+    public void setPropertyRequired(String propertyName) {
+        if (this.required == null) {
+            this.required = new ArrayList<>();
+        }
+        if (!this.required.contains(propertyName)) {
+            this.required.add(propertyName);
+        }
+    }
+
+    /**
+     * @see IPropertyParent#unsetPropertyRequired(String)
+     */
+    @Override
+    public void unsetPropertyRequired(String propertyName) {
+        if (this.required != null) {
+            this.required.remove(propertyName);
+            if (this.required.isEmpty()) {
+                this.required = null;
+            }
+        }
     }
     
     /**

--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiSchema.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.apicurio.datamodels.cmd.util.ModelUtils;
 import io.apicurio.datamodels.compat.NodeCompat;
 import io.apicurio.datamodels.core.models.common.ExternalDocumentation;
 import io.apicurio.datamodels.core.models.common.IExternalDocumentationParent;
@@ -126,7 +127,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     @Override
     public List<String> getPropertyNames() {
         List<String> rval = new ArrayList<>();
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             rval.addAll(this.properties.keySet());
         }
         return rval;
@@ -138,7 +139,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
     @Override
     public List<Schema> getProperties() {
         List<Schema> rval = new ArrayList<>();
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             rval.addAll(this.properties.values());
         }
         return rval;
@@ -149,7 +150,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema addProperty(String propertyName, Schema schema) {
-        if (this.properties == null) {
+        if (ModelUtils.isNullOrUndefined(this.properties)) {
             this.properties = new LinkedHashMap<>();
         }
         this.properties.put(propertyName, ((AaiSchema) schema));
@@ -161,7 +162,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema removeProperty(String propertyName) {
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             return this.properties.remove(propertyName);
         }
         return null;
@@ -172,7 +173,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema getProperty(String propertyName) {
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             return this.properties.get(propertyName);
         }
         return null;
@@ -199,7 +200,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public boolean isPropertyRequired(String propertyName) {
-        if (this.required != null) {
+        if (ModelUtils.isDefined(this.required)) {
             return this.required.contains(propertyName);
         }
         return false;
@@ -210,7 +211,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public void setPropertyRequired(String propertyName) {
-        if (this.required == null) {
+        if (ModelUtils.isNullOrUndefined(this.required)) {
             this.required = new ArrayList<>();
         }
         if (!this.required.contains(propertyName)) {
@@ -223,7 +224,7 @@ public abstract class AaiSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public void unsetPropertyRequired(String propertyName) {
-        if (this.required != null) {
+        if (ModelUtils.isDefined(this.required)) {
             this.required.remove(propertyName);
             if (this.required.isEmpty()) {
                 this.required = null;

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
@@ -16,34 +16,29 @@
 
 package io.apicurio.datamodels.cmd.commands;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
 import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.asyncapi.models.AaiSchema;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.cmd.models.SimplifiedPropertyType;
 import io.apicurio.datamodels.cmd.util.ModelUtils;
 import io.apicurio.datamodels.cmd.util.SimplifiedTypeUtil;
 import io.apicurio.datamodels.compat.LoggerCompat;
 import io.apicurio.datamodels.compat.MarshallCompat.NullableJsonNodeDeserializer;
-import io.apicurio.datamodels.compat.NodeCompat;
 import io.apicurio.datamodels.core.models.Document;
-import io.apicurio.datamodels.core.models.DocumentType;
 import io.apicurio.datamodels.core.models.Node;
 import io.apicurio.datamodels.core.models.NodePath;
 import io.apicurio.datamodels.core.models.common.IPropertyParent;
 import io.apicurio.datamodels.core.models.common.IPropertySchema;
 import io.apicurio.datamodels.core.models.common.Schema;
-import io.apicurio.datamodels.openapi.models.OasSchema;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A command used to modify the type of a property of a schema.
  * @author eric.wittmann@gmail.com
  */
-public class ChangePropertyTypeCommand extends AbstractCommand { // TODO (the aai counterpart is needed)
+public abstract class ChangePropertyTypeCommand extends AbstractCommand {
     
     public NodePath _propPath;
     public String _propName;
@@ -121,11 +116,7 @@ public class ChangePropertyTypeCommand extends AbstractCommand { // TODO (the aa
         Library.readNode(this._oldProperty, oldProp);
 
         // Restore the schema attributes
-        if (DocumentType.asyncapi2.equals(document.getDocumentType())) {
-            restoreAaiSchemaInternalProperties((AaiSchema) prop, (AaiSchema) oldProp);
-        } else {
-            restoreOasSchemaInternalProperties((OasSchema) prop, (OasSchema) oldProp);
-        }
+        restoreSchemaInternalProperties((Schema) prop, oldProp);
         // Restore the "required" flag
         if (!this.isNullOrUndefined(this._newType.required)) {
             if (this._nullRequired) {
@@ -143,44 +134,9 @@ public class ChangePropertyTypeCommand extends AbstractCommand { // TODO (the aa
         }
     }
 
-    private void restoreOasSchemaInternalProperties(OasSchema prop, OasSchema oldProp) {
-        prop.$ref = null;
-        prop.type = null;
-        prop.enum_ = null;
-        prop.format = null;
-        prop.items = null;
-        if (ModelUtils.isDefined(oldProp)) {
-            prop.$ref = oldProp.$ref;
-            prop.type = oldProp.type;
-            prop.enum_ = oldProp.enum_;
-            prop.format = oldProp.format;
-            prop.items = oldProp.items;
-            if (ModelUtils.isDefined(prop.items) && !NodeCompat.isList(prop.items)) {
-                Node itemsNode = (Node) prop.items;
-                itemsNode._parent = prop;
-                itemsNode._ownerDocument = prop.ownerDocument();
-            }
-        }
-    }
-
-    private void restoreAaiSchemaInternalProperties(AaiSchema prop, AaiSchema oldProp) {
-        prop.$ref = null;
-        prop.type = null;
-        prop.enum_ = null;
-        prop.format = null;
-        prop.items = null;
-        if (ModelUtils.isDefined(oldProp)) {
-            prop.$ref = oldProp.$ref;
-            prop.type = oldProp.type;
-            prop.enum_ = oldProp.enum_;
-            prop.format = oldProp.format;
-            prop.items = oldProp.items;
-            if (ModelUtils.isDefined(prop.items) && !NodeCompat.isList(prop.items)) {
-                Node itemsNode = (Node) prop.items;
-                itemsNode._parent = prop;
-                itemsNode._ownerDocument = prop.ownerDocument();
-            }
-        }
-    }
+    /**
+     * Restores document type dependent fields in the schema
+     */
+    protected abstract void restoreSchemaInternalProperties(Schema toSchema, Schema fromSchema);
 
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
@@ -39,7 +39,7 @@ import io.apicurio.datamodels.openapi.models.OasSchema;
  * A command used to modify the type of a property of a schema.
  * @author eric.wittmann@gmail.com
  */
-public class ChangePropertyTypeCommand extends AbstractCommand { // TODO check if an aai counterpart is needed
+public class ChangePropertyTypeCommand extends AbstractCommand { // TODO (the aai counterpart is needed)
     
     public NodePath _propPath;
     public String _propName;

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand.java
@@ -39,7 +39,7 @@ import io.apicurio.datamodels.openapi.models.OasSchema;
  * A command used to modify the type of a property of a schema.
  * @author eric.wittmann@gmail.com
  */
-public class ChangePropertyTypeCommand extends AbstractCommand {
+public class ChangePropertyTypeCommand extends AbstractCommand { // TODO check if an aai counterpart is needed
     
     public NodePath _propPath;
     public String _propName;
@@ -113,7 +113,7 @@ public class ChangePropertyTypeCommand extends AbstractCommand {
 
         boolean wasRequired = ModelUtils.isDefined(required) && required.size() > 0 && required.indexOf(prop.getPropertyName()) != -1;
 
-        OasSchema oldProp = parent.createPropertySchema(this._propName);
+        OasSchema oldProp = (OasSchema) parent.createPropertySchema(this._propName);
         Library.readNode(this._oldProperty, oldProp);
 
         // Restore the schema attributes

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand_Aai20.java
@@ -1,0 +1,48 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.apicurio.datamodels.cmd.models.SimplifiedPropertyType;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.common.IPropertySchema;
+import io.apicurio.datamodels.core.models.common.Schema;
+
+public class ChangePropertyTypeCommand_Aai20 extends ChangePropertyTypeCommand {
+
+    public ChangePropertyTypeCommand_Aai20() {
+    }
+
+    public ChangePropertyTypeCommand_Aai20(IPropertySchema property, SimplifiedPropertyType newType) {
+        super(property, newType);
+    }
+
+    /**
+     * @see ChangePropertyTypeCommand#restoreSchemaInternalProperties(Schema, Schema) 
+     */
+    @Override
+    protected void restoreSchemaInternalProperties(Schema toSchema, Schema fromSchema) {
+        final AaiSchema newSchema = (AaiSchema) toSchema;
+        final AaiSchema oldSchema = (AaiSchema) fromSchema;
+        
+        newSchema.$ref = null;
+        newSchema.type = null;
+        newSchema.enum_ = null;
+        newSchema.format = null;
+        newSchema.items = null;
+        if (ModelUtils.isDefined(oldSchema)) {
+            newSchema.$ref = oldSchema.$ref;
+            newSchema.type = oldSchema.type;
+            newSchema.enum_ = oldSchema.enum_;
+            newSchema.format = oldSchema.format;
+            newSchema.items = oldSchema.items;
+            if (ModelUtils.isDefined(newSchema.items) && !NodeCompat.isList(newSchema.items)) {
+                Node itemsNode = (Node) newSchema.items;
+                itemsNode._parent = newSchema;
+                itemsNode._ownerDocument = newSchema.ownerDocument();
+            }
+        }
+    }
+    
+    
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand_Oas.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePropertyTypeCommand_Oas.java
@@ -1,0 +1,48 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.cmd.models.SimplifiedPropertyType;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.common.IPropertySchema;
+import io.apicurio.datamodels.core.models.common.Schema;
+import io.apicurio.datamodels.openapi.models.OasSchema;
+
+public class ChangePropertyTypeCommand_Oas extends ChangePropertyTypeCommand {
+
+    public ChangePropertyTypeCommand_Oas() {
+    }
+
+    public ChangePropertyTypeCommand_Oas(IPropertySchema property, SimplifiedPropertyType newType) {
+        super(property, newType);
+    }
+
+    /**
+     * @see ChangePropertyTypeCommand#restoreSchemaInternalProperties(Schema, Schema)
+     */
+    @Override
+    protected void restoreSchemaInternalProperties(Schema toSchema, Schema fromSchema) {
+        final OasSchema newSchema = (OasSchema) toSchema;
+        final OasSchema oldSchema = (OasSchema) fromSchema;
+        
+        newSchema.$ref = null;
+        newSchema.type = null;
+        newSchema.enum_ = null;
+        newSchema.format = null;
+        newSchema.items = null;
+        if (ModelUtils.isDefined(oldSchema)) {
+            newSchema.$ref = oldSchema.$ref;
+            newSchema.type = oldSchema.type;
+            newSchema.enum_ = oldSchema.enum_;
+            newSchema.format = oldSchema.format;
+            newSchema.items = oldSchema.items;
+            if (ModelUtils.isDefined(newSchema.items) && !NodeCompat.isList(newSchema.items)) {
+                Node itemsNode = (Node) newSchema.items;
+                itemsNode._parent = newSchema;
+                itemsNode._ownerDocument = newSchema.ownerDocument();
+            }
+        }
+    }
+    
+    
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -155,9 +155,12 @@ public class CommandFactory {
             case "ChangeParameterDefinitionTypeCommand_30":
             { return new ChangeParameterDefinitionTypeCommand_30(); }
             case "ChangePropertyTypeCommand":
+            case "ChangePropertyTypeCommand_Oas":
             case "ChangePropertyTypeCommand_20":
             case "ChangePropertyTypeCommand_30":
-            { return new ChangePropertyTypeCommand(); }
+            { return new ChangePropertyTypeCommand_Oas(); }
+            case "ChangePropertyTypeCommand_Aai20":
+            { return new ChangePropertyTypeCommand_Aai20(); }
             case "ChangeResponseTypeCommand":
             case "ChangeResponseTypeCommand_20":
             case "ChangeResponseDefinitionTypeCommand_20":
@@ -591,9 +594,26 @@ public class CommandFactory {
         throw new RuntimeException("Document type not supported by this command.");
     }
 
+    /**
+     * @deprecated Prefer the {@link CommandFactory#createChangePropertyTypeCommand(DocumentType, IPropertySchema, SimplifiedPropertyType)} 
+     * alternative that handles non Oas document types
+     */
+    @Deprecated
     public static final ICommand createChangePropertyTypeCommand(IPropertySchema property,
-            SimplifiedPropertyType newType) {
-        return new ChangePropertyTypeCommand(property, newType);
+                                                                 SimplifiedPropertyType newType) {
+        return new ChangePropertyTypeCommand_Oas(property, newType);
+    }
+    
+    public static final ICommand createChangePropertyTypeCommand(DocumentType docType,
+                                                                 IPropertySchema property,
+                                                                 SimplifiedPropertyType newType) {
+        if (docType == DocumentType.openapi2 || docType == DocumentType.openapi3) {
+            return new ChangePropertyTypeCommand_Oas(property, newType);
+        }
+        if (docType == DocumentType.asyncapi2) {
+            return new ChangePropertyTypeCommand_Aai20(property, newType);
+        }
+        throw new RuntimeException("Document type not supported by this command.");
     }
 
     public static final ICommand createChangeSchemaTypeCommand(OasSchema schema, SimplifiedType newType) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -594,19 +594,9 @@ public class CommandFactory {
         throw new RuntimeException("Document type not supported by this command.");
     }
 
-    /**
-     * @deprecated Prefer the {@link CommandFactory#createChangePropertyTypeCommand(DocumentType, IPropertySchema, SimplifiedPropertyType)} 
-     * alternative that handles non Oas document types
-     */
-    @Deprecated
     public static final ICommand createChangePropertyTypeCommand(IPropertySchema property,
                                                                  SimplifiedPropertyType newType) {
-        return new ChangePropertyTypeCommand_Oas(property, newType);
-    }
-    
-    public static final ICommand createChangePropertyTypeCommand(DocumentType docType,
-                                                                 IPropertySchema property,
-                                                                 SimplifiedPropertyType newType) {
+        DocumentType docType = ((Node) property).ownerDocument().getDocumentType();
         if (docType == DocumentType.openapi2 || docType == DocumentType.openapi3) {
             return new ChangePropertyTypeCommand_Oas(property, newType);
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand.java
@@ -78,7 +78,7 @@ public class NewSchemaPropertyCommand extends AbstractCommand {
             return;
         }
 
-        OasSchema property = schema.createPropertySchema(this._propertyName);
+        OasSchema property = (OasSchema) schema.createPropertySchema(this._propertyName);
         if (ModelUtils.isDefined(this._description)) {
             property.description = this._description;
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewSchemaPropertyCommand_Aai20.java
@@ -63,7 +63,7 @@ public class NewSchemaPropertyCommand_Aai20 extends NewSchemaPropertyCommand {
             return;
         }
 
-        AaiSchema property = schema.createPropertySchema(this._propertyName);
+        AaiSchema property = (AaiSchema) schema.createPropertySchema(this._propertyName);
         if (ModelUtils.isDefined(this._description)) {
             property.description = this._description;
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand.java
@@ -63,7 +63,7 @@ public abstract class RenameSchemaDefinitionCommand extends AbstractCommand {
     public void execute(Document document) {
         LoggerCompat.info("[RenameSchemaDefinitionCommand] Executing.");
         this._references = new ArrayList<>();
-        if (this._renameSchemaDefinition((OasDocument) document, this._oldName, this._newName)) {
+        if (this._renameSchemaDefinition(document, this._oldName, this._newName)) {
             String oldRef = this._nameToReference(this._oldName);
             String newRef = this._nameToReference(this._newName);
             SchemaRefFinder schemaFinder = new SchemaRefFinder(oldRef);
@@ -81,11 +81,11 @@ public abstract class RenameSchemaDefinitionCommand extends AbstractCommand {
     @Override
     public void undo(Document document) {
         LoggerCompat.info("[RenameSchemaDefinitionCommand] Reverting.");
-        if (this._renameSchemaDefinition((OasDocument) document, this._newName, this._oldName)) {
+        if (this._renameSchemaDefinition(document, this._newName, this._oldName)) {
             String oldRef = this._nameToReference(this._oldName);
             if (ModelUtils.isDefined(this._references)) {
                 this._references.forEach( ref -> {
-                    OasSchema schema = (OasSchema) ref.resolve(document);
+                    Schema schema = (Schema) ref.resolve(document);
                     schema.$ref = oldRef;
                 });
             }
@@ -102,7 +102,7 @@ public abstract class RenameSchemaDefinitionCommand extends AbstractCommand {
      * Called to actually change the name of the schema definition.  This impl will vary
      * depending on the OAI data model version.  Returns true if the rename actually happened.
      */
-    protected abstract boolean _renameSchemaDefinition(OasDocument document, String fromName, String toName);
+    protected abstract boolean _renameSchemaDefinition(Document document, String fromName, String toName);
     
     private static class SchemaRefFinder extends CombinedVisitorAdapter {
 

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand_20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand_20.java
@@ -17,7 +17,7 @@
 package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.cmd.util.ModelUtils;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.apicurio.datamodels.core.models.Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20SchemaDefinition;
 
@@ -42,10 +42,10 @@ public class RenameSchemaDefinitionCommand_20 extends RenameSchemaDefinitionComm
     }
     
     /**
-     * @see io.apicurio.datamodels.cmd.commands.RenameSchemaDefinitionCommand#_renameSchemaDefinition(io.apicurio.datamodels.openapi.models.OasDocument, java.lang.String, java.lang.String)
+     * @see RenameSchemaDefinitionCommand#_renameSchemaDefinition(Document, String, String)
      */
     @Override
-    protected boolean _renameSchemaDefinition(OasDocument document, String fromName, String toName) {
+    protected boolean _renameSchemaDefinition(Document document, String fromName, String toName) {
         Oas20Document doc20 = (Oas20Document) document;
         if (this.isNullOrUndefined(doc20.definitions)) {
             return false;

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand_30.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/RenameSchemaDefinitionCommand_30.java
@@ -17,7 +17,7 @@
 package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.cmd.util.ModelUtils;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.apicurio.datamodels.core.models.Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30SchemaDefinition;
 
@@ -42,10 +42,10 @@ public class RenameSchemaDefinitionCommand_30 extends RenameSchemaDefinitionComm
     }
     
     /**
-     * @see io.apicurio.datamodels.cmd.commands.RenameSchemaDefinitionCommand#_renameSchemaDefinition(io.apicurio.datamodels.openapi.models.OasDocument, java.lang.String, java.lang.String)
+     * @see RenameSchemaDefinitionCommand#_renameSchemaDefinition(Document, String, String)
      */
     @Override
-    protected boolean _renameSchemaDefinition(OasDocument document, String fromName, String toName) {
+    protected boolean _renameSchemaDefinition(Document document, String fromName, String toName) {
         Oas30Document doc30 = (Oas30Document) document;
         if (this.isNullOrUndefined(doc30.components) || this.isNullOrUndefined(doc30.components.schemas)) {
             return false;

--- a/src/main/java/io/apicurio/datamodels/core/factories/AaiSchemaFactory.java
+++ b/src/main/java/io/apicurio/datamodels/core/factories/AaiSchemaFactory.java
@@ -112,7 +112,7 @@ public class AaiSchemaFactory {
          schema.type = "object";
          List<String> keys = JsonCompat.keys(object);
          for (String propName : keys) {
-            AaiSchema pschema = schema.createPropertySchema(propName);
+            AaiSchema pschema = (AaiSchema) schema.createPropertySchema(propName);
             schema.addProperty(propName, pschema);
             Object propValue = JsonCompat.getProperty(object, propName);
             resolveAll(propValue, pschema);

--- a/src/main/java/io/apicurio/datamodels/core/factories/OasSchemaFactory.java
+++ b/src/main/java/io/apicurio/datamodels/core/factories/OasSchemaFactory.java
@@ -118,7 +118,7 @@ public class OasSchemaFactory {
             schema.type = "object";
             List<String> keys = JsonCompat.keys(object);
             for (String propName : keys) {
-                OasSchema pschema = schema.createPropertySchema(propName);
+                OasSchema pschema = (OasSchema) schema.createPropertySchema(propName);
                 schema.addProperty(propName, pschema);
                 Object propValue = JsonCompat.getProperty(object, propName);
                 resolveAll(propValue, pschema);

--- a/src/main/java/io/apicurio/datamodels/core/models/common/IPropertyParent.java
+++ b/src/main/java/io/apicurio/datamodels/core/models/common/IPropertyParent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.core.models.common;
+
+import java.util.List;
+
+/**
+ * @author c.desc2@gmail.com
+ */
+public interface IPropertyParent {
+    
+    /**
+     * Creates a child schema model.
+     */
+    public Schema createPropertySchema(String propertyName);
+
+    /**
+     * Gets a list of all property names.
+     */
+    public List<String> getPropertyNames();
+
+    /**
+     * Gets a list of all the properties.
+     */
+    public List<Schema> getProperties();
+
+    /**
+     * Add a property.
+     * @param propertyName
+     * @param schema
+     */
+    public Schema addProperty(String propertyName, Schema schema);
+
+    /**
+     * Removes a property by name.
+     * @param propertyName
+     */
+    public Schema removeProperty(String propertyName);
+
+    /**
+     * Gets a single property.
+     * @param propertyName
+     */
+    public Schema getProperty(String propertyName);
+
+    /**
+     * Gets a copy of the required properties.
+     */
+    public List<String> getRequiredProperties();
+
+    /**
+     * Returns true if the property is required.
+     */
+    public boolean isPropertyRequired(String propertyName);
+
+    /**
+     * Sets the property as required.
+     */
+    public void setPropertyRequired(String propertyName);
+
+    /**
+     * Unsets the property as required.
+     */
+    public void unsetPropertyRequired(String propertyName);
+
+}

--- a/src/main/java/io/apicurio/datamodels/core/models/common/IPropertyParent.java
+++ b/src/main/java/io/apicurio/datamodels/core/models/common/IPropertyParent.java
@@ -58,9 +58,14 @@ public interface IPropertyParent {
     public Schema getProperty(String propertyName);
 
     /**
-     * Gets a copy of the required properties.
+     * Gets the required properties list.
      */
     public List<String> getRequiredProperties();
+
+    /**
+     * Sets the required properties list.
+     */
+    public void setRequiredProperties(List<String> requiredProperties);
 
     /**
      * Returns true if the property is required.

--- a/src/main/java/io/apicurio/datamodels/openapi/io/OasDataModelReader.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/io/OasDataModelReader.java
@@ -308,7 +308,7 @@ public abstract class OasDataModelReader extends DataModelReader {
             List<String> propertyNames = JsonCompat.keys(properties);
             for (String propertyName : propertyNames) {
                 Object propertySchema = JsonCompat.consumeProperty(properties, propertyName);
-                OasSchema propertySchemaModel = schema.createPropertySchema(propertyName);
+                Schema propertySchemaModel = schema.createPropertySchema(propertyName);
                 this.readSchema(propertySchema, propertySchemaModel);
                 schema.addProperty(propertyName, propertySchemaModel);
             }

--- a/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
@@ -166,11 +166,15 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public List<String> getRequiredProperties() {
-        List<String> rval = new ArrayList<>();
-        if (this.required != null) {
-            rval.addAll(this.required);
-        }
-        return rval;
+        return this.required;
+    }
+
+    /**
+     * @see IPropertyParent#setRequiredProperties(List)
+     */
+    @Override
+    public void setRequiredProperties(List<String> requiredProperties) {
+        this.required = requiredProperties;
     }
     
     /**

--- a/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.apicurio.datamodels.cmd.util.ModelUtils;
 import io.apicurio.datamodels.compat.NodeCompat;
 import io.apicurio.datamodels.core.models.common.ExternalDocumentation;
 import io.apicurio.datamodels.core.models.common.IExternalDocumentationParent;
@@ -109,7 +110,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     @Override
     public List<String> getPropertyNames() {
         List<String> rval = new ArrayList<>();
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             rval.addAll(this.properties.keySet());
         }
         return rval;
@@ -121,7 +122,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     @Override
     public List<Schema> getProperties() {
         List<Schema> rval = new ArrayList<>();
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             rval.addAll(this.properties.values());
         }
         return rval;
@@ -132,7 +133,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema addProperty(String propertyName, Schema schema) {
-        if (this.properties == null) {
+        if (ModelUtils.isNullOrUndefined(this.properties)) {
             this.properties = new LinkedHashMap<>();
         }
         this.properties.put(propertyName, (OasSchema) schema);
@@ -144,7 +145,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema removeProperty(String propertyName) {
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             return this.properties.remove(propertyName);
         }
         return null;
@@ -155,7 +156,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public Schema getProperty(String propertyName) {
-        if (this.properties != null) {
+        if (ModelUtils.isDefined(this.properties)) {
             return this.properties.get(propertyName);
         }
         return null;
@@ -182,7 +183,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public boolean isPropertyRequired(String propertyName) {
-        if (this.required != null) {
+        if (ModelUtils.isDefined(this.required)) {
             return this.required.contains(propertyName);
         }
         return false;
@@ -193,7 +194,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public void setPropertyRequired(String propertyName) {
-        if (this.required == null) {
+        if (ModelUtils.isNullOrUndefined(this.required)) {
             this.required = new ArrayList<>();
         }
         if (!this.required.contains(propertyName)) {
@@ -206,7 +207,7 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
      */
     @Override
     public void unsetPropertyRequired(String propertyName) {
-        if (this.required != null) {
+        if (ModelUtils.isDefined(this.required)) {
             this.required.remove(propertyName);
             if (this.required.isEmpty()) {
                 this.required = null;

--- a/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/models/OasSchema.java
@@ -24,13 +24,14 @@ import java.util.Map;
 import io.apicurio.datamodels.compat.NodeCompat;
 import io.apicurio.datamodels.core.models.common.ExternalDocumentation;
 import io.apicurio.datamodels.core.models.common.IExternalDocumentationParent;
+import io.apicurio.datamodels.core.models.common.IPropertyParent;
 import io.apicurio.datamodels.core.models.common.Schema;
 
 /**
  * Models an OpenAPI schema.
  * @author eric.wittmann@gmail.com
  */
-public abstract class OasSchema extends Schema implements IExternalDocumentationParent {
+public abstract class OasSchema extends Schema implements IExternalDocumentationParent, IPropertyParent {
 
     public String format;
     public String title;
@@ -97,13 +98,15 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     public abstract OasSchema createAdditionalPropertiesSchema();
 
     /**
-     * Creates a child schema model.
+     * @see IPropertyParent#createPropertySchema(String) 
      */
-    public abstract OasSchema createPropertySchema(String propertyName);
+    @Override
+    public abstract Schema createPropertySchema(String propertyName);
 
     /**
-     * Gets a list of all property names.
+     * @see IPropertyParent#getPropertyNames() 
      */
+    @Override
     public List<String> getPropertyNames() {
         List<String> rval = new ArrayList<>();
         if (this.properties != null) {
@@ -113,10 +116,11 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Gets a list of all the properties.
+     * @see IPropertyParent#getProperties() 
      */
-    public List<OasSchema> getProperties() {
-        List<OasSchema> rval = new ArrayList<>();
+    @Override
+    public List<Schema> getProperties() {
+        List<Schema> rval = new ArrayList<>();
         if (this.properties != null) {
             rval.addAll(this.properties.values());
         }
@@ -124,23 +128,22 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Add a property.
-     * @param propertyName
-     * @param schema
+     * @see IPropertyParent#addProperty(String, Schema) 
      */
-    public OasSchema addProperty(String propertyName, OasSchema schema) {
+    @Override
+    public Schema addProperty(String propertyName, Schema schema) {
         if (this.properties == null) {
             this.properties = new LinkedHashMap<>();
         }
-        this.properties.put(propertyName, schema);
+        this.properties.put(propertyName, (OasSchema) schema);
         return schema;
     }
 
     /**
-     * Removes a property by name.
-     * @param propertyName
+     * @see IPropertyParent#removeProperty(String) 
      */
-    public OasSchema removeProperty(String propertyName) {
+    @Override
+    public Schema removeProperty(String propertyName) {
         if (this.properties != null) {
             return this.properties.remove(propertyName);
         }
@@ -148,16 +151,65 @@ public abstract class OasSchema extends Schema implements IExternalDocumentation
     }
 
     /**
-     * Gets a single property.
-     * @param propertyName
+     * @see IPropertyParent#getProperty(String) 
      */
-    public OasSchema getProperty(String propertyName) {
+    @Override
+    public Schema getProperty(String propertyName) {
         if (this.properties != null) {
             return this.properties.get(propertyName);
         }
         return null;
     }
+
+    /**
+     * @see IPropertyParent#getRequiredProperties() 
+     */
+    @Override
+    public List<String> getRequiredProperties() {
+        List<String> rval = new ArrayList<>();
+        if (this.required != null) {
+            rval.addAll(this.required);
+        }
+        return rval;
+    }
     
+    /**
+     * @see IPropertyParent#isPropertyRequired(String) 
+     */
+    @Override
+    public boolean isPropertyRequired(String propertyName) {
+        if (this.required != null) {
+            return this.required.contains(propertyName);
+        }
+        return false;
+    }
+
+    /**
+     * @see IPropertyParent#setPropertyRequired(String)
+     */
+    @Override
+    public void setPropertyRequired(String propertyName) {
+        if (this.required == null) {
+            this.required = new ArrayList<>();
+        }
+        if (!this.required.contains(propertyName)) {
+            this.required.add(propertyName);
+        }
+    }
+
+    /**
+     * @see IPropertyParent#unsetPropertyRequired(String)
+     */
+    @Override
+    public void unsetPropertyRequired(String propertyName) {
+        if (this.required != null) {
+            this.required.remove(propertyName);
+            if (this.required.isEmpty()) {
+                this.required = null;
+            }
+        }
+    }
+
     /**
      * Returns true if there is a single items schema.
      */

--- a/src/test/java/io/apicurio/datamodels/cmd/models/SimplifiedTypeTest.java
+++ b/src/test/java/io/apicurio/datamodels/cmd/models/SimplifiedTypeTest.java
@@ -167,17 +167,17 @@ public class SimplifiedTypeTest {
 
         definition = doc.definitions.getDefinition("Examples");
         // Array
-        OasSchema property = definition.getProperty("array-property");
+        OasSchema property = (OasSchema) definition.getProperty("array-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         assertSimplifiedType(simplifiedType, false, true, false, false, false, "array", null, null);
         Assert.assertNotNull(simplifiedType.of);
         Assert.assertEquals("string", simplifiedType.of.type);
         // Boolean
-        property = definition.getProperty("boolean-property");
+        property = (OasSchema) definition.getProperty("boolean-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         assertSimplifiedType(simplifiedType, false, false, false, false, true, "boolean", null, null);
         // Enum
-        property = definition.getProperty("enum-property");
+        property = (OasSchema) definition.getProperty("enum-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         List<Object> vals = new ArrayList<>(3);
         vals.add("val1");
@@ -185,15 +185,15 @@ public class SimplifiedTypeTest {
         vals.add("val3");
         assertSimplifiedType(simplifiedType, false, false, true, false, true, "string", null, vals);
         // Number
-        property = definition.getProperty("number-property");
+        property = (OasSchema) definition.getProperty("number-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         assertSimplifiedType(simplifiedType, false, false, false, false, true, "number", null, null);
         // Ref
-        property = definition.getProperty("ref-property");
+        property = (OasSchema) definition.getProperty("ref-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         assertSimplifiedType(simplifiedType, true, false, false, false, false, "#/definitions/ExampleObject", null, null);
         // String
-        property = definition.getProperty("string-property");
+        property = (OasSchema) definition.getProperty("string-property");
         simplifiedType = SimplifiedType.fromSchema(property);
         assertSimplifiedType(simplifiedType, false, false, false, false, true, "string", null, null);
     }

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.after.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.after.json
@@ -1,0 +1,118 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            }
+          },
+          "type": {
+            "description": "",
+            "enum": [
+              "type1",
+              "type2"
+            ],
+            "type": "string"
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.before.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.before.json
@@ -1,0 +1,114 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            }
+          },
+          "type": {
+            "description": "",
+            "type": "string"
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-enum.commands.json
@@ -1,0 +1,11 @@
+[
+    {
+        "__type": "ChangePropertyTypeCommand_Aai20",
+        "_propPath": "/components/schemas[Group]/properties[type]",
+        "_propName": "type",
+        "_newType": {
+            "type" :"string",
+            "enum" :["type1", "type2"]
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.after.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.after.json
@@ -1,0 +1,109 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            }
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.before.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.before.json
@@ -1,0 +1,110 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            }
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type-required.commands.json
@@ -1,0 +1,11 @@
+[
+    {
+        "__type": "ChangePropertyTypeCommand_Aai20",
+        "_propPath": "/components/schemas[Person]/properties[name]",
+        "_propName": "name",
+        "_newType": {
+            "type": "string",
+            "required": false
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.after.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.after.json
@@ -1,0 +1,110 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            }
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.before.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.before.json
@@ -1,0 +1,108 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:io.asyncapi.example.user-signedup",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "rename-schema-definition",
+    "version": "0.1.0",
+    "description": "test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": {
+    "development": {
+      "url": "broker.kafka.org:443",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "user/signedup": {
+      "description": "The channel on which user signed up events may be consumed",
+      "subscribe": {
+        "operationId": "receivedUserSIgnedUp",
+        "summary": "Receive informations about user signed up",
+        "message": {
+          "description": "An event describing that a user just signed up.",
+          "payload": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "traits": [
+            {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "title": "Person",
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "title": "Root Type for Address",
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string"
+          },
+          "field2": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "field1": "value1",
+          "field2": 2
+        }
+      },
+      "Group": {
+        "title": "Root Type for Group",
+        "description": "",
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": {}
+          }
+        },
+        "example": {
+          "persons": []
+        }
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.commands.json
@@ -1,6 +1,6 @@
 [
     {
-        "__type": "ChangePropertyTypeCommand",
+        "__type": "ChangePropertyTypeCommand_Aai20",
         "_propPath": "/components/schemas[Group]/properties[persons]",
         "_propName": "persons",
         "_newType": {

--- a/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/change-property-type/asyncapi-2/change-property-type.commands.json
@@ -1,0 +1,19 @@
+[
+    {
+        "__type": "ChangePropertyTypeCommand",
+        "_propPath": "/components/schemas[Group]/properties[persons]",
+        "_propName": "persons",
+        "_newType": {
+            "type": "array",
+            "enum": null,
+            "of": {
+                "type": "#/components/schemas/Person",
+                "enum": null,
+                "of": null,
+                "as": null
+            },
+            "as": null,
+            "required": false
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.after.json
@@ -1,0 +1,20 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeleteSchemaDefinitionCommand_Aai20 test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "type": "object",
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.before.json
@@ -1,0 +1,32 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeleteSchemaDefinitionCommand_Aai20 test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "required": [
+          "baz"
+        ],
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "baz": {
+            "description": "",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-properties/asyncapi-2/delete-all-properties.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteAllPropertiesCommand",
+    "_schemaPath": "/components/schemas[MySchema1]"
+}]

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.after.json
@@ -1,0 +1,25 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeletePropertyCommand test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.before.json
@@ -1,0 +1,32 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeletePropertyCommand test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "required": [
+          "baz"
+        ],
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "baz": {
+            "description": "",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property-required.commands.json
@@ -1,0 +1,6 @@
+[{
+    "__type": "DeletePropertyCommand",
+    "_propertyName": "baz",
+    "_propertyPath": "/components/schemas[MySchema1]/properties[baz]",
+    "_schemaPath": "/components/schemas[MySchema1]"
+}]

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.after.json
@@ -1,0 +1,29 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeletePropertyCommand test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "required": [
+          "baz"
+        ],
+        "type": "object",
+        "properties": {
+          "baz": {
+            "description": "",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.before.json
@@ -1,0 +1,32 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "DeletePropertyCommand test",
+    "version": "1.0.1"
+  },
+  "components": {
+    "schemas": {
+      "MySchema1": {
+        "title": "Root Type for MySchema1",
+        "description": "test",
+        "required": [
+          "baz"
+        ],
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "baz": {
+            "description": "",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "foo": "some text",
+          "baz": 19
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-property/asyncapi-2/delete-property.commands.json
@@ -1,0 +1,6 @@
+[{
+    "__type": "DeletePropertyCommand",
+    "_propertyName": "foo",
+    "_propertyPath": "/components/schemas[MySchema1]/properties[foo]",
+    "_schemaPath": "/components/schemas[MySchema1]"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -283,6 +283,7 @@
     { "name": "[AsyncAPI 2] {Delete All Message Examples} - Delete All Message Examples", "test": "commands/delete-all-message-examples/asyncapi-2/delete-all-message-examples" },
     { "name": "[AsyncAPI 2] {Delete All Channel Operations} - Delete All Channel Operations", "test": "commands/delete-all-operations/asyncapi-2/delete-all-operations" },
     { "name": "[AsyncAPI 2] {Delete All Channel Operations} - Delete All Channel Operations Only One Operation", "test": "commands/delete-all-operations/asyncapi-2/delete-all-operations-single-operation" },
+    { "name": "[AsyncAPI 2] {Delete All Properties} - Delete All Properties", "test": "commands/delete-all-properties/asyncapi-2/delete-all-properties" },
     { "name": "[AsyncAPI 2] {Delete All Servers} - Delete All Servers", "test": "commands/delete-all-servers/asyncapi-2/delete-all-servers" },
     { "name": "[AsyncAPI 2] {Delete All Security Requirements} - Delete All Security Requirements", "test": "commands/delete-all-security-requirements/asyncapi-2/delete-all-security-requirements" },
     { "name": "[AsyncAPI 2] {Delete All Security Schemes} - Delete All Security Schemes", "test": "commands/delete-all-security-schemes/asyncapi-2/delete-all-security-schemes" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -270,6 +270,7 @@
     { "name": "[AsyncAPI 2] {Change Headers Ref} - Change Headers Ref", "test": "commands/change-headers-ref/asyncapi-2/change-headers-ref" },
     { "name": "[AsyncAPI 2] {Change Security Scheme} - Change Security Scheme", "test": "commands/change-security-scheme/asyncapi-2/change-security-scheme" },
     { "name": "[AsyncAPI 2] {Change Server} - Change Server", "test": "commands/change-server/asyncapi-2/change-server" },
+    { "name": "[AsyncAPI 2] {Change Property Type} - Change Property Type", "test": "commands/change-property-type/asyncapi-2/change-property-type" },
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
     { "name": "[AsyncAPI 2] {Delete Operation} - Delete Operation", "test": "commands/delete-operation/asyncapi-2/delete-operation" },
     { "name": "[AsyncAPI 2] {Delete Property} - Delete Property Required", "test": "commands/delete-property/asyncapi-2/delete-property-required" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -271,6 +271,8 @@
     { "name": "[AsyncAPI 2] {Change Security Scheme} - Change Security Scheme", "test": "commands/change-security-scheme/asyncapi-2/change-security-scheme" },
     { "name": "[AsyncAPI 2] {Change Server} - Change Server", "test": "commands/change-server/asyncapi-2/change-server" },
     { "name": "[AsyncAPI 2] {Change Property Type} - Change Property Type", "test": "commands/change-property-type/asyncapi-2/change-property-type" },
+    { "name": "[AsyncAPI 2] {Change Property Type} - Change Property Type Enum", "test": "commands/change-property-type/asyncapi-2/change-property-type-enum" },
+    { "name": "[AsyncAPI 2] {Change Property Type} - Change Property Type Required", "test": "commands/change-property-type/asyncapi-2/change-property-type-required" },
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
     { "name": "[AsyncAPI 2] {Delete Operation} - Delete Operation", "test": "commands/delete-operation/asyncapi-2/delete-operation" },
     { "name": "[AsyncAPI 2] {Delete Property} - Delete Property Required", "test": "commands/delete-property/asyncapi-2/delete-property-required" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -272,6 +272,8 @@
     { "name": "[AsyncAPI 2] {Change Server} - Change Server", "test": "commands/change-server/asyncapi-2/change-server" },
     { "name": "[AsyncAPI 2] {Delete Channel} - Delete Channel", "test": "commands/delete-channel/asyncapi-2/delete-channel" },
     { "name": "[AsyncAPI 2] {Delete Operation} - Delete Operation", "test": "commands/delete-operation/asyncapi-2/delete-operation" },
+    { "name": "[AsyncAPI 2] {Delete Property} - Delete Property Required", "test": "commands/delete-property/asyncapi-2/delete-property-required" },
+    { "name": "[AsyncAPI 2] {Delete Property} - Delete Property", "test": "commands/delete-property/asyncapi-2/delete-property" },
     { "name": "[AsyncAPI 2] {Delete Schema Def} - Delete Schema Definition", "test": "commands/delete-schema-definition/asyncapi-2/delete-schema-definition" },
     { "name": "[AsyncAPI 2] {Delete Security Scheme} - Delete Security Scheme", "test": "commands/delete-security-scheme/asyncapi-2/delete-security-scheme" },
     { "name": "[AsyncAPI 2] {Delete Security Requirement} - Delete Security Requirement", "test": "commands/delete-security-requirement/asyncapi-2/delete-security-requirement" },


### PR DESCRIPTION
Hello, 

It was possible to create these 3 commands in the studio, the front end accepted them but it made rollups and all dependent functionnalities unavailable because of an impossible java cast 

```
Caused by: java.lang.ClassCastException: class io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition cannot be cast to class io.apicurio.datamodels.openapi.models.OasSchema (io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition and io.apicurio.datamodels.openapi.models.OasSchema are in unnamed module of loader 'deployment.apicurio-studio-api.war' @7677d600)
```

I deprecated the old factory method for ChangePropertyType in favor of a new one that uses the docType but I think there's no way to automatically execute the ChangePropertyType commands that are stuck in the DB

This change will require using the new version of createChangePropertyTypeCommand in the studio

 ---

Here are the recovery steps I used here to "repair" the studio rollup
- From the editor edit & save the source view (to be sure a ReplaceDocument is stacked with what the user sees/wants)
- Inspect the stuck documents `select design_id, version, name, d.created_by as owner, c.created_by as kikatoupt from api_content c join api_designs d on design_id=id where api_type='AsyncAPI20' and type=1 and reverted=0 and data like '%"ChangePropertyTypeCommand"%';`
- Manually revert the blocking commands `update api_content set reverted=1 where design_id='19' and version in (151, 152);`