### PR TITLE
fix: use AaiMessageBase in ChangeHeadersRefCommand_Aai20 to support headers ref in message traits

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ChangeHeadersRefCommand_Aai20.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ChangeHeadersRefCommand_Aai20.java
@@ -17,7 +17,7 @@ package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.asyncapi.models.AaiHeaderItem;
-import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.asyncapi.models.AaiMessageBase;
 import io.apicurio.datamodels.asyncapi.models.AaiOperation;
 import io.apicurio.datamodels.asyncapi.v2.models.Aai20NodeFactory;
 import io.apicurio.datamodels.cmd.AbstractCommand;
@@ -47,7 +47,7 @@ public class ChangeHeadersRefCommand_Aai20 extends AbstractCommand {
       this._headersRef = headersRef;
    }
 
-   ChangeHeadersRefCommand_Aai20(String headersRef, AaiMessage messageNode) {
+   ChangeHeadersRefCommand_Aai20(String headersRef, AaiMessageBase messageNode) {
       this._messagePath = Library.createNodePath(messageNode);
       this._headersRef = headersRef;
    }
@@ -58,7 +58,7 @@ public class ChangeHeadersRefCommand_Aai20 extends AbstractCommand {
 
       this._changed = false;
       
-      AaiMessage message = getMessage(document);
+      AaiMessageBase message = getMessage(document);
       if (this.isNullOrUndefined(message) || !isValidRef(this._headersRef)) {
          return;
       }
@@ -80,7 +80,7 @@ public class ChangeHeadersRefCommand_Aai20 extends AbstractCommand {
    public void undo(Document document) {
       LoggerCompat.info("[ChangeHeadersRefCommand_Aai20] Reverting.");
 
-      AaiMessage message = getMessage(document);
+      AaiMessageBase message = getMessage(document);
 
       if (!this._changed || this.isNullOrUndefined(message)) {
          return;
@@ -94,7 +94,7 @@ public class ChangeHeadersRefCommand_Aai20 extends AbstractCommand {
       }
    }
    
-   private AaiMessage getMessage(Document document) {
+   private AaiMessageBase getMessage(Document document) {
       if (!this.isNullOrUndefined(this._operationPath)) {
          AaiOperation operation = (AaiOperation) this._operationPath.resolve(document);
 
@@ -104,7 +104,7 @@ public class ChangeHeadersRefCommand_Aai20 extends AbstractCommand {
 
          return operation.message;
       } else {
-         return  (AaiMessage) this._messagePath.resolve(document);
+         return  (AaiMessageBase) this._messagePath.resolve(document);
       }
       
    }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CommandFactory.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.apicurio.datamodels.asyncapi.models.AaiChannelItem;
 import io.apicurio.datamodels.asyncapi.models.AaiMessage;
+import io.apicurio.datamodels.asyncapi.models.AaiMessageBase;
 import io.apicurio.datamodels.asyncapi.models.AaiMessageTrait;
 import io.apicurio.datamodels.asyncapi.models.AaiOperation;
 import io.apicurio.datamodels.asyncapi.models.AaiOperationTrait;
@@ -732,7 +733,7 @@ public class CommandFactory {
     public static final ICommand createChangeHeadersRefCommand_Aai20(String headersRef, AaiOperation operation) {
         return new ChangeHeadersRefCommand_Aai20(headersRef, operation);
     }
-    public static final ICommand createChangeHeadersRefCommand_Aai20(String headersRef, AaiMessage message) {
+    public static final ICommand createChangeHeadersRefCommand_Aai20(String headersRef, AaiMessageBase message) {
         return new ChangeHeadersRefCommand_Aai20(headersRef, message);
     }
 


### PR DESCRIPTION
Use `AaiMessageBase` as node type in `ChangeHeadersRefCommand_Aai20` to allow using it on message traits header ref change.