### PR TITLE
feat(asyncapi): add commands to handle tags on operation and message based nodes

### DIFF
--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiMessageBase.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiMessageBase.java
@@ -1,5 +1,6 @@
 package io.apicurio.datamodels.asyncapi.models;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -16,7 +17,7 @@ import io.apicurio.datamodels.core.models.common.Tag;
  * @author Jakub Senko <jsenko@redhat.com>
  * @author Laurent Broudoux <laurent.broudoux@gmail.com>
  */
-public abstract class AaiMessageBase extends ExtensibleNode implements IReferenceNode, INamed {
+public abstract class AaiMessageBase extends ExtensibleNode implements IReferenceNode, INamed, IAaiTagged {
 
     public String _name; // Map
     public String $ref;
@@ -103,4 +104,14 @@ public abstract class AaiMessageBase extends ExtensibleNode implements IReferenc
     }
 
     public abstract void addTag(AaiTag tag);
+
+    @Override
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    @Override
+    public void deleteAllTags() {
+        this.tags = new LinkedList<>();
+    }
 }

--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiOperationBase.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/AaiOperationBase.java
@@ -28,7 +28,7 @@ import io.apicurio.datamodels.core.models.common.Tag;
 /**
  * @author Jakub Senko <jsenko@redhat.com>
  */
-public abstract class AaiOperationBase extends Operation implements IReferenceNode {
+public abstract class AaiOperationBase extends Operation implements IReferenceNode, IAaiTagged {
 
     public String $ref;
     public List<Tag> tags;
@@ -100,4 +100,14 @@ public abstract class AaiOperationBase extends Operation implements IReferenceNo
     }
     
     public abstract AaiTag createTag();
+
+    @Override
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    @Override
+    public void deleteAllTags() {
+        this.tags = new LinkedList<>();
+    }
 }

