### PR TITLE
rename npm package to '@apicurio/data-models'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 For details on how to use the library, see the documentation included with the library on
 npmjs.com:
 
-  [https://www.npmjs.com/package/apicurio-data-models](https://www.npmjs.com/package/apicurio-data-models)
+  [https://www.npmjs.com/package/@apicurio/data-models](https://www.npmjs.com/package/@apicurio/data-models)
 
 This documentation can also be found in this repository here:
 

--- a/src/main/ts/module/README.md
+++ b/src/main/ts/module/README.md
@@ -2,7 +2,7 @@
 
 A Typescript library for reading, manipulating, and writing OpenAPI and AsyncAPI documents.
 
-Install with `npm install apicurio-data-models`.
+Install with `npm install @apicurio/data-models`.
 
 ## Overview
 

--- a/src/main/ts/package.json
+++ b/src/main/ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apicurio-data-models",
+  "name": "@apicurio/data-models",
   "version": "${project.version}",
   "description": "A library to read, write, and manipulate OpenAPI and AsyncAPI content.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Changes the npm package name to `@apicurio/data-models` to begin a process of putting our packages under a single npm organization.

The next step will be to publish this package and deprecate `apicurio-data-models`.