### PR TITLE
Fix documentType typo in Oas20IReferenceManipulationStrategy

### DIFF
--- a/src/main/java/io/apicurio/datamodels/openapi/visitors/dereference/Oas20IReferenceManipulationStrategy.java
+++ b/src/main/java/io/apicurio/datamodels/openapi/visitors/dereference/Oas20IReferenceManipulationStrategy.java
@@ -87,7 +87,7 @@ public class Oas20IReferenceManipulationStrategy extends AbstractReferenceLocali
 
     @Override
     public boolean removeComponent(Document document, String name) {
-        if (document.getDocumentType() != DocumentType.openapi3) {
+        if (document.getDocumentType() != DocumentType.openapi2) {
             throw new IllegalArgumentException("Oas20Document expected.");
         }
         Oas20Document model = (Oas20Document) document;


### PR DESCRIPTION
This fixes https://github.com/Apicurio/apicurio-studio/issues/1810 that prevented dereferencing on OAS2 documents