### PR TITLE
Upgrade to apicurio-unified-model-generator 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <version.org.codehaus.mojo.exec-maven-plugin>3.6.3</version.org.codehaus.mojo.exec-maven-plugin>
         <version.com.github.eirslett.frontend-maven-plugin>1.15.4</version.com.github.eirslett.frontend-maven-plugin>
         <version.org.sonatype.central-publishing-maven-plugin>0.10.0</version.org.sonatype.central-publishing-maven-plugin>
-        <version.apicurio-unified-model-generator-plugin>1.2.14</version.apicurio-unified-model-generator-plugin>
+        <version.apicurio-unified-model-generator-plugin>1.3.0</version.apicurio-unified-model-generator-plugin>
         <version.jsweet-maven-plugin>3.1.1.RedHat</version.jsweet-maven-plugin>
     </properties>
 

--- a/src/main/java/io/apicurio/datamodels/deref/AsyncApi3NodeImporter.java
+++ b/src/main/java/io/apicurio/datamodels/deref/AsyncApi3NodeImporter.java
@@ -166,11 +166,8 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
         } else {
             AsyncApi30Components components = ensureAsyncApi30Components();
             String name = generateNodeName(getNameHintFromRef("ImportedSchema"), getComponentNames(components.getSchemas()));
-            // AsyncAPI 3.0 schemas are a union type, so we manually add to the map
-            if (components.getSchemas() == null) {
-                components.setSchemas(new java.util.LinkedHashMap<>());
-            }
-            components.getSchemas().put(name, node);
+            // AsyncAPI 3.0 schemas are a union type, use addSchema() method
+            components.addSchema(name, node);
             node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
@@ -305,25 +302,20 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
 
             String name = generateNodeName(nameHint, getComponentNames(components.getSchemas()));
 
-            // AsyncAPI 3.0 schemas are a union type, so we manually add to the map
-            if (components.getSchemas() == null) {
-                components.setSchemas(new java.util.LinkedHashMap<>());
-            }
-
             // Check if this is a non-JSON schema that needs wrapping
             if (isAvroSchema(node)) {
                 AsyncApi30MultiFormatSchema multiFormatSchema = wrapInMultiFormatSchema(node, "avro");
-                components.getSchemas().put(name, multiFormatSchema);
+                components.addSchema(name, multiFormatSchema);
                 multiFormatSchema.attach(components);
                 setPathToImportedNode(multiFormatSchema, componentType, name);
             } else if (isProtobufSchema(node)) {
                 AsyncApi30MultiFormatSchema multiFormatSchema = wrapInMultiFormatSchema(node, "protobuf");
-                components.getSchemas().put(name, multiFormatSchema);
+                components.addSchema(name, multiFormatSchema);
                 multiFormatSchema.attach(components);
                 setPathToImportedNode(multiFormatSchema, componentType, name);
             } else {
                 // Cast to MultiFormatSchemaSchemaUnion (AsyncApi30Schema implements this)
-                components.getSchemas().put(name, (MultiFormatSchemaSchemaUnion) node);
+                components.addSchema(name, (MultiFormatSchemaSchemaUnion) node);
                 node.attach(components);
                 setPathToImportedNode(node, componentType, name);
             }
@@ -424,10 +416,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
         AsyncApi30MultiFormatSchema multiFormatSchema = wrapJsonInMultiFormatSchema(jsonNode, mediaType);
 
         // Add to components
-        if (components.getSchemas() == null) {
-            components.setSchemas(new java.util.LinkedHashMap<>());
-        }
-        components.getSchemas().put(name, multiFormatSchema);
+        components.addSchema(name, multiFormatSchema);
         multiFormatSchema.attach(components);
         setPathToImportedNode(multiFormatSchema, componentType, name);
     }
@@ -454,10 +443,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
         AsyncApi30MultiFormatSchema multiFormatSchema = wrapTextInMultiFormatSchema(textContent, mediaType);
 
         // Add to components
-        if (components.getSchemas() == null) {
-            components.setSchemas(new java.util.LinkedHashMap<>());
-        }
-        components.getSchemas().put(name, multiFormatSchema);
+        components.addSchema(name, multiFormatSchema);
         multiFormatSchema.attach(components);
         setPathToImportedNode(multiFormatSchema, componentType, name);
     }


### PR DESCRIPTION
## Summary

This PR upgrades the apicurio-unified-model-generator plugin from version 1.2.14 to 1.3.0 and updates code to work with the new collection manipulation API for union maps and lists.

## Code Generator Changes

Version 1.3.0 of the code generator ([PR #196](https://github.com/Apicurio/apicurio-unified-model-generator/pull/196)) introduces a consistent API for union collections:

**New Methods Generated:**
- `addSchema(String name, MultiFormatSchemaStandardSchemaUnion value)` - add item to union map
- `removeSchema(String name)` - remove item from union map
- `clearSchemas()` - clear all items
- `getSchemas()` - get the map (getter remains)

**Removed Methods:**
- `setSchemas(Map)` - setter removed, use add/remove/clear instead

This aligns union maps/lists with the same manipulation patterns as entity maps/lists, providing a more consistent and intuitive API.

## Changes in This PR

### pom.xml
- Upgraded `version.apicurio-unified-model-generator-plugin` from `1.2.14` to `1.3.0`

### AsyncApi3NodeImporter.java
Updated four locations to use the new `addSchema()` method:

**Before:**
```java
if (components.getSchemas() == null) {
    components.setSchemas(new java.util.LinkedHashMap<>());
}
components.getSchemas().put(name, value);
```

**After:**
```java
components.addSchema(name, value);
```

**Locations Updated:**
1. `importNode()` - Line 170: Adding imported schema nodes
2. `visitSchema()` - Lines 308, 313, 318: Adding standard/Avro/Protobuf schemas
3. `importJson()` - Line 419: Adding JSON schemas wrapped in MultiFormatSchema
4. `importText()` - Line 446: Adding text schemas wrapped in MultiFormatSchema

## Benefits

1. **Simpler Code**: No need for null checks or manual map initialization
2. **Consistent API**: Union collections now match entity collection patterns
3. **Type Safety**: Methods are strongly typed for the specific collection
4. **Cleaner Diffs**: 14 fewer lines of code

## Testing

- Build compiles successfully: `mvn clean compile`
- Ready for full test suite execution

## Files Changed

- `pom.xml` - Version upgrade
- `src/main/java/io/apicurio/datamodels/deref/AsyncApi3NodeImporter.java` - API updates

**Stats:** 2 files changed, 8 insertions(+), 22 deletions(-)