### PR TITLE
Replace x-text-content hack with ResolvedReference architecture for multi-format schemas

### DIFF
--- a/src/main/java/io/apicurio/datamodels/deref/ReferencedNodeImporter.java
+++ b/src/main/java/io/apicurio/datamodels/deref/ReferencedNodeImporter.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apicurio.datamodels.Library;
@@ -65,6 +66,30 @@ public abstract class ReferencedNodeImporter extends CombinedVisitorAdapter {
 
     public void importNode(Node resolvedNode) {
         resolvedNode.accept(this);
+    }
+
+    /**
+     * Imports a JsonNode (JSON/YAML content that is not OpenAPI/AsyncAPI).
+     * Subclasses should override this method to handle JSON content appropriately.
+     * The default implementation throws an UnsupportedOperationException.
+     *
+     * @param jsonNode the JsonNode to import
+     * @param mediaType the media type of the content (may be null)
+     */
+    public void importJson(JsonNode jsonNode, String mediaType) {
+        throw new UnsupportedOperationException("importJson is not supported by " + getClass().getName());
+    }
+
+    /**
+     * Imports text content (non-JSON content such as Protocol Buffers, GraphQL, etc.).
+     * Subclasses should override this method to handle text content appropriately.
+     * The default implementation throws an UnsupportedOperationException.
+     *
+     * @param textContent the text content to import
+     * @param mediaType the media type of the content (may be null)
+     */
+    public void importText(String textContent, String mediaType) {
+        throw new UnsupportedOperationException("importText is not supported by " + getClass().getName());
     }
 
     public void setPathToImportedNode(Node importedNode, String pathToImportedNode) {

--- a/src/main/java/io/apicurio/datamodels/refs/IReferenceResolver.java
+++ b/src/main/java/io/apicurio/datamodels/refs/IReferenceResolver.java
@@ -32,28 +32,43 @@ import io.apicurio.datamodels.models.Node;
 public interface IReferenceResolver {
 
     /**
-     * Resolves a reference to a {@link Node}.
+     * Resolves a reference to a {@link ResolvedReference}.
      *
-     * <p>For references to JSON content, the resolver should return a Node containing
-     * the parsed JSON structure.</p>
+     * <p>The resolver can return three different types of content:</p>
+     * <ul>
+     *   <li><b>Node</b>: Use {@link ResolvedReference#fromNode(Node)} when the resolved content is
+     *       an OpenAPI or AsyncAPI document/component that has been parsed into the data model.</li>
+     *   <li><b>JsonNode</b>: Use {@link ResolvedReference#fromJson(com.fasterxml.jackson.databind.JsonNode)}
+     *       or {@link ResolvedReference#fromJson(com.fasterxml.jackson.databind.JsonNode, String)} when the
+     *       resolved content is JSON or YAML that is not OpenAPI/AsyncAPI (e.g., JSON Schema, Avro JSON format).
+     *       Include the media type when known.</li>
+     *   <li><b>Text</b>: Use {@link ResolvedReference#fromText(String, String)} when the resolved content
+     *       is non-JSON text such as Protocol Buffers (.proto), GraphQL schemas, Avro text format, etc.
+     *       The media type should be provided (e.g., "application/vnd.google.protobuf;version=3").</li>
+     * </ul>
      *
-     * <p>For references to non-JSON content (such as Protocol Buffers .proto files,
-     * Apache Avro .avsc files, or other text-based schema formats), the resolver must
-     * return a Node with the text content stored in an extension element named
-     * "x-text-content". This allows the dereferencer to properly detect and wrap
-     * non-JSON schemas in AsyncAPI 3.0 Multi-Format Schema Objects.</p>
-     *
-     * <p>Example for a .proto file reference:</p>
+     * <p>Example for a Protocol Buffers .proto file reference:</p>
      * <pre>
-     * {
-     *   "x-text-content": "syntax = \"proto3\";\n\nmessage MyMessage {\n  string field = 1;\n}\n"
-     * }
+     * String protoContent = "syntax = \"proto3\";\n\nmessage UserEvent {\n  string userId = 1;\n}\n";
+     * return ResolvedReference.fromText(protoContent, "application/vnd.google.protobuf;version=3");
+     * </pre>
+     *
+     * <p>Example for a JSON Schema reference:</p>
+     * <pre>
+     * JsonNode jsonSchema = // ... parse JSON ...
+     * return ResolvedReference.fromJson(jsonSchema, "application/schema+json");
+     * </pre>
+     *
+     * <p>Example for an OpenAPI component reference:</p>
+     * <pre>
+     * Node node = // ... parse and convert to Node ...
+     * return ResolvedReference.fromNode(node);
      * </pre>
      *
      * @param reference the reference URI to resolve (e.g., "http://example.com/schema.proto")
      * @param from the node containing the reference
-     * @return a Node containing the resolved content, or null if the resolver cannot resolve the reference
+     * @return a ResolvedReference containing the resolved content, or null if the resolver cannot resolve the reference
      */
-    public Node resolveRef(String reference, Node from);
+    public ResolvedReference resolveRef(String reference, Node from);
 
 }

--- a/src/main/java/io/apicurio/datamodels/refs/LocalReferenceResolver.java
+++ b/src/main/java/io/apicurio/datamodels/refs/LocalReferenceResolver.java
@@ -31,7 +31,7 @@ public class LocalReferenceResolver implements IReferenceResolver {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public Node resolveRef(String $ref, Node from) {
+    public ResolvedReference resolveRef(String $ref, Node from) {
         // Only handle internal $refs
         if ($ref == null || $ref.indexOf("#/") != 0) {
             return null;
@@ -55,7 +55,7 @@ public class LocalReferenceResolver implements IReferenceResolver {
         }
 
         if (cnode instanceof Node) {
-            return (Node) cnode;
+            return ResolvedReference.fromNode((Node) cnode);
         } else {
             return null;
         }

--- a/src/main/java/io/apicurio/datamodels/refs/ReferenceResolverChain.java
+++ b/src/main/java/io/apicurio/datamodels/refs/ReferenceResolverChain.java
@@ -64,11 +64,11 @@ public class ReferenceResolverChain implements IReferenceResolver {
     }
 
     @Override
-    public Node resolveRef(String reference, Node from) {
+    public ResolvedReference resolveRef(String reference, Node from) {
         for (IReferenceResolver resolver : resolvers) {
-            Node resolvedNode = resolver.resolveRef(reference, from);
-            if (resolvedNode != null) {
-                return resolvedNode;
+            ResolvedReference resolvedRef = resolver.resolveRef(reference, from);
+            if (resolvedRef != null) {
+                return resolvedRef;
             }
         }
         return null;

--- a/src/main/java/io/apicurio/datamodels/refs/ResolvedReference.java
+++ b/src/main/java/io/apicurio/datamodels/refs/ResolvedReference.java
@@ -1,0 +1,184 @@
+package io.apicurio.datamodels.refs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.datamodels.models.Node;
+
+/**
+ * Represents a resolved reference that can contain three different types of content:
+ * <ul>
+ *   <li><b>NODE</b>: An {@link io.apicurio.datamodels.models.Node} representing an OpenAPI or AsyncAPI document/component</li>
+ *   <li><b>JSON</b>: A {@link com.fasterxml.jackson.databind.JsonNode} representing JSON/YAML content that isn't OpenAPI/AsyncAPI</li>
+ *   <li><b>TEXT</b>: A String representing non-JSON content such as Protocol Buffers (.proto), GraphQL, Avro text schemas, etc.</li>
+ * </ul>
+ *
+ * <p>This class is used as the return type for {@link IReferenceResolver#resolveRef(String, Node)} to support
+ * dereferencing external schemas in formats other than OpenAPI/AsyncAPI, particularly for AsyncAPI 3.0
+ * Multi-Format Schema Objects.</p>
+ *
+ * @author ewittman
+ */
+public class ResolvedReference {
+
+    /**
+     * Enumeration of the types of content that can be contained in a {@link ResolvedReference}.
+     */
+    public enum ResolvedReferenceType {
+        /**
+         * Content is an {@link io.apicurio.datamodels.models.Node} (OpenAPI or AsyncAPI document/component).
+         */
+        NODE,
+
+        /**
+         * Content is a {@link com.fasterxml.jackson.databind.JsonNode} (JSON/YAML that isn't OpenAPI/AsyncAPI).
+         */
+        JSON,
+
+        /**
+         * Content is a String (non-JSON content like Protocol Buffers, GraphQL, Avro text, etc.).
+         */
+        TEXT
+    }
+
+    private final ResolvedReferenceType referenceType;
+    private final Object content;
+    private final String mediaType;
+
+    /**
+     * Creates a ResolvedReference containing a Node.
+     *
+     * @param node the Node content
+     * @return a ResolvedReference of type NODE
+     */
+    public static ResolvedReference fromNode(Node node) {
+        return new ResolvedReference(ResolvedReferenceType.NODE, node, null);
+    }
+
+    /**
+     * Creates a ResolvedReference containing a JsonNode with application/json media type.
+     *
+     * @param jsonNode the JsonNode content
+     * @return a ResolvedReference of type JSON
+     */
+    public static ResolvedReference fromJson(JsonNode jsonNode) {
+        return new ResolvedReference(ResolvedReferenceType.JSON, jsonNode, "application/json");
+    }
+
+    /**
+     * Creates a ResolvedReference containing a JsonNode with a specific media type.
+     *
+     * @param jsonNode the JsonNode content
+     * @param mediaType the media type of the content (e.g., "application/vnd.apache.avro+json;version=1.12.0")
+     * @return a ResolvedReference of type JSON
+     */
+    public static ResolvedReference fromJson(JsonNode jsonNode, String mediaType) {
+        return new ResolvedReference(ResolvedReferenceType.JSON, jsonNode, mediaType);
+    }
+
+    /**
+     * Creates a ResolvedReference containing text content with a specific media type.
+     *
+     * @param text the text content
+     * @param mediaType the media type of the content (e.g., "application/vnd.google.protobuf;version=3")
+     * @return a ResolvedReference of type TEXT
+     */
+    public static ResolvedReference fromText(String text, String mediaType) {
+        return new ResolvedReference(ResolvedReferenceType.TEXT, text, mediaType);
+    }
+
+    /**
+     * Private constructor.
+     *
+     * @param referenceType the type of content
+     * @param content the actual content
+     * @param mediaType the media type (may be null for NODE type)
+     */
+    private ResolvedReference(ResolvedReferenceType referenceType, Object content, String mediaType) {
+        this.referenceType = referenceType;
+        this.content = content;
+        this.mediaType = mediaType;
+    }
+
+    /**
+     * Gets the type of content in this reference.
+     *
+     * @return the reference type
+     */
+    public ResolvedReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    /**
+     * Gets the media type of the content, if available.
+     *
+     * @return the media type, or null if not available
+     */
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    /**
+     * Checks if this reference contains a Node.
+     *
+     * @return true if the content is a Node
+     */
+    public boolean isNode() {
+        return referenceType == ResolvedReferenceType.NODE;
+    }
+
+    /**
+     * Checks if this reference contains a JsonNode.
+     *
+     * @return true if the content is a JsonNode
+     */
+    public boolean isJson() {
+        return referenceType == ResolvedReferenceType.JSON;
+    }
+
+    /**
+     * Checks if this reference contains text.
+     *
+     * @return true if the content is text
+     */
+    public boolean isText() {
+        return referenceType == ResolvedReferenceType.TEXT;
+    }
+
+    /**
+     * Gets the content as a Node.
+     *
+     * @return the Node content
+     * @throws ClassCastException if the content is not a Node
+     */
+    public Node asNode() {
+        if (referenceType != ResolvedReferenceType.NODE) {
+            throw new ClassCastException("Content is not a Node, it is " + referenceType);
+        }
+        return (Node) content;
+    }
+
+    /**
+     * Gets the content as a JsonNode.
+     *
+     * @return the JsonNode content
+     * @throws ClassCastException if the content is not a JsonNode
+     */
+    public JsonNode asJson() {
+        if (referenceType != ResolvedReferenceType.JSON) {
+            throw new ClassCastException("Content is not a JsonNode, it is " + referenceType);
+        }
+        return (JsonNode) content;
+    }
+
+    /**
+     * Gets the content as text.
+     *
+     * @return the text content
+     * @throws ClassCastException if the content is not text
+     */
+    public String asText() {
+        if (referenceType != ResolvedReferenceType.TEXT) {
+            throw new ClassCastException("Content is not text, it is " + referenceType);
+        }
+        return (String) content;
+    }
+}

--- a/src/main/ts/tests/dereference.test.ts
+++ b/src/main/ts/tests/dereference.test.ts
@@ -1,6 +1,7 @@
 import {Library} from "../src/io/apicurio/datamodels/Library";
 import {readJSON} from "./util/tutils";
 import {IReferenceResolver} from "../src/io/apicurio/datamodels/refs/IReferenceResolver";
+import {ResolvedReference} from "../src/io/apicurio/datamodels/refs/ResolvedReference";
 import {Node} from "../src/io/apicurio/datamodels/models/Node";
 import {Document} from "../src/io/apicurio/datamodels/models/Document";
 
@@ -9,27 +10,47 @@ interface TestSpec {
     name: string;
     input: string;
     expected: string;
+    strict: boolean;
 }
 
 
 const refs: any = readJSON("tests/fixtures/dereference/tests.refs.json");
 class DereferenceTestReferenceResolver implements IReferenceResolver {
 
-    public resolveRef(reference: string, from: Node): Node {
+    public resolveRef(reference: string, from: Node): ResolvedReference {
         if (refs[reference]) {
             let ref = refs[reference];
-            if (typeof ref === "object") {
-                return this.toModel(ref, from);
+            if (typeof ref === "object" && ref["type"] === "record") {
+                return ResolvedReference.fromJson(ref, "application/vnd.apache.avro+json");
+            } else if (typeof ref === "object") {
+                // Object content - convert to Node
+                let node: Node = this.toModel(ref, from);
+                return ResolvedReference.fromNode(node);
             } else if (typeof ref === "string") {
-                return this.toModel({
-                    "x-text-content": ref
-                }, from);
+                // Text content - return as text with appropriate media type
+                let textContent: string = ref;
+                let mediaType: string = this.detectMediaType(reference, textContent);
+                return ResolvedReference.fromText(textContent, mediaType);
             }
         }
         return null;
     }
 
-    public toModel(jsonNode: any, from: Node): Node {
+    private detectMediaType(reference: string, textContent: string): string {
+        // Detect based on file extension in reference
+        if (reference.endsWith(".proto")) {
+            return "application/vnd.google.protobuf;version=3";
+        } else if (reference.endsWith(".avsc")) {
+            return "application/vnd.apache.avro+json;version=1.12.0";
+        } else if (reference.endsWith(".graphql") || reference.endsWith(".gql")) {
+            return "application/graphql";
+        }
+
+        // Fallback to plain text
+        return "text/plain";
+    }
+
+    private toModel(jsonNode: any, from: Node): Node {
         let rval: Node = from.emptyClone();
         rval.attach(from.parent());
         return Library.readNode(jsonNode, rval);
@@ -52,7 +73,7 @@ allTests.forEach(spec => {
         expect(sourceDoc).not.toBeNull();
 
         // Dereference the document
-        let dereferencedDoc: Document = Library.dereferenceDocument(sourceDoc, true);
+        let dereferencedDoc: Document = Library.dereferenceDocument(sourceDoc, spec.strict === undefined ? true : spec.strict);
 
         // Serialize/write the document
         let actual: any = Library.writeNode(dereferencedDoc);

--- a/src/test/java/io/apicurio/datamodels/refs/DereferenceTestCase.java
+++ b/src/test/java/io/apicurio/datamodels/refs/DereferenceTestCase.java
@@ -24,7 +24,8 @@ public class DereferenceTestCase {
     private String name;
     private String input;
     private String expected;
-    
+    private boolean strict = true; // Default to strict mode for backward compatibility
+
     /**
      * Constructor.
      */
@@ -71,6 +72,20 @@ public class DereferenceTestCase {
      */
     public void setExpected(String expected) {
         this.expected = expected;
+    }
+
+    /**
+     * @return the strict flag
+     */
+    public boolean isStrict() {
+        return strict;
+    }
+
+    /**
+     * @param strict the strict flag to set
+     */
+    public void setStrict(boolean strict) {
+        this.strict = strict;
     }
 
 }

--- a/src/test/java/io/apicurio/datamodels/refs/DereferenceTestRunner.java
+++ b/src/test/java/io/apicurio/datamodels/refs/DereferenceTestRunner.java
@@ -127,7 +127,7 @@ public class DereferenceTestRunner extends ParentRunner<DereferenceTestCase> {
 
                 // Dereference the document
                 try {
-                    Document dereferencedDoc = Library.dereferenceDocument(srcDoc, true);
+                    Document dereferencedDoc = Library.dereferenceDocument(srcDoc, child.isStrict());
                     Assert.assertNotNull(dereferencedDoc);
                     Assert.assertNotSame(srcDoc, dereferencedDoc);
 

--- a/src/test/java/io/apicurio/datamodels/validation/ValidationTestRunner.java
+++ b/src/test/java/io/apicurio/datamodels/validation/ValidationTestRunner.java
@@ -44,6 +44,7 @@ import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.util.JsonUtil;
 import io.apicurio.datamodels.refs.IReferenceResolver;
 import io.apicurio.datamodels.refs.ReferenceUtil;
+import io.apicurio.datamodels.refs.ResolvedReference;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -221,7 +222,7 @@ public class ValidationTestRunner extends ParentRunner<ValidationTestCase> imple
      * @see io.apicurio.datamodels.core.util.IReferenceResolver#resolveRef(java.lang.String, io.apicurio.datamodels.core.models.Node)
      */
     @Override
-    public Node resolveRef(String reference, Node from) {
+    public ResolvedReference resolveRef(String reference, Node from) {
         try {
             if (reference != null && reference.startsWith("test:")) {
                 int colonIdx = reference.indexOf(":");
@@ -239,7 +240,8 @@ public class ValidationTestRunner extends ParentRunner<ValidationTestCase> imple
                 Assert.assertNotNull("Failed to resolve fragment: " + fragment, resolvedContent);
                 Node emptyClone = from.emptyClone();
                 emptyClone.attach(from.parent());
-                return Library.readNode(resolvedContent, emptyClone);
+                Node node = Library.readNode(resolvedContent, emptyClone);
+                return ResolvedReference.fromNode(node);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/test/resources/fixtures/dereference/aai3/avro-schema-ref.expected.json
+++ b/src/test/resources/fixtures/dereference/aai3/avro-schema-ref.expected.json
@@ -24,7 +24,7 @@
     },
     "schemas": {
       "UserEvent": {
-        "schemaFormat": "application/vnd.apache.avro+json;version=1.12.0",
+        "schemaFormat": "application/vnd.apache.avro+json",
         "schema": {
           "type": "record",
           "name": "UserEvent",

--- a/src/test/resources/fixtures/dereference/oai3/protobuf-schema-ref-unsupported.expected.json
+++ b/src/test/resources/fixtures/dereference/oai3/protobuf-schema-ref-unsupported.expected.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/protobuf": {
+              "schema": {
+                "$ref": "http://www.example.com/schemas/user-event.proto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/dereference/oai3/protobuf-schema-ref-unsupported.input.json
+++ b/src/test/resources/fixtures/dereference/oai3/protobuf-schema-ref-unsupported.input.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/protobuf": {
+              "schema": {
+                "$ref": "http://www.example.com/schemas/user-event.proto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/dereference/tests.json
+++ b/src/test/resources/fixtures/dereference/tests.json
@@ -123,5 +123,11 @@
         "name" : "[AsyncAPI 3] Server Reference",
         "input" : "aai3/server-ref.input.json",
         "expected" : "aai3/server-ref.expected.json"
+    },
+    {
+        "name" : "[OpenAPI 3] Protobuf Schema Reference (Unsupported)",
+        "input" : "oai3/protobuf-schema-ref-unsupported.input.json",
+        "expected" : "oai3/protobuf-schema-ref-unsupported.expected.json",
+        "strict" : false
     }
 ]


### PR DESCRIPTION
## Summary

This PR introduces a new `ResolvedReference` architecture to properly handle multi-format schema references in AsyncAPI 3.0, replacing the previous "x-text-content" workaround.

Resolving external references that are not parseable by the data-models library is only necessary because AsyncAPI 3 introduced MultiFormatSchema, which allows users to reference external schemas that are not JSON Schema formatted.  This includes Avro, Protobuf, etc.  These schemas are not readable by the library, and in some cases are not even JSON (e.g. Protobuf).  As a result, we need the reference resolver to return something other than a Node when resolving references.

## Problem

Previously, resolvers had to wrap non-JSON content (like Protocol Buffers .proto files) in a Node with an `x-text-content` extension property. This was a hack that:
- Mixed content types inappropriately
- Lost media type information
- Required dereferencer to detect and unwrap the content
- Made the API unclear for resolver implementers

## Solution

Introduced `ResolvedReference` class that:
- Cleanly separates three content types: NODE, JSON, and TEXT
- Preserves media type metadata for proper schema wrapping
- Provides clear factory methods: `fromNode()`, `fromJson()`, `fromText()`
- Enables proper Multi-Format Schema Object creation in AsyncAPI 3.0

## Key Changes

### Core Architecture
- **New `ResolvedReference` class**: Handles three content types with media type metadata
- **Updated `IReferenceResolver` interface**: Returns `ResolvedReference` instead of `Node`
- **Enhanced `AsyncApi3NodeImporter`**: Wraps non-JSON schemas in Multi-Format Schema Objects
- **Error handling in `Dereferencer`**: Catches `UnsupportedOperationException` for unsupported formats

### Format Support
- Avro JSON schema detection and proper media type handling
- Protocol Buffers text format support
- JSON Schema as distinct from OpenAPI/AsyncAPI schemas

### Testing
- Extended test framework with `strict` field for non-strict dereferencing
- Added Avro schema detection to test resolvers (Java and TypeScript)
- Added negative test: OpenAPI 3.0 attempting to reference Protobuf (demonstrates graceful failure)
- All tests pass: 471 Java tests, 316 TypeScript tests

### Backward Compatibility
- Deprecated `ReferenceUtil.resolveRefWithOptions()` 
- Test framework defaults `strict=true` for existing tests
- No breaking changes to public APIs except `IReferenceResolver`

## Test Results

```
Java: Tests run: 471, Failures: 0, Errors: 0
TypeScript: Tests: 316 passed, 316 total
```

## Files Changed

- Core: `ResolvedReference.java` (new), `IReferenceResolver.java`, `Dereferencer.java`, `AsyncApi3NodeImporter.java`
- Utils: `LocalReferenceResolver.java`, `ReferenceResolverChain.java`, `ReferenceUtil.java`
- Tests: Test resolvers, test case model, new negative test files