### PR TITLE
Use PAT to create github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,7 +126,7 @@ jobs:
           
 
       - name: Create GitHub Release
-        run: ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.GITHUB_TOKEN }}
+        run: ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.ACCESS_TOKEN }}
 
 
       - name: Generate Release Notes

--- a/.github/workflows/update-website.yaml
+++ b/.github/workflows/update-website.yaml
@@ -5,7 +5,7 @@ on:
     types: [released]
 
 jobs:
-  release-images:
+  update-website:
     if: github.repository_owner == 'Apicurio'
     runs-on: ubuntu-18.04 
     steps:


### PR DESCRIPTION
events triggered by the GITHUB_TOKEN will not create a new workflow run. This is intentional because this prevents accidentally creating recursive workflow runs.