### PR TITLE
bugfix : Fix the problem of payload management in messages from the m…

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePayloadRefCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangePayloadRefCommand_Aai20.java
@@ -16,6 +16,7 @@
 package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiComponents;
 import io.apicurio.datamodels.asyncapi.models.AaiOperation;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.cmd.util.ModelUtils;
@@ -31,40 +32,81 @@ import io.apicurio.datamodels.core.models.NodePath;
 public class ChangePayloadRefCommand_Aai20 extends AbstractCommand {
 
    public NodePath _operationPath;
+   public NodePath _componentPath;
    public String _payloadRef;
    public String _oldPayloadRef = null;
 
    public boolean _changed;
 
+   private String _key;
+   private boolean _fromOp = true;
+
    ChangePayloadRefCommand_Aai20() {
    }
 
    ChangePayloadRefCommand_Aai20(String payloadRef, AaiOperation operationNode) {
+      this._fromOp = true;
       this._operationPath = Library.createNodePath(operationNode);
       this._payloadRef = payloadRef;
+   }
+
+   ChangePayloadRefCommand_Aai20(String payloadRef, AaiComponents componentNode, String key) {
+      this._fromOp = false;
+      this._componentPath = Library.createNodePath(componentNode);
+      this._payloadRef = payloadRef;
+      this._key = key;
    }
 
    @Override
    public void execute(Document document) {
       LoggerCompat.info("[ChangePayloadRefCommand_Aai20] Executing.");
 
-      AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
-      this._changed = false;
+      //change the payload in a message from an operation
+      if(this._fromOp){
+         AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
+         this._changed = false;
 
-      if (this.isNullOrUndefined(operation) || this.isNullOrUndefined(operation.message) || !isValidRef(this._payloadRef)) {
-         return;
+         if (this.isNullOrUndefined(operation) || this.isNullOrUndefined(operation.message) || !isValidRef(this._payloadRef)) {
+            return;
+         }
+
+         Object payload = operation.message.payload;
+         if (payload == null) {
+            payload = JsonCompat.objectNode();
+         }
+         Object oldValue = JsonCompat.getProperty(payload, "$ref");
+         if (oldValue != null && JsonCompat.isString(oldValue)) {
+            this._oldPayloadRef = JsonCompat.toString(oldValue);
+         }
+         JsonCompat.setProperty(payload, "$ref", this._payloadRef);
+         this._changed = true;
+
+      }else{ //change the payload in a message from a component (Message block)
+         AaiComponents component = (AaiComponents) this._componentPath.resolve(document);
+         this._changed = false;
+
+         if (this.isNullOrUndefined(component) || this.isNullOrUndefined(component.messages.get(this._key)) || !isValidRef(this._payloadRef)) {
+            return;
+         }
+
+         Object payload = component.messages.get(this._key).payload;
+         if (payload == null) {
+            payload = JsonCompat.objectNode();
+         }
+         Object oldValue = JsonCompat.getProperty(payload, "$ref");
+         if (oldValue != null && JsonCompat.isString(oldValue)) {
+            this._oldPayloadRef = JsonCompat.toString(oldValue);
+         }
+         JsonCompat.setProperty(payload, "$ref", this._payloadRef);
+         this._changed = true;
       }
 
-      Object payload = operation.message.payload;
-      if (payload == null) {
-         payload = JsonCompat.objectNode();
-      }
-      Object oldValue = JsonCompat.getProperty(payload, "$ref");
-      if (oldValue != null && JsonCompat.isString(oldValue)) {
-         this._oldPayloadRef = JsonCompat.toString(oldValue);
-      }
-      JsonCompat.setProperty(payload, "$ref", this._payloadRef);
-      this._changed = true;
+
+
+
+
+
+
    }
 
    @Override

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangeRefSeveralMessagesCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangeRefSeveralMessagesCommand.java
@@ -1,0 +1,85 @@
+package io.apicurio.datamodels.cmd.commands;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.cmd.util.ModelUtils;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.NodePath;
+
+import java.util.ArrayList;
+
+/**
+ * A command used to modify the reference from (OneOf) messages in operations.
+ *
+ * @author vvilerio
+ */
+public class ChangeRefSeveralMessagesCommand extends AbstractCommand {
+    public NodePath _parentPath;
+    public String _newReference;
+    public String _oldReference;
+
+    @JsonDeserialize(using = MarshallCompat.NullableJsonNodeDeserializer.class)
+    public Object _oldParentMessage;
+
+    /**
+     * Constructor.
+     */
+    ChangeRefSeveralMessagesCommand() {
+    }
+
+    /**
+     * C'tor.
+     */
+    ChangeRefSeveralMessagesCommand(AaiMessage message, String reference) {
+        if (ModelUtils.isDefined(message) && ModelUtils.isDefined(message.parent())) {
+            this._parentPath = Library.createNodePath(message.parent());
+        }
+        this._newReference = reference;
+        this._oldReference = message.getReference();
+
+    }
+
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[ChangeRefSeveralMessagesCommand] Executing.");
+        this._oldParentMessage = null;
+
+        AaiMessage parentMessage = (AaiMessage) this._parentPath.resolve(document);
+        if (this.isNullOrUndefined(parentMessage)) {
+            return;
+        }
+
+        // Save the old info (for later undo operation)
+        if (!this.isNullOrUndefined(parentMessage)) {
+            this._oldParentMessage = Library.writeNode(parentMessage);
+        }
+
+        // Update the reference
+        ArrayList<AaiMessage> res = new ArrayList<>();
+        parentMessage.oneOf.forEach( msg -> {
+            if(this._oldReference.equals(msg.getReference())){
+                msg.setReference(this._newReference);
+            }
+            res.add(msg);
+        });
+        parentMessage.oneOf = res;
+    }
+
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[ChangeRefSeveralMessagesCommand] Reverting.");
+        AaiMessage parentMessage = (AaiMessage) this._parentPath.resolve(document);
+        if (this.isNullOrUndefined(parentMessage)) {
+            return;
+        }
+
+        parentMessage.oneOf = new ArrayList<AaiMessage>();
+        Library.readNode(this._oldParentMessage, parentMessage);
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -19,6 +19,7 @@ package io.apicurio.datamodels.cmd.commands;
 import java.util.List;
 
 import io.apicurio.datamodels.asyncapi.models.AaiChannelItem;
+import io.apicurio.datamodels.asyncapi.models.AaiComponents;
 import io.apicurio.datamodels.asyncapi.models.AaiMessage;
 import io.apicurio.datamodels.asyncapi.models.AaiOperation;
 import io.apicurio.datamodels.asyncapi.models.AaiSchema;
@@ -169,6 +170,8 @@ public class CommandFactory {
             case "ChangeResponseTypeCommand_20":
             case "ChangeResponseDefinitionTypeCommand_20":
             { return new ChangeResponseTypeCommand(); }
+            case "ChangeRefSeveralMessagesCommand":
+            { return new ChangeRefSeveralMessagesCommand(); }
             case "ChangeSecuritySchemeCommand_20":
             { return new ChangeSecuritySchemeCommand_20(); }
             case "ChangeSecuritySchemeCommand_30":
@@ -552,6 +555,10 @@ public class CommandFactory {
         return new ChangePropertyCommand<T>(node, property, newValue);
     }
 
+    public static final ICommand createChangeRefSeveralMessagesCommand(AaiMessage message, String reference){
+        return new ChangeRefSeveralMessagesCommand(message, reference);
+    }
+
     public static final ICommand createChangeTitleCommand(String newTitle) {
         return new ChangeTitleCommand(newTitle);
     }
@@ -660,6 +667,10 @@ public class CommandFactory {
 
     public static final ICommand createChangePayloadRefCommand_Aai20(String payloadRef, AaiOperation operation) {
         return new ChangePayloadRefCommand_Aai20(payloadRef, operation);
+    }
+
+    public static final ICommand createChangePayloadRefCommand_Aai20(String payloadRef, AaiComponents component, String keyMap) {
+        return new ChangePayloadRefCommand_Aai20(payloadRef, component, keyMap);
     }
 
     public static final ICommand createChangeHeadersRefCommand_Aai20(String headersRef, AaiOperation operation) {

--- a/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.after.json
+++ b/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.after.json
@@ -1,0 +1,19 @@
+{
+  "asyncapi": "2.0.0",
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "message": {
+          "oneOf": [
+            {
+              "$ref": "#/components/messages/AddressChanged"
+            },
+            {
+              "$ref": "#/components/messages/PhoneNumberChanged"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.before.json
+++ b/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.before.json
@@ -1,0 +1,19 @@
+{
+  "asyncapi": "2.0.0",
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "message": {
+          "oneOf": [
+            {
+              "$ref": "#/components/messages/EmailChanged"
+            },
+            {
+              "$ref": "#/components/messages/PhoneNumberChanged"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/change-ref-messages/asyncapi-2/change-ref-messages.commands.json
@@ -1,0 +1,8 @@
+[
+  {
+    "__type": "ChangeRefSeveralMessagesCommand",
+    "_newReference": "#/components/messages/AddressChanged",
+    "_oldReference": "#/components/messages/EmailChanged",
+    "_parentPath": "/channels[999testtest99]/publish/message"
+  }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -95,6 +95,7 @@
     { "name": "[OpenAPI 2] {Change Title} - Change Title", "test": "commands/change-title/openapi-2/change-title" },
     { "name": "[OpenAPI 3] {Change Title} - Add Title", "test": "commands/change-title/openapi-3/add-title" },
     { "name": "[OpenAPI 3] {Change Title} - Change Title", "test": "commands/change-title/openapi-3/change-title" },
+    { "name": "[OpenAPI 2] {Change ref Message} - Change ref Message", "test": "commands/change-ref-messages/asyncapi-2/change-ref-messages" },
     { "name": "[OpenAPI 2] {Change Version} - Add Version", "test": "commands/change-version/openapi-2/add-version" },
     { "name": "[OpenAPI 2] {Change Version} - Change Version", "test": "commands/change-version/openapi-2/change-version" },
     { "name": "[OpenAPI 3] {Change Version} - Add Version", "test": "commands/change-version/openapi-3/add-version" },


### PR DESCRIPTION
 bugfix : Fix the problem of payload management in messages from the messages section (was working from the operations section) and adding change/update reference in messages(oneOf) from an operatio
![MessageOneOfPbm](https://user-images.githubusercontent.com/78545082/145413406-05c4ccbe-3d99-4eb3-905c-b0b610d164bb.png)

![updateMessageOneOf](https://user-images.githubusercontent.com/78545082/145413420-140eb3dc-0750-4e46-857e-f77656d00cdc.png)
n