### PR TITLE
downgrade jsweet-core dependency to 6.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
   - dependency-name: com.github.eirslett:frontend-maven-plugin
     versions:
     - 1.11.2
+  - dependency-name: org.jsweet:jsweet-core
 - package-ecosystem: npm
   directory: "/src/main/ts"
   schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <version.commons-io>2.11.0</version.commons-io>
         <version.junit>4.13.2</version.junit>
         <version.org.jsweet>2.3.5</version.org.jsweet>
+        <version.org.jsweet-core>6.3.0</version.org.jsweet-core>
         <version.org.jsweet-transpiler>2.3.7</version.org.jsweet-transpiler>
         <version.org.skyscreamer>1.5.0</version.org.skyscreamer>
         
@@ -98,11 +99,13 @@
             <version>${version.com.fasterxml.jackson}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.jsweet/jsweet-core -->
         <dependency>
             <groupId>org.jsweet</groupId>
             <artifactId>jsweet-core</artifactId>
-            <version>6.3.1</version>
+            <version>${version.org.jsweet-core}</version>
         </dependency>
+
 
         <!-- https://mvnrepository.com/artifact/org.jsweet/jsweet-transpiler -->
         <dependency>


### PR DESCRIPTION
Dependabot had updated the jsweet-core version to 6.3.1. However this version does not exist in Maven Central.

```shell
Could not resolve dependencies for project io.apicurio:apicurio-data-models:bundle:1.1.21-SNAPSHOT: Could not find artifact org.jsweet:jsweet-core:jar:6.3.1 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```