### PR TITLE
fix(validation): add OpenAPI 3.1 support to validation rules

### DIFF
--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasAllowReservedNotAllowedForParamRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasAllowReservedNotAllowedForParamRule.java
@@ -17,7 +17,12 @@
 package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
+import io.apicurio.datamodels.models.openapi.OpenApiParameter;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,8 +43,16 @@ public class OasAllowReservedNotAllowedForParamRule extends AbstractInvalidPrope
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.isAllowReserved())) {
+        OpenApiParameter param = (OpenApiParameter) node;
+
+        Boolean isAllowReserved = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            isAllowReserved = ((OpenApi30Parameter) node).isAllowReserved();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            isAllowReserved = ((OpenApi31Parameter) node).isAllowReserved();
+        }
+
+        if (hasValue(isAllowReserved)) {
             this.reportIfInvalid(equals(param.getIn(), "query"), node, "allowReserved", map());
         }
     }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasInvalidHeaderStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasInvalidHeaderStyleRule.java
@@ -18,6 +18,8 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.openapi.OpenApiHeader;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,9 +40,15 @@ public class OasInvalidHeaderStyleRule extends AbstractInvalidPropertyValueRule 
      */
     @Override
     public void visitHeader(OpenApiHeader node) {
-        OpenApi30Header header = (OpenApi30Header) node;
-        if (hasValue(header.getStyle())) {
-            this.reportIfInvalid(isValidEnumItem(header.getStyle(), array("simple")), node, "style", map());
+        String style = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Header) node).getStyle();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Header) node).getStyle();
+        }
+
+        if (hasValue(style)) {
+            this.reportIfInvalid(isValidEnumItem(style, array("simple")), node, "style", map());
         }
     }
 

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumOfParamMTsRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumOfParamMTsRule.java
@@ -22,6 +22,7 @@ import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
 import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -42,7 +43,7 @@ public class OasUnexpectedNumOfParamMTsRule extends AbstractInvalidPropertyValue
      */
     @Override
     public void visitParameter(Parameter node) {
-        Map<String, ?> content = Map.of();
+        Map<String, ?> content = new HashMap<>();
         if (ModelTypeUtil.isOpenApi30Model(node)) {
             content = ((OpenApi30Parameter) node).getContent();
         } else if (ModelTypeUtil.isOpenApi31Model(node)) {

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumOfParamMTsRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumOfParamMTsRule.java
@@ -18,7 +18,11 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -38,9 +42,14 @@ public class OasUnexpectedNumOfParamMTsRule extends AbstractInvalidPropertyValue
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.getContent())) {
-            this.reportIfInvalid(param.getContent().size() < 2, node, "content", map());
+        Map<String, ?> content = Map.of();
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            content = ((OpenApi30Parameter) node).getContent();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            content = ((OpenApi31Parameter) node).getContent();
+        }
+        if (hasValue(content)) {
+            this.reportIfInvalid(content.size() < 2, node, "content", map());
         }
     }
 

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumberOfHeaderMTsRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedNumberOfHeaderMTsRule.java
@@ -18,7 +18,12 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.openapi.OpenApiHeader;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30MediaType;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -38,9 +43,15 @@ public class OasUnexpectedNumberOfHeaderMTsRule extends AbstractInvalidPropertyV
      */
     @Override
     public void visitHeader(OpenApiHeader node) {
-        OpenApi30Header header = (OpenApi30Header) node;
-        if (isDefined(header.getContent())) {
-            this.reportIfInvalid(header.getContent().size() < 2, node, "content", map());
+        Map<String, ?> content = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            content = ((OpenApi30Header) node).getContent();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            content = ((OpenApi31Header) node).getContent();
+        }
+
+        if (isDefined(content)) {
+            this.reportIfInvalid(content.size() < 2, node, "content", map());
         }
     }
 

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownCookieParamStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownCookieParamStyleRule.java
@@ -17,8 +17,15 @@
 package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
