### PR TITLE
chore: update Node.js to 16.4.2 (LTS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
         <!-- Node/Yarn Versions -->
         <version.node-js>16.4.2</version.node-js>
-        <version.yarn>1.22.5</version.yarn>
+        <version.yarn>1.22.17</version.yarn>
 
         <!-- Dependency Versions -->
         <version.com.fasterxml.jackson>2.12.5</version.com.fasterxml.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Node/Yarn Versions -->
-        <version.node-js>10.22.1</version.node-js>
+        <version.node-js>16.4.2</version.node-js>
         <version.yarn>1.22.5</version.yarn>
 
         <!-- Dependency Versions -->


### PR DESCRIPTION
This seems to fix the failing build on master currently..

> [INFO] error lru-cache@7.7.3: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.22.1"
[INFO] error Found incompatible module.