--- a/src/main/java/io/apicurio/datamodels/asyncapi/models/IAaiTagged.java
+++ b/src/main/java/io/apicurio/datamodels/asyncapi/models/IAaiTagged.java
@@ -1,0 +1,33 @@
+package io.apicurio.datamodels.asyncapi.models;
+
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.core.models.common.Tag;
+
+import java.util.List;
+
+public interface IAaiTagged {
+
+    /**
+     * Gets list of all tags
+     */
+    List<Tag> getTags();
+
+    void deleteAllTags();
+    
+    /**
+     * Gets the tag with given name
+     */
+    static Tag getTag(IAaiTagged node, String name) {
+        for (Tag tag : node.getTags()) {
+            if (NodeCompat.equals(tag.name, name)) {
+                return tag;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Adds a tag
+     */
+    void addTag(AaiTag tag);
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -231,6 +231,8 @@ public class CommandFactory {
             { return new DeleteAllServersCommand_Aai20(); }
             case "DeleteAllTagsCommand":
             { return new DeleteAllTagsCommand(); }
+            case "DeleteAllTagsCommand_Aai20":
+            { return new DeleteAllTagsCommand_Aai20();}
             case "DeleteAllChildSchemasCommand":
             { return new DeleteAllChildSchemasCommand(); }
             case "DeleteExampleCommand_20":
@@ -750,6 +752,10 @@ public class CommandFactory {
 
     public static final ICommand createDeleteAllTagsCommand() {
         return new DeleteAllTagsCommand();
+    }
+
+    public static final ICommand createDeleteAllTagsCommand_Aai20(Node node) {
+        return new DeleteAllTagsCommand_Aai20(node);
     }
 
     public static final ICommand createDeleteAllChildSchemasCommand(OasSchema parent, String type) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -304,6 +304,8 @@ public class CommandFactory {
             case "DeleteTagCommand_20":
             case "DeleteTagCommand_30":
             { return new DeleteTagCommand(); }
+            case "DeleteTagCommand_Aai20":
+            { return new DeleteTagCommand_Aai20(); }
             case "DeleteChildSchemaCommand":
             { return new DeleteChildSchemaCommand(); }
             case "DeleteChannelCommand":
@@ -880,6 +882,10 @@ public class CommandFactory {
 
     public static final ICommand createDeleteTagCommand(String tagName) {
         return new DeleteTagCommand(tagName);
+    }
+    
+    public static final ICommand createDeleteTagCommand_Aai20(String tagName, Node node) {
+        return new DeleteTagCommand_Aai20(tagName, node);
     }
 
     public static final ICommand createDeleteChannelCommand(String channelName) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -373,6 +373,8 @@ public class CommandFactory {
             case "NewTagCommand_20":
             case "NewTagCommand_30":
             { return new NewTagCommand(); }
+            case "NewTagCommand_Aai20":
+            { return new NewTagCommand_Aai20(); }
             case "NewResponseDefinitionCommand_20":
             { return new NewResponseDefinitionCommand_20(); }
             case "NewResponseDefinitionCommand_30":
@@ -1003,6 +1005,10 @@ public class CommandFactory {
 
     public static final ICommand createNewTagCommand(String name, String description) {
         return new NewTagCommand(name, description);
+    }
+
+    public static final ICommand createNewTagCommand_Aai20(String name, String description, Node node) {
+        return new NewTagCommand_Aai20(name, description, node);
     }
 
     public static final ICommand createNewExtensionCommand(ExtensibleNode parent, String name, Object value) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllTagsCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllTagsCommand_Aai20.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiTag;
+import io.apicurio.datamodels.asyncapi.models.IAaiTagged;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Tag;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat.NullableJsonNodeDeserializer;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.NodePath;
+import io.apicurio.datamodels.core.models.common.Tag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to delete all tags from asyncapi operation base or message base nodes.
+ */
+public class DeleteAllTagsCommand_Aai20 extends AbstractCommand {
+
+    @JsonDeserialize(contentUsing=NullableJsonNodeDeserializer.class)
+    public List<Object> _oldTags;
+    public NodePath _nodePath;
+    
+    DeleteAllTagsCommand_Aai20() {
+    }
+
+    public DeleteAllTagsCommand_Aai20(Node node) {
+        this._nodePath = Library.createNodePath(node);
+
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[DeleteAllTagsCommand_Aai20] Executing.");
+
+        Node node = this._nodePath.resolve(document);
+        if (node instanceof IAaiTagged) {
+            IAaiTagged taggedNode = (IAaiTagged) node;
+            List<Tag> tags = taggedNode.getTags();
+            this._oldTags = new ArrayList<>();
+            // Save the old tags (if any)
+            if (!this.isNullOrUndefined(tags)) {
+                tags.forEach( tag -> {
+                    this._oldTags.add(Library.writeNode(tag));
+                });
+            }
+            taggedNode.deleteAllTags();
+        }
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[DeleteAllTagsCommand_Aai20] Reverting.");
+        if (this._oldTags.size() == 0) {
+            return;
+        }
+
+        Node node = this._nodePath.resolve(document);
+        if (node instanceof IAaiTagged) {
+            this._oldTags.forEach(oldTag -> {
+                AaiTag tag = new Aai20Tag(node);
+                Library.readNode(oldTag, tag);
+                ((IAaiTagged) node).addTag(tag);
+            });
+        }
+    }
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTagCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTagCommand_Aai20.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.IAaiTagged;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Tag;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat.NullableJsonNodeDeserializer;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.NodePath;
+import io.apicurio.datamodels.core.models.common.Tag;
+
+import java.util.List;
+
+/**
+ * A command used to delete a single tag definition from operation base and message base nodes on AsyncApi 2 document.
+ */
+public class DeleteTagCommand_Aai20 extends AbstractCommand {
+
+    public String _tagName;
+    public NodePath _nodePath;
+
+    public int _oldIndex;
+    @JsonDeserialize(using=NullableJsonNodeDeserializer.class)
+    public Object _oldTag;
+    
+    DeleteTagCommand_Aai20() {
+    }
+    
+    DeleteTagCommand_Aai20(String tagName, Node node) {
+        this._tagName = tagName;
+        this._nodePath = Library.createNodePath(node);
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[DeleteTagCommand_Aai20] Executing.");
+
+        Node node = this._nodePath.resolve(document);
+        if (node instanceof IAaiTagged) {
+            IAaiTagged tagged = (IAaiTagged) node;
+            List<Tag> tags = tagged.getTags();
+            Tag tag = IAaiTagged.getTag(tagged, this._tagName);
+            this._oldIndex = tags.indexOf(tag);
+            tags.remove(this._oldIndex);
+            this._oldTag = Library.writeNode(tag);
+        }
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[DeleteTagCommand_Aai20] Reverting.");
+
+        Node node = this._nodePath.resolve(document);
+        if (node instanceof IAaiTagged) {
+            IAaiTagged tagged = (IAaiTagged) node;
+            List<Tag> tags = tagged.getTags();
+
+            Tag tag = new Aai20Tag(node);
+            Library.readNode(this._oldTag, tag);
+            if (tags != null && tags.size() >= this._oldIndex) {
+                tags.add(_oldIndex, tag);
+            } else {
+                tags.add(tag);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/NewTagCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/NewTagCommand_Aai20.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiTag;
+import io.apicurio.datamodels.asyncapi.models.IAaiTagged;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Tag;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.NodePath;
+import io.apicurio.datamodels.core.models.common.Tag;
+
+import java.util.List;
+
+/**
+ * A command used to create a new tag on AsyncAPI 2 operation base and message base nodes.
+ */
+public class NewTagCommand_Aai20 extends AbstractCommand {
+
+    public String _tagName;
+    public String _tagDescription;
+    public NodePath _nodePath;
+
+    public boolean _created;
+    
+    NewTagCommand_Aai20() {
+    }
+    
+    NewTagCommand_Aai20(String name, String description, Node node) {
+        this._tagName = name;
+        this._tagDescription = description;
+        this._nodePath = Library.createNodePath(node);
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[NewTagCommand_Aai20] Executing.");
+
+        this._created = false;
+        Node node = this._nodePath.resolve(document);
+        
+        if (node instanceof IAaiTagged) {
+            AaiTag tag = new Aai20Tag(node);
+            tag.name = this._tagName;
+            tag.description = this._tagDescription;
+            ((IAaiTagged) node).addTag(tag);
+            this._created = true;
+        }
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[NewTagCommand_Aai20] Reverting.");
+        if (!this._created) {
+            return;
+        }
+
+        Node node = this._nodePath.resolve(document);
+        if (node instanceof IAaiTagged) {
+            IAaiTagged taggedNode = (IAaiTagged) node;
+            List<Tag> tags = taggedNode.getTags();
+            int index = tags.indexOf(IAaiTagged.getTag(taggedNode, this._tagName));
+            tags.remove(index);
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.after.json
@@ -1,0 +1,17 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "message":{
+                    "payload": {}
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.before.json
@@ -1,0 +1,27 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "message":{
+                    "payload": {},
+                    "tags": [
+                        {
+                            "name": "tag1",
+                            "description": "desc1"
+                        },
+                        {
+                            "name": "tag2",
+                            "description": "desc2"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-msg.commands.json
@@ -1,0 +1,6 @@
+[
+    {
+        "__type": "DeleteAllTagsCommand_Aai20",
+        "_nodePath": "/channels[myChannel]/subscribe/message"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.after.json
@@ -1,0 +1,17 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "message":{
+                    "payload": {}
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.before.json
@@ -1,0 +1,27 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "tags": [
+                    {
+                        "name": "tag1",
+                        "description": "desc1"
+                    },
+                    {
+                        "name": "tag2",
+                        "description": "desc2"
+                    }
+                ],
+                "message":{
+                    "payload": {}
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags-op.commands.json
@@ -1,0 +1,6 @@
+[
+    {
+        "__type": "DeleteAllTagsCommand_Aai20",
+        "_nodePath": "/channels[myChannel]/subscribe"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.after.json
@@ -1,0 +1,23 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "message":{
+                    "payload": {},
+                    "tags": [
+                        {
+                            "name": "tag2",
+                            "description": "desc2"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.before.json
@@ -1,0 +1,27 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "message":{
+                    "payload": {},
+                    "tags": [
+                        {
+                            "name": "tag1",
+                            "description": "desc1"
+                        },
+                        {
+                            "name": "tag2",
+                            "description": "desc2"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-msg.commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "__type": "DeleteTagCommand_Aai20",
+        "_nodePath": "/channels[myChannel]/subscribe/message",
+        "_tagName": "tag1"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.after.json
@@ -1,0 +1,23 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "tags": [
+                    {
+                        "name": "tag2",
+                        "description": "desc2"
+                    }
+                ],
+                "message":{
+                    "payload": {}
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.before.json
@@ -1,0 +1,27 @@
+{
+    "asyncapi": "2.0.0",
+    "info": {
+        "title": "Blank API",
+        "version": "1.0.0"
+    },
+    "channels": {
+        "myChannel": {
+            "description": "This is myChannel description",
+            "subscribe": {
+                "tags": [
+                    {
+                        "name": "tag1",
+                        "description": "desc1"
+                    },
+                    {
+                        "name": "tag2",
+                        "description": "desc2"
+                    }
+                ],
+                "message":{
+                    "payload": {}
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag-op.commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "__type": "DeleteTagCommand_Aai20",
+        "_nodePath": "/channels[myChannel]/subscribe",
+        "_tagName": "tag1"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.after.json
@@ -1,0 +1,23 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Blank API",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "myChannel": {
+      "description": "This is myChannel description",
+      "subscribe": {
+        "message":{
+          "payload": {},
+          "tags": [
+            {
+              "name": "tag1",
+              "description": "desc1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Blank API",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "myChannel": {
+      "description": "This is myChannel description",
+      "subscribe": {
+        "message":{
+          "payload": {}
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-msg.commands.json
@@ -1,0 +1,8 @@
+[
+	{
+		"__type": "NewTagCommand_Aai20",
+		"_nodePath": "/channels[myChannel]/subscribe/message",
+		"_tagName": "tag1",
+		"_tagDescription": "desc1"
+	}
+]

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.after.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.after.json
@@ -1,0 +1,23 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Blank API",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "myChannel": {
+      "description": "This is myChannel description",
+      "subscribe": {
+        "tags": [
+          {
+            "name": "tag1",
+            "description": "desc1"
+          }
+        ],
+        "message":{
+          "payload": {}
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.before.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Blank API",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "myChannel": {
+      "description": "This is myChannel description",
+      "subscribe": {
+        "message":{
+          "payload": {}
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/new-tag/asyncapi-2/new-tag-op.commands.json
@@ -1,0 +1,8 @@
+[
+	{
+		"__type": "NewTagCommand_Aai20",
+		"_nodePath": "/channels[myChannel]/subscribe",
+		"_tagName": "tag1",
+		"_tagDescription": "desc1"
+	}
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -170,6 +170,8 @@
     { "name": "[OpenAPI 3] {Delete Server} - Delete Server Path Item", "test": "commands/delete-server/openapi-3/delete-server-pathItem" },
     { "name": "[OpenAPI 2] {Delete Tag} - Delete Tag", "test": "commands/delete-tag/openapi-2/delete-tag" },
     { "name": "[OpenAPI 3] {Delete Tag} - Delete Tag", "test": "commands/delete-tag/openapi-3/delete-tag" },
+    { "name": "[AsyncAPI 2] {Delete Tag} - Delete Tag of Message", "test": "commands/delete-tag/asyncapi-2/delete-tag-msg" },
+    { "name": "[AsyncAPI 2] {Delete Tag} - Delete Tag of Operation", "test": "commands/delete-tag/asyncapi-2/delete-tag-op" },
     { "name": "[OpenAPI 3] {Delete Child Schema} - Any Of", "test": "commands/delete-child-schema/openapi-3/delete-child-schema" },
     { "name": "[OpenAPI 3] {New Media Type} - New Media Type Parameter", "test": "commands/new-media-type/openapi-3/new-media-type-parameter" },
     { "name": "[OpenAPI 3] {New Media Type} - New Media Type Request Body", "test": "commands/new-media-type/openapi-3/new-media-type-requestBody" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -124,6 +124,8 @@
     { "name": "[OpenAPI 3] {Delete All Servers} - Delete All Servers Path Item", "test": "commands/delete-all-servers/openapi-3/delete-all-servers-pathItem" },
     { "name": "[OpenAPI 2] {Delete All Tags} - Delete All Tags", "test": "commands/delete-all-tags/openapi-2/delete-all-tags" },
     { "name": "[OpenAPI 3] {Delete All Tags} - Delete All Tags", "test": "commands/delete-all-tags/openapi-3/delete-all-tags" },
+    { "name": "[AsyncAPI 2] {Delete All Tags} - Delete All Tags of Message", "test": "commands/delete-all-tags/asyncapi-2/delete-all-tags-msg" },
+    { "name": "[AsyncAPI 2] {Delete All Tags} - Delete All Tags of Operation", "test": "commands/delete-all-tags/asyncapi-2/delete-all-tags-op" },
     { "name": "[OpenAPI 3] {Delete All Child Schemas} - All Of", "test": "commands/delete-all-child-schemas/openapi-3/delete-all-schemas" },
     { "name": "[OpenAPI 2] {Delete Contact} - Delete Contact", "test": "commands/delete-contact/openapi-2/delete-contact" },
     { "name": "[OpenAPI 3] {Delete Contact} - Delete Contact NA", "test": "commands/delete-contact/openapi-3/delete-contact-na" },

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -218,6 +218,8 @@
     { "name": "[OpenAPI 3] {New Server} - New Server Path Item", "test": "commands/new-server/openapi-3/new-server-pathItem" },
     { "name": "[OpenAPI 2] {New Tag} - New Tag", "test": "commands/new-tag/openapi-2/new-tag" },
     { "name": "[OpenAPI 3] {New Tag} - New Tag", "test": "commands/new-tag/openapi-3/new-tag" },
+    { "name": "[AsyncAPI 2] {New Tag} - New Tag on Message", "test": "commands/new-tag/asyncapi-2/new-tag-msg" },
+    { "name": "[AsyncAPI 2] {New Tag} - New Tag on Operation", "test": "commands/new-tag/asyncapi-2/new-tag-op" },
     { "name": "[OpenAPI 3] {New Extension} - New Extension", "test": "commands/new-extension/openapi-3/new-extension" },
     { "name": "[OpenAPI 3] {New Extension} - New Extension Object", "test": "commands/new-extension/openapi-3/new-extension-object" },
     { "name": "[OpenAPI 2] {Rename Param} - Refactor Operation Parameter", "test": "commands/rename-parameter/openapi-2/refactor-operation-parameter" },


### PR DESCRIPTION
Adds the three following commands :
* add one tag on MessageBase and OperationBase nodes 
* delete one tag on MessageBase and OperationBase nodes
* delete all tags on MessageBase and OperationBase nodes