### PR TITLE
feat(openapi): add validation error if an openapi 3 spec version is unsupported

### DIFF
--- a/src/main/java/io/apicurio/datamodels/Library.java
+++ b/src/main/java/io/apicurio/datamodels/Library.java
@@ -267,7 +267,7 @@ public class Library {
             if (openapi.startsWith("2.")) {
                 return DocumentType.openapi2;
             }
-            if (openapi.startsWith("3.0")) {
+            if (openapi.startsWith("3.")) {
                 return DocumentType.openapi3;
             }
         }

--- a/src/main/java/io/apicurio/datamodels/core/validation/ValidationRuleSet.java
+++ b/src/main/java/io/apicurio/datamodels/core/validation/ValidationRuleSet.java
@@ -104,6 +104,7 @@ import io.apicurio.datamodels.core.validation.rules.invalid.value.OasInvalidLink
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasInvalidOperationIdRule;
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasInvalidOperationSchemeRule;
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasInvalidSecurityReqScopesRule;
+import io.apicurio.datamodels.core.validation.rules.invalid.value.OasInvalidSpecVersionRule;
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasMissingPathParamDefinitionRule;
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasMissingResponseForOperationRule;
 import io.apicurio.datamodels.core.validation.rules.invalid.value.OasOperationSummaryTooLongRule;
@@ -345,6 +346,7 @@ public class ValidationRuleSet {
         this.rules.add(md("SS-017", "Unexpected Usage of 'bearerFormat'", "Invalid Property Value", "Security Scheme", new DocumentType[] { oai30 }, true, "Security Scheme \"Bearer Format\" only allowed for HTTP Bearer auth scheme.", OasUnexpectedUsageOfBearerTokenRule.class));
         this.rules.add(md("SREQ-004", "Invalid Security Requirement Scopes", "Invalid Property Value", "Security Requirement", new DocumentType[] { oai30 }, true, "Value (scopes) for Security Requirement \"${'name'}\" must be an array.", OasInvalidSecurityReqScopesRule.class));
         this.rules.add(md("SVAR-003", "Server Variable Not Found in Template", "Invalid Property Value", "XXX", new DocumentType[] { oai30 }, true, "Server Variable \"${'name'}\" is not found in the server url template.", OasServerVarNotFoundInTemplateRule.class));
+        this.rules.add(md("DOC-001", "Invalid openapi version", "Invalid Property Value", "Document", new DocumentType[] { oai30 }, true, "openapi version \"${'openapi'}\" is not supported. Please use a version in the 3.0.* range." , OasInvalidSpecVersionRule.class));
         /** Invalid Reference **/
         this.rules.add(md("PAR-018", "Invalid Parameter Reference", "Invalid Reference", "Parameter", new DocumentType[] { oai20, oai30 }, true, "Parameter Reference must refer to a valid Parameter Definition.", OasInvalidParameterReferenceRule.class));
         this.rules.add(md("PATH-001", "Invalid Path Item Reference", "Invalid Reference", "Path Item", new DocumentType[] { oai20, oai30 }, true, "Path Item Reference must refer to a valid Path Item Definition.", OasInvalidPathItemReferenceRule.class));

--- a/src/main/java/io/apicurio/datamodels/core/validation/rules/invalid/value/OasInvalidSpecVersionRule.java
+++ b/src/main/java/io/apicurio/datamodels/core/validation/rules/invalid/value/OasInvalidSpecVersionRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.core.validation.rules.invalid.value;
+
+import io.apicurio.datamodels.core.Constants;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.validation.ValidationRuleMetaData;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+
+/**
+ * Reports an error if openapi 3 spec version is not supported (>= 3.1). 
+ */
+public class OasInvalidSpecVersionRule extends OasInvalidPropertyValueRule {
+    
+    public OasInvalidSpecVersionRule(ValidationRuleMetaData ruleInfo) {
+        super(ruleInfo);
+    }
+
+    @Override
+    public void visitDocument(Document node) {
+        if (node instanceof Oas30Document) {
+            String version = ((Oas30Document) node).openapi;
+            this.reportIfInvalid(isSupportedOas30Version(version), node, Constants.PROP_OPENAPI, map(Constants.PROP_OPENAPI, version));
+        }
+    }
+    
+    private boolean isSupportedOas30Version(String version) {
+        return version.startsWith("3.0");
+    }
+}

--- a/src/test/resources/fixtures/validation/openapi/3.0/invalid-spec-version-property-value.json
+++ b/src/test/resources/fixtures/validation/openapi/3.0/invalid-spec-version-property-value.json
@@ -1,0 +1,7 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Invalid Reference Test"
+  }
+}

--- a/src/test/resources/fixtures/validation/openapi/3.0/invalid-spec-version-property-value.json.expected
+++ b/src/test/resources/fixtures/validation/openapi/3.0/invalid-spec-version-property-value.json.expected
@@ -1,0 +1,2 @@
+[DOC-001] |medium| {/->openapi} :: openapi version "3.1.0" is not supported. Please use a version in the 3.0.* range.
+[R-003] |medium| {/->paths} :: API is missing the 'paths' property.

--- a/src/test/resources/fixtures/validation/tests.json
+++ b/src/test/resources/fixtures/validation/tests.json
@@ -39,6 +39,7 @@
     { "name": "[OpenAPI 3.0] Operation Properties", "test": "openapi/3.0/operation-properties.json", "severity": "high" },
     { "name": "[OpenAPI 3.0] Data Type Reference", "test": "openapi/3.0/data-type-reference.json" },
     { "name": "[OpenAPI 3.0] OAuth Flow With Scopes", "test": "openapi/3.0/oauth-flow-scopes.json" },
+    { "name": "[OpenAPI 3.0] Invalid spec version", "test": "openapi/3.0/invalid-spec-version-property-value.json" },
         
     { "name": "[Issues] Issue 804", "test": "openapi/issues/804/formData-params.json" },
     { "name": "[Issues] Issue 88", "test": "openapi/issues/88/response-def-description.json" }


### PR DESCRIPTION
Allows apicurio-data-models to parse openapi >= 3.1 specs and add new error during validation process if the spec is not in the 3.0.* range version to match 1.x branch supports .
Needed cause in apicurio studio users can create an openapi 3.0.2 doc and then change the spec version to 3.1.0. It will then create an error during further parsing of the doc cause only version starting with 3.0 were matched to openapi 3.