### PR TITLE
chore: remove jsweet plugin repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,14 +265,6 @@
                 </pluginRepository>
             </pluginRepositories>
 
-            <repositories>
-                <repository>
-                    <id>jsweet-central</id>
-                    <name>libs-release</name>
-                    <url>https://repository.jsweet.org/artifactory/libs-release-local</url>
-                </repository>
-            </repositories>
-
             <build>
                 <plugins>
                     <!-- Generate TS from Java -->


### PR DESCRIPTION
The new version of Apicurio Datamodels is causing Apicurio Studio to fail when it tries to build with this version. The error relates to `http://repository.jsweet.org/artifactory/libs-release-local`, from https://github.com/Apicurio/apicurio-studio/pull/1840. See the full error log:

```shell
Error:  Failed to execute goal on project apicurio-studio-be-hub-core: Could not resolve dependencies for project io.apicurio:apicurio-studio-be-hub-core:jar:0.2.52-SNAPSHOT: Failed to collect dependencies at io.apicurio:apicurio-data-models:jar:1.1.21 -> org.jsweet:jsweet-transpiler:jar:2.3.7 -> org.jsweet.ext:typescript.java-ts.core:jar:1.4.0.1: Failed to read artifact descriptor for org.jsweet.ext:typescript.java-ts.core:jar:1.4.0.1: Could not transfer artifact org.jsweet.ext:typescript.java-ts.core:pom:1.4.0.1 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [jsweet-central (http://repository.jsweet.org/artifactory/libs-release-local, default, releases+snapshots), jsweet-snapshots (http://repository.jsweet.org/artifactory/libs-snapshot-local, default, releases+snapshots), jsweet-external (http://repository.jsweet.org/artifactory/ext-release-local, default, releases+snapshots)] -> [Help 1
```

I've tried to remove this and the build now passes, I'm wondering will this make the issue go away on Studio?

Either way it does not seem like this is needed anyway so we can probably still remove it.