+import io.apicurio.datamodels.models.openapi.OpenApiParameter;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -38,11 +45,19 @@ public class OasUnknownCookieParamStyleRule extends AbstractInvalidPropertyValue
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.getStyle())) {
-            if (equals(param.getIn(), "cookie")) {
-                this.reportIfInvalid(isValidEnumItem(param.getStyle(), array("form")), node, "style",
-                        map("style", param.getStyle()));
+        String style = null;
+        String in = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Parameter) node).getStyle();
+            in = ((OpenApi30Parameter) node).getIn();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Parameter) node).getStyle();
+            in = ((OpenApi31Parameter) node).getIn();
+        }
+        if (hasValue(style)) {
+            if (equals(in, "cookie")) {
+                this.reportIfInvalid(isValidEnumItem(style, array("form")), node, "style",
+                        map("style", style));
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownHeaderParamStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownHeaderParamStyleRule.java
@@ -18,6 +18,8 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,10 +40,18 @@ public class OasUnknownHeaderParamStyleRule extends AbstractInvalidPropertyValue
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.getStyle())) {
-            if (equals(param.getIn(), "header")) {
-                this.reportIfInvalid(isValidEnumItem(param.getStyle(), array("simple")), node, "style", map("style", param.getStyle()));
+        String style = null;
+        String in = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Parameter) node).getStyle();
+            in = ((OpenApi30Parameter) node).getIn();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Parameter) node).getStyle();
+            in = ((OpenApi31Parameter) node).getIn();
+        }
+        if (hasValue(style)) {
+            if (equals(in, "header")) {
+                this.reportIfInvalid(isValidEnumItem(style, array("simple")), node, "style", map("style", style));
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownParamStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownParamStyleRule.java
@@ -18,6 +18,8 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,10 +40,15 @@ public class OasUnknownParamStyleRule extends AbstractInvalidPropertyValueRule {
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.getStyle())) {
-            this.reportIfInvalid(isValidEnumItem(param.getStyle(), array("matrix", "label", "form", "simple", "spaceDelimited", "pipeDelimited", "deepObject")),
-                    node, "style", map("style", param.getStyle()));
+        String style = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Parameter) node).getStyle();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Parameter) node).getStyle();
+        }
+        if (hasValue(style)) {
+            this.reportIfInvalid(isValidEnumItem(style, array("matrix", "label", "form", "simple", "spaceDelimited", "pipeDelimited", "deepObject")),
+                    node, "style", map("style", style));
         }
     }
 

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownPathParamStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownPathParamStyleRule.java
@@ -18,6 +18,8 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,11 +40,19 @@ public class OasUnknownPathParamStyleRule extends AbstractInvalidPropertyValueRu
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (equals(param.getIn(), "path")) {
-            if (hasValue(param.getStyle())) {
-                this.reportIfInvalid(isValidEnumItem(param.getStyle(), array("matrix", "label", "simple")), param,
-                        "style", map("style", param.getStyle()));
+        String style = null;
+        String in = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Parameter) node).getStyle();
+            in = ((OpenApi30Parameter) node).getIn();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Parameter) node).getStyle();
+            in = ((OpenApi31Parameter) node).getIn();
+        }
+        if (equals(in, "path")) {
+            if (hasValue(style)) {
+                this.reportIfInvalid(isValidEnumItem(style, array("matrix", "label", "simple")), node,
+                        "style", map("style", style));
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownQueryParamStyleRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnknownQueryParamStyleRule.java
@@ -18,6 +18,8 @@ package io.apicurio.datamodels.validation.rules.invalid.value;
 
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -38,11 +40,19 @@ public class OasUnknownQueryParamStyleRule extends AbstractInvalidPropertyValueR
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        if (hasValue(param.getStyle())) {
-            if (equals(param.getIn(), "query")) {
-                this.reportIfInvalid(isValidEnumItem(param.getStyle(), array("form", "spaceDelimited", "pipeDelimited", "deepObject")),
-                        node, "style", map("style", param.getStyle()));
+        String style = null;
+        String in = null;
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            style = ((OpenApi30Parameter) node).getStyle();
+            in = ((OpenApi30Parameter) node).getIn();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            style = ((OpenApi31Parameter) node).getStyle();
+            in = ((OpenApi31Parameter) node).getIn();
+        }
+        if (hasValue(style)) {
+            if (equals(in, "query")) {
+                this.reportIfInvalid(isValidEnumItem(style, array("form", "spaceDelimited", "pipeDelimited", "deepObject")),
+                        node, "style", map("style", style));
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderExamplesMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderExamplesMutualExclusivityRule.java
@@ -16,10 +16,16 @@
 
 package io.apicurio.datamodels.validation.rules.mutex;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.datamodels.models.openapi.OpenApiExample;
 import io.apicurio.datamodels.models.openapi.OpenApiHeader;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * Implements the Header Example/Examples Mutual Exclusivity Rule.
@@ -40,8 +46,18 @@ public class OasHeaderExamplesMutualExclusivityRule extends ValidationRule {
      */
     @Override
     public void visitHeader(OpenApiHeader node) {
-        OpenApi30Header header = (OpenApi30Header) node;
-        this.reportIf(hasValue(header.getExample()) && header.getExamples().size() > 0, node, "example", map());
+        JsonNode example = null;
+        Map<String, OpenApiExample> examples = Map.of();
+
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            example = ((OpenApi30Header) node).getExample();
+            examples = ((OpenApi30Header) node).getExamples();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            example = ((OpenApi31Header) node).getExample();
+            examples = ((OpenApi31Header) node).getExamples();
+        }
+
+        this.reportIf(hasValue(example) && !examples.isEmpty(), node, "example", map());
     }
 
 }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderExamplesMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderExamplesMutualExclusivityRule.java
@@ -25,6 +25,7 @@ import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -47,7 +48,7 @@ public class OasHeaderExamplesMutualExclusivityRule extends ValidationRule {
     @Override
     public void visitHeader(OpenApiHeader node) {
         JsonNode example = null;
-        Map<String, OpenApiExample> examples = Map.of();
+        Map<String, OpenApiExample> examples = new HashMap<>();
 
         if (ModelTypeUtil.isOpenApi30Model(node)) {
             example = ((OpenApi30Header) node).getExample();

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderSchemaContentMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasHeaderSchemaContentMutualExclusivityRule.java
@@ -18,8 +18,13 @@ package io.apicurio.datamodels.validation.rules.mutex;
 
 import io.apicurio.datamodels.models.openapi.OpenApiHeader;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Header;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30MediaType;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Header;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * Implements the Header Schema/Content Mutual Exclusivity Rule.
@@ -35,8 +40,8 @@ public class OasHeaderSchemaContentMutualExclusivityRule extends ValidationRule 
         super(ruleInfo);
     }
 
-    private boolean hasContent(OpenApi30Header contentParent) {
-        return isDefined(contentParent.getContent()) && contentParent.getContent().size() > 0;
+    private boolean hasContent(Map<String, ?> content) {
+        return isDefined(content) && !content.isEmpty();
     }
 
     /**
@@ -44,7 +49,17 @@ public class OasHeaderSchemaContentMutualExclusivityRule extends ValidationRule 
      */
     @Override
     public void visitHeader(OpenApiHeader node) {
-        OpenApi30Header header = (OpenApi30Header) node;
-        this.reportIf(hasValue(header.getSchema()) && hasContent(header), node, "schema", map());
+        Object schema = null;
+        Map<String, ?> content = null;
+
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            schema = ((OpenApi30Header) node).getSchema();
+            content = ((OpenApi30Header) node).getContent();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            schema = ((OpenApi31Header) node).getSchema();
+            content = ((OpenApi31Header) node).getContent();
+        }
+
+        this.reportIf(hasValue(schema) && hasContent(content), node, "schema", map());
     }
 }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterExamplesMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterExamplesMutualExclusivityRule.java
@@ -16,10 +16,15 @@
 
 package io.apicurio.datamodels.validation.rules.mutex;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * Implements the Parameter Example/Examples Mutual Exclusivity Rule.
@@ -40,8 +45,16 @@ public class OasParameterExamplesMutualExclusivityRule extends ValidationRule {
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
-        this.reportIf(hasValue(param.getExample()) && param.getExamples().size() > 0, node, "example", map());
+        JsonNode example = null;
+        Map<String, ?> examples = Map.of();
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
+            example = ((OpenApi30Parameter) node).getExample();
+            examples = ((OpenApi30Parameter) node).getExamples();
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+            example = ((OpenApi31Parameter) node).getExample();
+            examples = ((OpenApi31Parameter) node).getExamples();
+        }
+        this.reportIf(hasValue(example) && !examples.isEmpty(), node, "example", map());
     }
 
 }

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterExamplesMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterExamplesMutualExclusivityRule.java
@@ -24,6 +24,7 @@ import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -46,7 +47,7 @@ public class OasParameterExamplesMutualExclusivityRule extends ValidationRule {
     @Override
     public void visitParameter(Parameter node) {
         JsonNode example = null;
-        Map<String, ?> examples = Map.of();
+        Map<String, ?> examples = new HashMap<>();
         if (ModelTypeUtil.isOpenApi30Model(node)) {
             example = ((OpenApi30Parameter) node).getExample();
             examples = ((OpenApi30Parameter) node).getExamples();

--- a/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterSchemaContentMutualExclusivityRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/mutex/OasParameterSchemaContentMutualExclusivityRule.java
@@ -19,8 +19,12 @@ package io.apicurio.datamodels.validation.rules.mutex;
 import io.apicurio.datamodels.models.Parameter;
 import io.apicurio.datamodels.models.openapi.OpenApiParameter;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRule;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
+
+import java.util.Map;
 
 /**
  * Implements the Parameter Schema/Content Mutual Exclusivity Rule.
@@ -36,11 +40,18 @@ public class OasParameterSchemaContentMutualExclusivityRule extends ValidationRu
         super(ruleInfo);
     }
 
-    private boolean hasContent(OpenApi30Parameter contentParent) {
-        if (!isDefined(contentParent.getContent())) {
+    private boolean hasContent(OpenApiParameter contentParent) {
+        Map<String, ?> content = null;
+        if (ModelTypeUtil.isOpenApi30Model(contentParent)) {
+            content = ((OpenApi30Parameter) contentParent).getContent();
+        } else if (ModelTypeUtil.isOpenApi31Model(contentParent)) {
+            content = ((OpenApi31Parameter) contentParent).getContent();
+        }
+
+        if (!isDefined(content)) {
             return false;
         }
-        return contentParent.getContent().size() > 0;
+        return !content.isEmpty();
     }
 
     /**
@@ -49,7 +60,7 @@ public class OasParameterSchemaContentMutualExclusivityRule extends ValidationRu
     @Override
     public void visitParameter(Parameter node) {
         OpenApiParameter parameter = (OpenApiParameter) node;
-        this.reportIf(hasValue(parameter.getSchema()) && hasContent((OpenApi30Parameter) node), node, "schema", map());
+        this.reportIf(hasValue(parameter.getSchema()) && hasContent(parameter), node, "schema", map());
     }
 
 }

--- a/src/test/resources/fixtures/validation/openapi/3.1/issue-6612.json
+++ b/src/test/resources/fixtures/validation/openapi/3.1/issue-6612.json
@@ -1,0 +1,275 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Person Service",
+    "description": "API for managing persons.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/api/v1"
+    }
+  ],
+  "tags": [
+    {
+      "name": "persons",
+      "description": "Endpoints for Persons"
+    }
+  ],
+  "paths": {
+    "/v1/persons": {
+      "post": {
+        "tags": [
+          "persons"
+        ],
+        "summary": "Create a new person",
+        "operationId": "create",
+        "description": "Create a new person with personal and party details.",
+        "requestBody": {
+          "required": true,
+          "description": "The person to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Person"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            },
+            "description": "Person created successfully",
+            "headers": {
+              "Location": {
+                "description": "The URI of the newly created person",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400-BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401-Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/500-InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/persons/{guid}": {
+      "get": {
+        "tags": [
+          "persons"
+        ],
+        "operationId": "get",
+        "summary": "Get a person by GUID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Guid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Person details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400-BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401-Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/404-NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500-InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/persons/{guid}/contacts/{contactGuid}": {
+      "put": {
+        "tags": [
+          "persons"
+        ],
+        "operationId": "updateContact",
+        "summary": "Update a contact by person guid and contact guid",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Guid"
+          },
+          {
+            "$ref": "#/components/parameters/ContactGuid"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The contact data to update.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Person"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Contact updated successfully"
+          },
+          "400": {
+            "$ref": "#/components/responses/400-BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401-Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/404-NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500-InternalServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Problem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the person was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last update to the person"
+          }
+        }
+      },
+      "Person": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "object"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Surname": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "Guid": {
+        "name": "guid",
+        "in": "path",
+        "required": true,
+        "description": "The GUID of the person",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "ContactGuid": {
+        "name": "contactGuid",
+        "in": "path",
+        "required": true,
+        "description": "The GUID of a contact",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "AddressGuid": {
+        "name": "addressGuid",
+        "in": "path",
+        "required": true,
+        "description": "The GUID of the address",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "responses": {
+      "400-BadRequest": {
+        "description": "The request was invalid or not well-formatted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "401-Unauthorized": {
+        "description": "The request does not have a valid access token or it is expired.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "404-NotFound": {
+        "description": "The resource you were trying to reach is not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "500-InternalServerError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/validation/tests.json
+++ b/src/test/resources/fixtures/validation/tests.json
@@ -41,6 +41,7 @@
     { "name": "[OpenAPI 3.0] OAuth Flow With Scopes", "test": "openapi/3.0/oauth-flow-scopes.json" },
 
     { "name": "[OpenAPI 3.1] Multi-typed Schema", "test": "openapi/3.1/multiple-schema-types.json" },
+    { "name": "[OpenAPI 3.1] Issue 6612", "test": "openapi/3.1/issue-6612.json" },
 
     { "name": "[Issues] Issue 804", "test": "openapi/issues/804/formData-params.json" },
     { "name": "[Issues] Issue 88", "test": "openapi/issues/88/response-def-description.json" }


### PR DESCRIPTION
Added compatibility for OpenApi31Parameter and OpenApi31Header models across multiple validation rules to resolve type casting issues when validating OpenAPI 3.1 specifications. This ensures all validation rules work correctly with both OpenAPI 3.0 and 3.1 models.