### PR TITLE
fix: Handle OpenAPI 3.1 documents in OasSecurityRequirementScopesMu…

### DIFF
--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasSecurityRequirementScopesMustBeEmptyRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasSecurityRequirementScopesMustBeEmptyRule.java
@@ -25,6 +25,7 @@ import io.apicurio.datamodels.models.SecurityScheme;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -47,10 +48,15 @@ public class OasSecurityRequirementScopesMustBeEmptyRule extends AbstractInvalid
             if (hasValue(doc20.getSecurityDefinitions())) {
                 return doc20.getSecurityDefinitions().getItem(schemeName);
             }
-        } else {
+        } else if (document.root().modelType() == ModelType.OPENAPI30) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             if (hasValue(doc30.getComponents()) && hasValue(doc30.getComponents().getSecuritySchemes())) {
                 return doc30.getComponents().getSecuritySchemes().get(schemeName);
+            }
+        } else if (document.root().modelType() == ModelType.OPENAPI31) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (hasValue(doc31.getComponents()) && hasValue(doc31.getComponents().getSecuritySchemes())) {
+                return doc31.getComponents().getSecuritySchemes().get(schemeName);
             }
         }
 
@@ -62,7 +68,7 @@ public class OasSecurityRequirementScopesMustBeEmptyRule extends AbstractInvalid
         List<String> allowedTypes = new ArrayList<>();
         allowedTypes.add("oauth2");
         String options = "\"oauth2\"";
-        if (node.root().modelType() == ModelType.OPENAPI30) {
+        if (node.root().modelType() == ModelType.OPENAPI30 || node.root().modelType() == ModelType.OPENAPI31) {
             allowedTypes.add("openIdConnect");
             options = "\"oauth2\" or \"openIdConnect\"";
         }

--- a/src/test/resources/fixtures/validation/openapi/3.1/security-requirements.json
+++ b/src/test/resources/fixtures/validation/openapi/3.1/security-requirements.json
@@ -1,0 +1,86 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Security Requirements Test",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/hello": {
+            "get": {
+                "summary": "Returns a greeting",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "Hello, World!"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/protected": {
+            "post": {
+                "summary": "Protected endpoint with OAuth2",
+                "security": [
+                    {
+                        "OAuth2": ["read", "write"]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                }
+            }
+        },
+        "/openid": {
+            "get": {
+                "summary": "Endpoint with OpenID Connect",
+                "security": [
+                    {
+                        "OpenIDConnect": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "HTTPBearer": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "OAuth2": {
+                "type": "oauth2",
+                "flows": {
+                    "clientCredentials": {
+                        "tokenUrl": "https://example.com/oauth/token",
+                        "scopes": {
+                            "read": "Read access",
+                            "write": "Write access"
+                        }
+                    }
+                }
+            },
+            "OpenIDConnect": {
+                "type": "openIdConnect",
+                "openIdConnectUrl": "https://example.com/.well-known/openid-configuration"
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/validation/tests.json
+++ b/src/test/resources/fixtures/validation/tests.json
@@ -42,6 +42,7 @@
 
     { "name": "[OpenAPI 3.1] Multi-typed Schema", "test": "openapi/3.1/multiple-schema-types.json" },
     { "name": "[OpenAPI 3.1] Issue 6612", "test": "openapi/3.1/issue-6612.json" },
+    { "name": "[OpenAPI 3.1] Security Requirements", "test": "openapi/3.1/security-requirements.json" },
 
     { "name": "[Issues] Issue 804", "test": "openapi/issues/804/formData-params.json" },
     { "name": "[Issues] Issue 88", "test": "openapi/issues/88/response-def-description.json" }


### PR DESCRIPTION
The validation rule OasSecurityRequirementScopesMustBeEmptyRule was incorrectly
casting all non-OpenAPI 2.0 documents to OpenApi30Document, causing a
ClassCastException when validating OpenAPI 3.1 documents with security
requirements.

Changes:
- Added OpenApi31Document import
- Updated findSecurityScheme() to explicitly check for OPENAPI30 and OPENAPI31
  model types instead of using an unsafe else block
- Updated visitSecurityRequirement() to handle both OpenAPI 3.0 and 3.1 for
  openIdConnect security scheme support
- Added comprehensive test case for OpenAPI 3.1 security requirements covering
  HTTP Bearer, OAuth2, and OpenID Connect schemes

Fixes Apicurio/apicurio-registry#6864
