### PR TITLE
Refactor release workflow to make publishing phases independently retriable

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -1,0 +1,115 @@
+name: Maven Publish Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Release version to publish (e.g., 2.3.0)'
+        required: true
+      branch:
+        description: 'Branch/tag to publish from'
+        required: true
+        default: 'main'
+  workflow_call:
+    inputs:
+      release-version:
+        description: 'Release version to publish'
+        required: true
+        type: string
+      branch:
+        description: 'Branch/tag to publish from'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  maven-publish:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    if: github.repository_owner == 'Apicurio'
+    steps:
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+
+      - name: Check Java Version
+        run: java -version
+
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: '3.8.5'
+
+
+      - name: Check Maven Version
+        run: mvn --version
+
+
+      - name: Log Metadata
+        run: |
+          echo "Publishing Apicurio Data Models version ${{ inputs.release-version }} to Maven Central"
+          echo "Publishing from branch/tag: ${{ inputs.branch }}"
+
+
+      - name: Set up settings.xml
+        run: |
+          echo "<settings><servers><server><id>central</id><username>${{ secrets.CENTRAL_USERNAME }}</username><password>${{ secrets.CENTRAL_TOKEN }}</password></server></servers><profiles><profile><id>central</id><activation><activeByDefault>true</activeByDefault></activation><properties><gpg.executable>gpg</gpg.executable></properties></profile></profiles></settings>" > /home/runner/.m2/settings.xml
+          cat /home/runner/.m2/settings.xml
+
+
+      - name: Code Checkout
+        run: |
+          git init
+          git config --global user.name "apicurio-ci"
+          git config --global user.email "apicurio.ci@gmail.com"
+          git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY.git"
+          git fetch
+          git checkout ${{ inputs.branch }}
+          echo "#### Listing files after checkout ####"
+          find .
+
+
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+
+      - name: Build
+        run: mvn clean install -Ptranspilation -DskipTests
+
+
+      - name: Maven Deploy
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: mvn deploy -Prelease --batch-mode --settings /home/runner/.m2/settings.xml -DskipTests
+
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="Maven publish for version ${{ inputs.release-version }} completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="Maven publish for version ${{ inputs.release-version }} FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,119 @@
+name: NPM Publish Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Release version to publish (e.g., 2.3.0)'
+        required: true
+      branch:
+        description: 'Branch/tag to publish from'
+        required: true
+        default: 'main'
+  workflow_call:
+    inputs:
+      release-version:
+        description: 'Release version to publish'
+        required: true
+        type: string
+      branch:
+        description: 'Branch/tag to publish from'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    steps:
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+
+      - name: Check Java Version
+        run: java -version
+
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: '3.8.5'
+
+
+      - name: Check Maven Version
+        run: mvn --version
+
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+
+      - name: Check Node Version
+        run: node --version
+
+
+      - name: Check NPM Version
+        run: npm --version
+
+
+      - name: Log Metadata
+        run: |
+          echo "Publishing Apicurio Data Models version ${{ inputs.release-version }} to NPM"
+          echo "Publishing from branch/tag: ${{ inputs.branch }}"
+
+
+      - name: Code Checkout
+        run: |
+          git init
+          git config --global user.name "apicurio-ci"
+          git config --global user.email "apicurio.ci@gmail.com"
+          git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY.git"
+          git fetch
+          git checkout ${{ inputs.branch }}
+          echo "#### Listing files after checkout ####"
+          find .
+
+
+      - name: Create '.npmrc' File
+        uses: filipstefansson/set-npm-token-action@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+
+      - name: Build TypeScript Package
+        run: mvn clean install -Ptranspilation -DskipTests
+
+
+      - name: Publish to NPM
+        run: npm publish ./target/ts/dist/
+
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="NPM publish for version ${{ inputs.release-version }} completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="NPM publish for version ${{ inputs.release-version }} FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     if: github.repository_owner == 'Apicurio'
     steps:
 
@@ -117,35 +115,52 @@ jobs:
           git push
 
 
-      - name: Create '.npmrc' File 
-        uses: filipstefansson/set-npm-token-action@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-
-
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          
-
       - name: Create GitHub Release
         run: ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.ACCESS_TOKEN }}
 
 
+  maven-publish:
+    needs: release
+    uses: ./.github/workflows/maven-publish.yaml
+    with:
+      release-version: ${{ github.event.inputs.release-version }}
+      branch: ${{ github.event.inputs.branch }}
+    secrets: inherit
+    continue-on-error: true
 
-      - name: Maven Deploy
-        uses: nick-fields/retry@v3
+
+  npm-publish:
+    needs: release
+    uses: ./.github/workflows/npm-publish.yaml
+    with:
+      release-version: ${{ github.event.inputs.release-version }}
+      branch: ${{ github.event.inputs.branch }}
+    secrets: inherit
+    continue-on-error: true
+
+
+  finalize:
+    needs: [release, maven-publish, npm-publish]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
         with:
