### PR TITLE
feat(asyncapi): add commands to handle addition and deletion of traits on messages and operations

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddTraitCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddTraitCommand.java
@@ -1,0 +1,108 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.asyncapi.models.AaiMessageTrait;
+import io.apicurio.datamodels.asyncapi.models.AaiOperation;
+import io.apicurio.datamodels.asyncapi.models.AaiOperationTrait;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20MessageTrait;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20OperationTrait;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat;
+import io.apicurio.datamodels.compat.NodeCompat;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.NodePath;
+
+public class AddTraitCommand extends AbstractCommand {
+
+    public NodePath _operationPath;
+    public NodePath _messagePath;
+
+    @JsonDeserialize(using = MarshallCompat.NullableJsonNodeDeserializer.class)
+    public Object _newTrait;
+    
+    @JsonDeserialize(using = MarshallCompat.NullableJsonNodeDeserializer.class)
+    public Object _oldNode;
+
+    AddTraitCommand() {
+    }
+
+    AddTraitCommand(AaiOperationTrait trait, AaiOperation operation) {
+        this._operationPath = Library.createNodePath(operation);
+        this._newTrait = Library.writeNode(trait);
+    }
+
+    AddTraitCommand(AaiMessageTrait trait, AaiMessage message) {
+        this._messagePath = Library.createNodePath(message);
+        this._newTrait = Library.writeNode(trait);
+    }
+    
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+
+        LoggerCompat.info("[AddTraitCommand] Executing.");
+        
+        if (!this.isNullOrUndefined(this._messagePath)) {
+            AaiMessage message = (AaiMessage) this._messagePath.resolve(document);
+            
+            if (this.isNullOrUndefined(message)) {
+                return;
+            }
+
+            this._oldNode = Library.writeNode(message);
+            AaiMessageTrait trait = new Aai20MessageTrait(message, null);
+            Library.readNode(this._newTrait, trait);
+            message.addTrait(trait);
+        } else if (!this.isNullOrUndefined(this._operationPath)) {
+            AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
+
+            if (this.isNullOrUndefined(operation)) {
+                return;
+            }
+
+            this._oldNode = Library.writeNode(operation);
+            AaiOperationTrait trait = new Aai20OperationTrait(operation, null);
+            Library.readNode(this._newTrait, trait);
+            operation.addTrait(trait);
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[AddTraitCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldNode)) {
+            return;
+        }
+        
+        if (!this.isNullOrUndefined(this._messagePath)) {
+            AaiMessage message = (AaiMessage) this._messagePath.resolve(document);
+            
+            if (this.isNullOrUndefined(message)) {
+                return;
+            }
+            
+            NodeCompat.setProperty(message.parent(), "message", message);
+            message.traits = null;
+            Library.readNode(this._oldNode, message);
+        } else if (!this.isNullOrUndefined(this._operationPath)) {
+            AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
+            
+            if (this.isNullOrUndefined(operation)) {
+                return;
+            }
+
+            NodeCompat.setProperty(operation.parent(), "operation", operation);
+            operation.traits = null;
+            Library.readNode(this._oldNode, operation);
+        }
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -20,7 +20,9 @@ import java.util.List;
 
 import io.apicurio.datamodels.asyncapi.models.AaiChannelItem;
 import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.asyncapi.models.AaiMessageTrait;
 import io.apicurio.datamodels.asyncapi.models.AaiOperation;
+import io.apicurio.datamodels.asyncapi.models.AaiOperationTrait;
 import io.apicurio.datamodels.asyncapi.models.AaiSchema;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20SchemaDefinition;
@@ -119,6 +121,8 @@ public class CommandFactory {
             { return new AddChannelItemCommand(); }
             case "AddSchemaDefinitionCommand_Aai20":
             { return new AddSchemaDefinitionCommand_Aai20(); }
+            case "AddTraitCommand":
+            { return new AddTraitCommand(); }
 
             /** Change Commands **/
 
@@ -332,6 +336,8 @@ public class CommandFactory {
             case "DeleteOperationTraitDefinitionCommand":
             case "DeleteOperationTraitDefinitionCommand_Aai20":
             { return new DeleteOperationTraitDefinitionCommand(); }
+            case "DeleteTraitCommand":
+            { return new DeleteTraitCommand(); }
 
             /** New Commands **/
 
@@ -570,6 +576,13 @@ public class CommandFactory {
         return new AddChannelItemCommand(channelItemName, from);
     }
 
+    public static final ICommand createAddTraitCommand(AaiOperationTrait trait, AaiOperation operation) {
+        return new AddTraitCommand(trait, operation);
+    }
+
+    public static final ICommand createAddTraitCommand(AaiMessageTrait trait, AaiMessage message) {
+        return new AddTraitCommand(trait, message);
+    }
 
     /* ***  Change Commands  *** */
 
@@ -943,6 +956,14 @@ public class CommandFactory {
     
     public static final ICommand createDeleteTagCommand_Aai20(String tagName, Node node) {
         return new DeleteTagCommand_Aai20(tagName, node);
+    }
+
+    public static final ICommand createDeleteTraitCommand(AaiOperation operation, int traitIdx) {
+        return new DeleteTraitCommand(operation, traitIdx);
+    }
+    
+    public static final ICommand createDeleteTraitCommand(AaiMessage message, int traitIdx) {
+        return new DeleteTraitCommand(message, traitIdx);
     }
 
     public static final ICommand createDeleteChannelCommand(String channelName) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTraitCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTraitCommand.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.asyncapi.models.AaiMessageTrait;
+import io.apicurio.datamodels.asyncapi.models.AaiOperation;
+import io.apicurio.datamodels.asyncapi.models.AaiOperationTrait;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Message;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20MessageTrait;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20OperationTrait;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.compat.LoggerCompat;
+import io.apicurio.datamodels.compat.MarshallCompat;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.Node;
+import io.apicurio.datamodels.core.models.NodePath;
+
+public class DeleteTraitCommand extends AbstractCommand {
+
+    public int _traitIdx;
+    public NodePath _messagePath;
+    public NodePath _operationPath;
+
+
+    @JsonDeserialize(using = MarshallCompat.NullableJsonNodeDeserializer.class)
+    public Object _oldNode;
+
+    DeleteTraitCommand() {
+    }
+
+    DeleteTraitCommand(AaiMessage message, int traitIdx) {
+        this._messagePath = Library.createNodePath(message);
+        this._traitIdx = traitIdx;
+    }
+
+    DeleteTraitCommand(AaiOperation operation, int traitIdx) {
+        this._operationPath = Library.createNodePath(operation);
+        this._traitIdx = traitIdx;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerCompat.info("[DeleteTraitCommand] Executing.");
+
+        if (!this.isNullOrUndefined(this._messagePath)) {
+            AaiMessage message = (AaiMessage) this._messagePath.resolve(document);
+
+            if (this.isNullOrUndefined(message)) {
+                return;
+            }
+
+            Node res = message.traits.remove(this._traitIdx);
+
+            if (!this.isNullOrUndefined(res)) {
+                this._oldNode = Library.writeNode(res);
+            }
+        } else if (!this.isNullOrUndefined(this._operationPath)) {
+            AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
+
+            if (this.isNullOrUndefined(operation)) {
+                return;
+            }
+
+            Node res = operation.traits.remove(this._traitIdx);
+
+            if (!this.isNullOrUndefined(res)) {
+                this._oldNode = Library.writeNode(res);
+            }
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerCompat.info("[DeleteTraitCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldNode)) {
+            return;
+        }
+        
+        if (!this.isNullOrUndefined(this._messagePath)) {
+            AaiMessage message = (AaiMessage) this._messagePath.resolve(document);
+            
+            if (this.isNullOrUndefined(message)) {
+                return;
+            }
+
+            AaiMessageTrait trait = new Aai20MessageTrait(message);
+            Library.readNode(this._oldNode, trait);
+            message.addTrait(trait);
+            
+        } else if (!this.isNullOrUndefined(this._operationPath)) {
+            AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
+
+            if (this.isNullOrUndefined(operation)) {
+                return;
+            }
+
+            AaiOperationTrait trait = new Aai20OperationTrait(operation);
+            Library.readNode(this._oldNode, trait);
+            operation.addTrait(trait);
+        }
+    }
+
+}

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.after.json
@@ -1,0 +1,34 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {},
+          "traits": [{
+            "$ref": "#/components/messageTraits/commonHeaders"
+          }]
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "content-type": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.before.json
@@ -1,0 +1,31 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "content-type": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-message.commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "__type": "AddTraitCommand",
+    "_messagePath": "/channels[999testtest99]/publish/message",
+    "_newTrait":
+          {
+            "$ref": "#/components/messageTraits/commonHeaders"
+          }
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.after.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        },
+        "traits": [
+          {
+            "$ref": "#/components/operationTraits/commonBindings"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "operationTraits": {
+      "commonBindings": {
+        "bindings": {
+          "amqp": {
+            "ack": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.before.json
@@ -1,0 +1,28 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        }
+      }
+    }
+  },
+  "components": {
+    "operationTraits": {
+      "commonBindings": {
+        "bindings": {
+          "amqp": {
+            "ack": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-trait/asyncapi-2/add-trait-operation.commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "__type": "AddTraitCommand",
+    "_operationPath": "/channels[999testtest99]/publish",
+    "_newTrait":
+          {
+            "$ref": "#/components/operationTraits/commonBindings"
+          }
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.after.json
@@ -1,0 +1,34 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {},
+          "traits": [{
+            "$ref": "#/components/messageTraits/commonHeaders"
+          }]
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "content-type": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.before.json
@@ -1,0 +1,31 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "content-type": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-message.commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "__type": "AddTraitCommand",
+    "_messagePath": "/channels[999testtest99]/publish/message",
+    "_newTrait":
+          {
+            "$ref": "#/components/messageTraits/commonHeaders"
+          }
+  }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.after.json
@@ -1,0 +1,33 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        },
+        "traits": [
+          {
+            "$ref": "#/components/operationTraits/commonBindings"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "operationTraits": {
+      "commonBindings": {
+        "bindings": {
+          "amqp": {
+            "ack": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.before.json
@@ -1,0 +1,28 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "TopicMultiEvent-oneOf",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "999testtest99": {
+      "publish": {
+        "summary": "All updates about the user",
+        "message": {
+          "payload": {}
+        }
+      }
+    }
+  },
+  "components": {
+    "operationTraits": {
+      "commonBindings": {
+        "bindings": {
+          "amqp": {
+            "ack": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-trait/asyncapi-2/delete-trait-operation.commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "__type": "AddTraitCommand",
+    "_operationPath": "/channels[999testtest99]/publish",
+    "_newTrait":
+          {
+            "$ref": "#/components/operationTraits/commonBindings"
+          }
+  }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -39,6 +39,8 @@
     { "name": "[OpenAPI 3] {Add Security Requirement} - Add Security Req Doc2", "test": "commands/add-security-requirement/openapi-3/add-security-requirement-doc2" },
     { "name": "[OpenAPI 3] {Add Security Requirement} - Add Security Req Op", "test": "commands/add-security-requirement/openapi-3/add-security-requirement-op" },
     { "name": "[OpenAPI 3] {Add Security Requirement} - Add Security Req", "test": "commands/add-security-requirement/openapi-3/add-security-requirement" },
+    { "name": "[AsyncAPI 2] {Add Trait} - Add Trait on message", "test": "commands/add-trait/asyncapi-2/add-trait-message" },
+    { "name": "[AsyncAPI 2] {Add Trait} - Add Trait on operation", "test": "commands/add-trait/asyncapi-2/add-trait-operation" },
     { "name": "[OpenAPI 3] {Add Child Schema} - Add to AllOf", "test": "commands/add-child-schema/openapi-3/add-child-schema" },
     { "name": "[AsyncAPI 2] {Add Child Schema} - Add to AllOf", "test": "commands/add-child-schema/asyncapi-2/add-child-schema" },
     { "name": "[OpenAPI 3] {Aggregate} - Aggregate Ordering", "test": "commands/aggregate/openapi-3/aggregate-ordering" },


### PR DESCRIPTION
It's currently possible to define operation traits and message traits in apicurio-studio, but users can't add these traits on operations and messages with forms. This PR adds required commands to handle addition and deletion of these traits.