### PR TITLE
Implement dereferencing for Aai20SchemaDefinition

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cloning/Aai20ModelClonerVisitor.java
+++ b/src/main/java/io/apicurio/datamodels/cloning/Aai20ModelClonerVisitor.java
@@ -92,7 +92,7 @@ public class Aai20ModelClonerVisitor extends ModelClonerVisitor implements IAai2
      */
     @Override
     public void visitSchemaDefinition(IDefinition node) {
-        // Note: should never happen because AsyncAPI doesn't have schema definitions
+        this.clone = factory.createSchemaDefinition(((Node) node).parent(), node.getName());
     }
 
     /**

--- a/src/main/java/io/apicurio/datamodels/openapi/visitors/dereference/Aai20IReferenceManipulationStrategy.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/visitors/dereference/Aai20IReferenceManipulationStrategy.java
@@ -20,6 +20,7 @@ import io.apicurio.datamodels.asyncapi.v2.models.Aai20MessageTraitDefinition;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20OperationBindingsDefinition;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20OperationTraitDefinition;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20Parameter;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20SecurityScheme;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20ServerBindingsDefinition;
 import io.apicurio.datamodels.core.models.Document;
@@ -61,6 +62,15 @@ public class Aai20IReferenceManipulationStrategy extends AbstractReferenceLocali
             definition.attachToParent(model.components);
             model.components.addSecurityScheme(definition.getName(), definition);
             return new ReferenceAndNode(PREFIX + "securitySchemes/" + name, definition);
+        }
+        if (component instanceof Aai20SchemaDefinition) {
+            if (model.components.schemas != null && model.components.schemas.get(name) != null)
+                throw new IllegalArgumentException("Definition with that name already exists: " + name);
+
+            Aai20SchemaDefinition definition = wrap(component, new Aai20SchemaDefinition(name), model);
+            definition.attachToParent(model.components);
+            model.components.addSchemaDefinition(definition.getName(), definition);
+            return new ReferenceAndNode(PREFIX + "schemas/" + name, definition);
         }
         if (component instanceof AaiParameter) {
             if (model.components.parameters != null && model.components.parameters.get(name) != null)
@@ -197,6 +207,8 @@ public class Aai20IReferenceManipulationStrategy extends AbstractReferenceLocali
         INamed removed = model.components.messages.remove(name); // Does not implement IDefinition
         if(removed != null) return true;
         removed = model.components.securitySchemes.remove(name);
+        if(removed != null) return true;
+        removed = (Aai20SchemaDefinition) model.components.schemas.remove(name);
         if(removed != null) return true;
         removed = model.components.parameters.remove(name); // Does not implement IDefinition
         if(removed != null) return true;

--- a/src/test/resources/fixtures/dereference/aai2/kitchen-sink.expected.json
+++ b/src/test/resources/fixtures/dereference/aai2/kitchen-sink.expected.json
@@ -42,6 +42,26 @@
 		"schemas": {
 			"dimLightPayload": {
 				"type": "string"
+			},
+			"lightMeasuredPayload": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 0,
+						"description": "Id of the streetlight."
+					},
+					"lumens": {
+						"type": "integer",
+						"minimum": 0,
+						"description": "Light intensity measured in lumens."
+					},
+					"sentAt": {
+						"type": "string",
+						"format": "date-time",
+						"description": "Date and time when the message was sent."
+					}
+				}
 			}
 		},
 		"messages": {

--- a/src/test/resources/fixtures/dereference/aai2/kitchen-sink.input.json
+++ b/src/test/resources/fixtures/dereference/aai2/kitchen-sink.input.json
@@ -42,6 +42,9 @@
 		"schemas": {
 			"dimLightPayload": {
 				"type": "string"
+			},
+			"lightMeasuredPayload": {
+				"$ref": "https://asyncapi.example.com/common#/components/schemas/lightMeasuredPayload"
 			}
 		},
 		"messages": {

--- a/src/test/resources/fixtures/dereference/tests.refs.json
+++ b/src/test/resources/fixtures/dereference/tests.refs.json
@@ -297,6 +297,26 @@
 			"$ref": "#/components/schemas/lightMeasuredPayload"
 		}
 	},
+	"https://asyncapi.example.com/common#/components/schemas/lightMeasuredPayload": {
+		"type": "object",
+		"properties": {
+			"id": {
+				"type": "integer",
+				"minimum": 0,
+				"description": "Id of the streetlight."
+			},
+			"lumens": {
+				"type": "integer",
+				"minimum": 0,
+				"description": "Light intensity measured in lumens."
+			},
+			"sentAt": {
+				"type": "string",
+				"format": "date-time",
+				"description": "Date and time when the message was sent."
+			}
+		}
+	},
 	"https://asyncapi.example.com/common#/components/securitySchemes/token": {
 		"type": "http",
 		"scheme": "bearer"


### PR DESCRIPTION
Hello, 

References in asyncapi documents under `#/components/schemas` were not resolved because `visitSchemaDefinition` actually happens in the model cloner visitor but was not handled.