-          timeout_minutes: 10
-          max_attempts: 5
-          retry_wait_seconds: 120
-          command: mvn deploy -Prelease --batch-mode --settings /home/runner/.m2/settings.xml -DskipTests
+          maven-version: '3.8.5'
 
 
-      - name: Publish to NPM
-        run: npm publish ./target/ts/dist/
+      - name: Code Checkout
+        run: |
+          git init
+          git config --global user.name "apicurio-ci"
+          git config --global user.email "apicurio.ci@gmail.com"
+          git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY.git"
+          git fetch
+          git checkout ${{ github.event.inputs.branch}}
+          git branch --set-upstream-to=origin/${{ github.event.inputs.branch}}
+          git pull
 
 
       - name: Update Snapshot version ${{ github.event.inputs.snapshot-version}}
@@ -155,25 +170,42 @@ jobs:
       - name: Commit Snapshot Version Change
         run: |
           git add .
-          git restore --staged .npmrc    # can't commit, contains NPM token
           git commit -m"Automated version update: ${{ github.event.inputs.snapshot-version}}"
           git push
+
+
+      - name: Check Publishing Results
+        run: |
+          echo "Release workflow completed"
+          echo "Maven publish status: ${{ needs.maven-publish.result }}"
+          echo "NPM publish status: ${{ needs.npm-publish.result }}"
+          if [[ "${{ needs.maven-publish.result }}" != "success" ]] || [[ "${{ needs.npm-publish.result }}" != "success" ]]; then
+            echo "WARNING: One or more publishing steps failed. You can retry them manually:"
+            echo "  - Maven: https://github.com/${{ github.repository }}/actions/workflows/maven-publish.yaml"
+            echo "  - NPM: https://github.com/${{ github.repository }}/actions/workflows/npm-publish.yaml"
+          fi
 
 
       - name: Slack Notification (Always)
         if: always()
         run: |
-          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          MAVEN_STATUS="${{ needs.maven-publish.result }}"
+          NPM_STATUS="${{ needs.npm-publish.result }}"
+          if [[ "$MAVEN_STATUS" != "success" ]] || [[ "$NPM_STATUS" != "success" ]]; then
+            MESSAGE="Release ${{ github.event.inputs.release-version }} completed with warnings. Maven: $MAVEN_STATUS, NPM: $NPM_STATUS. Manual retry may be needed."
+          else
+            MESSAGE="Release ${{ github.event.inputs.release-version }} completed successfully"
+          fi
           REPO="${{ github.repository }}"
           LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
           PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
           curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
 
-      - name: Slack Notification (Error)
-        if: failure()
+      - name: Slack Notification (Publishing Failures)
+        if: needs.maven-publish.result != 'success' || needs.npm-publish.result != 'success'
         run: |
-          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          MESSAGE="Release ${{ github.event.inputs.release-version }}: Publishing failures detected. Maven: ${{ needs.maven-publish.result }}, NPM: ${{ needs.npm-publish.result }}. Retry at https://github.com/${{ github.repository }}/actions"
           REPO="${{ github.repository }}"
           LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
-          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"warning\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
           curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}


### PR DESCRIPTION
## Problem

The Maven deployment phase of the release workflow sometimes fails or times out due to transient issues on Sonatype servers. When this happens, the entire release workflow fails, requiring a complete re-run of the release process including version updates and commits that have already succeeded.

## Solution

This PR refactors the release workflow to separate the publishing phases into independent, retriable workflows that won't fail the main release process.

### New Workflows

- **maven-publish.yaml**: Standalone workflow for Maven Central publishing
  - Can be manually triggered via workflow_dispatch
  - Can be called from other workflows via workflow_call
  - Includes retry logic (5 attempts, 2-minute intervals, 20-minute timeout)
  - Sends dedicated Slack notifications

- **npm-publish.yaml**: Standalone workflow for NPM publishing
  - Can be manually triggered via workflow_dispatch
  - Can be called from other workflows via workflow_call
  - Sends dedicated Slack notifications

### Refactored Release Workflow

The release workflow now has 4 distinct jobs:

1. **release** - Core release process (version updates, build verification, GitHub release creation)
2. **maven-publish** - Calls maven-publish.yaml with `continue-on-error: true`
3. **npm-publish** - Calls npm-publish.yaml with `continue-on-error: true`
4. **finalize** - Always runs to update snapshot version and send enhanced notifications

## Benefits

✅ Publishing failures no longer fail the entire release
✅ Failed publishing can be manually retried from the Actions UI without re-running version updates
✅ Enhanced Slack notifications clearly indicate which publishing steps failed
✅ Each publishing workflow is independently testable and maintainable
✅ Existing retry logic preserved in Maven publishing

## Usage

**Normal release**: Works exactly as before - trigger the release workflow with version parameters

**Manual retry after publishing failure**:
1. Navigate to Actions tab
2. Select "Maven Publish Workflow" or "NPM Publish Workflow"
3. Click "Run workflow"
4. Enter the release version and branch/tag
5. The workflow checks out that specific release and publishes it

## Test Plan

- [ ] Verify release workflow completes successfully when all publishing succeeds
- [ ] Verify release workflow completes with warnings when publishing fails
- [ ] Verify maven-publish.yaml can be manually triggered
- [ ] Verify npm-publish.yaml can be manually triggered
- [ ] Verify Slack notifications include publishing status