### PR TITLE
Fix: unescape json refs special chars

### DIFF
--- a/src/main/java/io/apicurio/datamodels/core/util/ReferenceUtil.java
+++ b/src/main/java/io/apicurio/datamodels/core/util/ReferenceUtil.java
@@ -147,7 +147,7 @@ public class ReferenceUtil {
         List<String[]> split = RegexCompat.findMatches(fragment, "([^/]+)/?");
         Object cnode = contextNode;
         for (String[] mi : split) {
-            String seg = mi[1];
+            String seg = mi[1].replaceAll("~1", "/").replaceAll("~0", "~");
             if (NodeCompat.equals(seg, "#")) {
                 cnode = contextNode;
             } else if (cnode != null) {


### PR DESCRIPTION
# Summary
Openapi 2+ specs specifies that a _path item_ can have references. Since path items references must contain the path key starting with a `/` all the references will contain it escaped with `~1`  [see spec](https://swagger.io/docs/specification/v3_0/using-ref/).

# Issue
The method [ReferenceUtil#ResolveFragmentFromJS](https://github.com/Apicurio/apicurio-data-models/blob/351176953448208555a43dffadb05d0e7d3580e5/src/main/java/io/apicurio/datamodels/core/util/ReferenceUtil.java#L146)  that finds node in external doc doesn't unescape the `~1`, so these reference can never be resolved and apicurio studio throws a `Path Item Reference must refer to a valid Path Item Definition.` error.

# Description
This PR unescapes special json refs characters `/` and `~` while getting node keys in `ReferenceUtil#ResolveFragmentFromJS`.