### PR TITLE
feat: add AsyncAPI support to 14 editor commands

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -17,6 +17,7 @@ import io.apicurio.datamodels.cmd.commands.AddSchemaDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecuritySchemeCommand;
 import io.apicurio.datamodels.cmd.commands.AddServerCommand;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.cmd.commands.AddTagCommand;
 import io.apicurio.datamodels.cmd.commands.ChangeContactCommand;
 import io.apicurio.datamodels.cmd.commands.ChangeDescriptionCommand;
@@ -308,6 +309,19 @@ public class CommandFactory {
 
     public static ICommand createDeleteServerCommand(OpenApiServersParent parent, String serverUrl) {
         return new DeleteServerCommand(parent, serverUrl);
+    }
+
+    public static ICommand createAddServerCommand(AsyncApiDocument document, String serverName,
+                                                  String serverUrl, String serverDescription) {
+        return new AddServerCommand(document, serverName, serverUrl, serverDescription);
+    }
+
+    public static ICommand createDeleteServerCommand(AsyncApiDocument document, String serverName) {
+        return new DeleteServerCommand(document, serverName);
+    }
+
+    public static ICommand createDeleteAllServersCommand(AsyncApiDocument document) {
+        return new DeleteAllServersCommand(document);
     }
 
     // --- Path commands ---

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaDefinitionCommand.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
-import io.apicurio.datamodels.models.openapi.OpenApiDocument;
+import io.apicurio.datamodels.models.Schema;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Schema;
@@ -14,6 +16,9 @@ import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.util.LoggerUtil;
 import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
+
+import java.util.Map;
 
 /**
  * A command used to add a new definition in a document.  Source for the new
@@ -46,19 +51,17 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         LoggerUtil.info("[AddSchemaDefinitionCommand] Executing.");
         this._helper = createHelper(document);
 
-        OpenApiDocument doc = (OpenApiDocument) document;
-
         // Do nothing if the definition already exists.
-        if (this._helper.defExists(doc)) {
+        if (this._helper.defExists(document)) {
             LoggerUtil.info("[AddSchemaDefinitionCommand] Definition with name %s already exists.", this._newDefinitionName);
             this._defExisted = true;
             return;
         }
 
-        this._nullDefinitionsParent = this._helper.prepareDocumentForDef(doc);
+        this._nullDefinitionsParent = this._helper.prepareDocumentForDef(document);
 
-        OpenApiSchema definition = this._helper.createSchemaDefinition(doc);
-        this._helper.addDefinition(doc, definition);
+        Schema definition = this._helper.createSchemaDefinition(document);
+        this._helper.addDefinition(document, definition);
     }
 
     /**
@@ -71,9 +74,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
             return;
         }
 
-        OpenApiDocument doc = (OpenApiDocument) document;
-
-        this._helper.removeDefinition(doc);
+        this._helper.removeDefinition(document);
     }
 
     private AddSchemaDefinitionCommandHelper createHelper(Document document) {
@@ -86,25 +87,28 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
+        if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            return new AsyncApi2Helper();
+        }
         throw new RuntimeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddSchemaDefinitionCommandHelper {
-        boolean defExists(OpenApiDocument document);
+        boolean defExists(Document document);
 
-        boolean prepareDocumentForDef(OpenApiDocument document);
+        boolean prepareDocumentForDef(Document document);
 
-        OpenApiSchema createSchemaDefinition(OpenApiDocument document);
+        Schema createSchemaDefinition(Document document);
 
-        void addDefinition(OpenApiDocument document, OpenApiSchema definition);
+        void addDefinition(Document document, Schema definition);
 
-        void removeDefinition(OpenApiDocument document);
+        void removeDefinition(Document document);
     }
 
     private class OpenApi20Helper implements AddSchemaDefinitionCommandHelper {
 
         @Override
-        public boolean defExists(OpenApiDocument document) {
+        public boolean defExists(Document document) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             if (isNullOrUndefined(doc20.getDefinitions())) {
                 return false;
@@ -113,7 +117,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public boolean prepareDocumentForDef(OpenApiDocument document) {
+        public boolean prepareDocumentForDef(Document document) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             if (isNullOrUndefined(doc20.getDefinitions())) {
                 doc20.setDefinitions(doc20.createDefinitions());
@@ -123,7 +127,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public OpenApiSchema createSchemaDefinition(OpenApiDocument document) {
+        public Schema createSchemaDefinition(Document document) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             OpenApi20Schema definition = doc20.getDefinitions().createSchema();
             Library.readNode(_newDefinitionObj, definition);
@@ -131,14 +135,14 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public void addDefinition(OpenApiDocument document, OpenApiSchema definition) {
+        public void addDefinition(Document document, Schema definition) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             OpenApi20Schema def20 = (OpenApi20Schema) definition;
             doc20.getDefinitions().addItem(_newDefinitionName, def20);
         }
 
         @Override
-        public void removeDefinition(OpenApiDocument document) {
+        public void removeDefinition(Document document) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             if (_nullDefinitionsParent) {
                 doc20.setDefinitions(null);
@@ -150,7 +154,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
 
     private class OpenApi30Helper implements AddSchemaDefinitionCommandHelper {
         @Override
-        public boolean defExists(OpenApiDocument document) {
+        public boolean defExists(Document document) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             if (isNullOrUndefined(doc30.getComponents())) {
                 return false;
@@ -159,7 +163,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public boolean prepareDocumentForDef(OpenApiDocument document) {
+        public boolean prepareDocumentForDef(Document document) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             if (isNullOrUndefined(doc30.getComponents())) {
                 doc30.setComponents(doc30.createComponents());
@@ -169,7 +173,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public OpenApiSchema createSchemaDefinition(OpenApiDocument document) {
+        public Schema createSchemaDefinition(Document document) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             OpenApi30Schema definition = (OpenApi30Schema) doc30.getComponents().createSchema();
             Library.readNode(_newDefinitionObj, definition);
@@ -177,13 +181,13 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public void addDefinition(OpenApiDocument document, OpenApiSchema definition) {
+        public void addDefinition(Document document, Schema definition) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
-            doc30.getComponents().addSchema(_newDefinitionName, definition);
+            doc30.getComponents().addSchema(_newDefinitionName, (OpenApiSchema) definition);
         }
 
         @Override
-        public void removeDefinition(OpenApiDocument document) {
+        public void removeDefinition(Document document) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             if (_nullDefinitionsParent) {
                 doc30.setComponents(null);
@@ -195,7 +199,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
 
     private class OpenApi31Helper implements AddSchemaDefinitionCommandHelper {
         @Override
-        public boolean defExists(OpenApiDocument document) {
+        public boolean defExists(Document document) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
             if (isNullOrUndefined(doc31.getComponents())) {
                 return false;
@@ -204,7 +208,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public boolean prepareDocumentForDef(OpenApiDocument document) {
+        public boolean prepareDocumentForDef(Document document) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
             if (isNullOrUndefined(doc31.getComponents())) {
                 doc31.setComponents(doc31.createComponents());
@@ -214,7 +218,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public OpenApiSchema createSchemaDefinition(OpenApiDocument document) {
+        public Schema createSchemaDefinition(Document document) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
             OpenApi31Schema definition = (OpenApi31Schema) doc31.getComponents().createSchema();
             Library.readNode(_newDefinitionObj, definition);
@@ -222,18 +226,68 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         }
 
         @Override
-        public void addDefinition(OpenApiDocument document, OpenApiSchema definition) {
+        public void addDefinition(Document document, Schema definition) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
-            doc31.getComponents().addSchema(_newDefinitionName, definition);
+            doc31.getComponents().addSchema(_newDefinitionName, (OpenApiSchema) definition);
         }
 
         @Override
-        public void removeDefinition(OpenApiDocument document) {
+        public void removeDefinition(Document document) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
             if (_nullDefinitionsParent) {
                 doc31.setComponents(null);
             } else {
                 doc31.getComponents().removeSchema(_newDefinitionName);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private class AsyncApi2Helper implements AddSchemaDefinitionCommandHelper {
+        @Override
+        public boolean defExists(Document document) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            if (isNullOrUndefined(components)) {
+                return false;
+            }
+            Map<String, ?> schemas = (Map<String, ?>) NodeUtil.getNodeProperty(components, "schemas");
+            return !isNullOrUndefined(schemas) && schemas.containsKey(_newDefinitionName);
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(Document document) {
+            AsyncApiDocument doc = (AsyncApiDocument) document;
+            if (isNullOrUndefined(doc.getComponents())) {
+                doc.setComponents(doc.createComponents());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Schema createSchemaDefinition(Document document) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            Schema definition = (Schema) NodeUtil.invokeMethod(components, "createSchema");
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(Document document, Schema definition) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            NodeUtil.invokeMethod(components, "addSchema", _newDefinitionName, definition);
+        }
+
+        @Override
+        public void removeDefinition(Document document) {
+            AsyncApiDocument doc = (AsyncApiDocument) document;
+            if (_nullDefinitionsParent) {
+                doc.setComponents(null);
+            } else {
+                AsyncApiComponents components = doc.getComponents();
+                if (!isNullOrUndefined(components)) {
+                    NodeUtil.invokeMethod(components, "removeSchema", _newDefinitionName);
+                }
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddSecuritySchemeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddSecuritySchemeCommand.java
@@ -5,6 +5,8 @@ import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.SecurityScheme;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityDefinitions;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityScheme;
@@ -52,6 +54,8 @@ public class AddSecuritySchemeCommand extends AbstractCommand {
             executeForOpenApi30((OpenApi30Document) document);
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             executeForOpenApi31((OpenApi31Document) document);
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            executeForAsyncApi((AsyncApiDocument) document);
         }
     }
 
@@ -114,6 +118,26 @@ public class AddSecuritySchemeCommand extends AbstractCommand {
         this._schemeCreated = true;
     }
 
+    private void executeForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiComponents components = doc.getComponents();
+        if (this.isNullOrUndefined(components)) {
+            components = doc.createComponents();
+            doc.setComponents(components);
+            this._nullParent = true;
+        }
+
+        // Check if scheme already exists
+        if (!this.isNullOrUndefined(components.getSecuritySchemes()) &&
+                components.getSecuritySchemes().containsKey(this._schemeName)) {
+            return;
+        }
+
+        SecurityScheme newScheme = components.createSecurityScheme();
+        Library.readNode(this._schemeObj, newScheme);
+        components.addSecurityScheme(this._schemeName, newScheme);
+        this._schemeCreated = true;
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -150,6 +174,16 @@ public class AddSecuritySchemeCommand extends AbstractCommand {
                 doc.setComponents(null);
             } else {
                 OpenApi31Components components = doc.getComponents();
+                if (!this.isNullOrUndefined(components)) {
+                    components.removeSecurityScheme(this._schemeName);
+                }
+            }
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiDocument doc = (AsyncApiDocument) document;
+            if (this._nullParent) {
+                doc.setComponents(null);
+            } else {
+                AsyncApiComponents components = doc.getComponents();
                 if (!this.isNullOrUndefined(components)) {
                     components.removeSecurityScheme(this._schemeName);
                 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddServerCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddServerCommand.java
@@ -1,8 +1,12 @@
 package io.apicurio.datamodels.cmd.commands;
 
+import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServer;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServers;
 import io.apicurio.datamodels.models.openapi.OpenApiServer;
 import io.apicurio.datamodels.models.openapi.OpenApiServersParent;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Server;
@@ -11,6 +15,7 @@ import io.apicurio.datamodels.paths.NodePath;
 import io.apicurio.datamodels.paths.NodePathUtil;
 import io.apicurio.datamodels.util.LoggerUtil;
 import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.datamodels.util.RegexUtil;
 
 import java.util.ArrayList;
@@ -25,14 +30,24 @@ public class AddServerCommand extends AbstractCommand {
     public NodePath _parentPath;
     public String _serverUrl;
     public String _serverDescription;
+    public String _serverName;
 
     public boolean _serverCreated;
+    public boolean _nullServersParent;
 
     public AddServerCommand() {
     }
 
     public AddServerCommand(OpenApiServersParent parent, String serverUrl, String serverDescription) {
         this._parentPath = NodePathUtil.createNodePath((Node) parent);
+        this._serverUrl = serverUrl;
+        this._serverDescription = serverDescription;
+    }
+
+    public AddServerCommand(AsyncApiDocument document, String serverName, String serverUrl,
+                            String serverDescription) {
+        this._parentPath = Library.createNodePath(document);
+        this._serverName = serverName;
         this._serverUrl = serverUrl;
         this._serverDescription = serverDescription;
     }
@@ -44,7 +59,16 @@ public class AddServerCommand extends AbstractCommand {
     public void execute(Document document) {
         LoggerUtil.info("[AddServerCommand] Executing.");
         this._serverCreated = false;
+        this._nullServersParent = false;
 
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            executeForAsyncApi((AsyncApiDocument) document);
+        } else {
+            executeForOpenApi(document);
+        }
+    }
+
+    private void executeForOpenApi(Document document) {
         OpenApiServersParent parent = (OpenApiServersParent) NodePathUtil.resolveNodePath(this._parentPath, document);
         if (this.isNullOrUndefined(parent)) {
             return;
@@ -83,6 +107,36 @@ public class AddServerCommand extends AbstractCommand {
         this._serverCreated = true;
     }
 
+    private void executeForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiServers servers = doc.getServers();
+        if (this.isNullOrUndefined(servers)) {
+            servers = doc.createServers();
+            doc.setServers(servers);
+            this._nullServersParent = true;
+        }
+
+        // Check if server with this name already exists
+        if (!this.isNullOrUndefined(servers.getItem(this._serverName))) {
+            return;
+        }
+
+        // Create new server
+        AsyncApiServer newServer = servers.createServer();
+        NodeUtil.setProperty(newServer, "url", this._serverUrl);
+        if (!this.isNullOrUndefined(this._serverDescription) && !this._serverDescription.isEmpty()) {
+            newServer.setDescription(this._serverDescription);
+        }
+
+        // Extract and create server variables
+        List<String> variableNames = extractVariables(this._serverUrl);
+        for (String variableName : variableNames) {
+            newServer.addVariable(variableName, newServer.createServerVariable());
+        }
+
+        servers.addItem(this._serverName, newServer);
+        this._serverCreated = true;
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -93,6 +147,14 @@ public class AddServerCommand extends AbstractCommand {
             return;
         }
 
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            undoForAsyncApi((AsyncApiDocument) document);
+        } else {
+            undoForOpenApi(document);
+        }
+    }
+
+    private void undoForOpenApi(Document document) {
         OpenApiServersParent parent = (OpenApiServersParent) NodePathUtil.resolveNodePath(this._parentPath, document);
         if (this.isNullOrUndefined(parent)) {
             return;
@@ -107,6 +169,17 @@ public class AddServerCommand extends AbstractCommand {
             if (this._serverUrl.equals(server.getUrl())) {
                 parent.removeServer(server);
                 return;
+            }
+        }
+    }
+
+    private void undoForAsyncApi(AsyncApiDocument doc) {
+        if (this._nullServersParent) {
+            doc.setServers(null);
+        } else {
+            AsyncApiServers servers = doc.getServers();
+            if (!this.isNullOrUndefined(servers)) {
+                servers.removeItem(this._serverName);
             }
         }
     }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddTagCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddTagCommand.java
@@ -2,9 +2,12 @@ package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Tag;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiTag;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 import java.util.List;
 
@@ -35,8 +38,14 @@ public class AddTagCommand extends AbstractCommand {
         LoggerUtil.info("[AddTagCommand] Executing.");
         this._tagCreated = false;
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            executeForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2(document);
+        }
+    }
 
+    private void executeForOpenApi(OpenApiDocument doc) {
         // Check if tag already exists
         List<OpenApiTag> existingTags = (List<OpenApiTag>) doc.getTags();
         if (!this.isNullOrUndefined(existingTags)) {
@@ -58,6 +67,29 @@ public class AddTagCommand extends AbstractCommand {
         this._tagCreated = true;
     }
 
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(Document document) {
+        // Check if tag already exists
+        List<? extends Tag> existingTags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (!this.isNullOrUndefined(existingTags)) {
+            for (Tag tag : existingTags) {
+                if (this._tagName.equals(tag.getName())) {
+                    return;
+                }
+            }
+        }
+
+        // Create new tag
+        Tag newTag = (Tag) NodeUtil.invokeMethod(document, "createTag");
+        newTag.setName(this._tagName);
+        if (!this.isNullOrUndefined(this._tagDescription) && !this._tagDescription.isEmpty()) {
+            newTag.setDescription(this._tagDescription);
+        }
+
+        NodeUtil.invokeMethod(document, "addTag", newTag);
+        this._tagCreated = true;
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -68,7 +100,14 @@ public class AddTagCommand extends AbstractCommand {
             return;
         }
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            undoForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            undoForAsyncApi2(document);
+        }
+    }
+
+    private void undoForOpenApi(OpenApiDocument doc) {
         List<OpenApiTag> tags = (List<OpenApiTag>) doc.getTags();
         if (this.isNullOrUndefined(tags)) {
             return;
@@ -77,6 +116,21 @@ public class AddTagCommand extends AbstractCommand {
         for (OpenApiTag tag : tags) {
             if (this._tagName.equals(tag.getName())) {
                 doc.removeTag(tag);
+                return;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void undoForAsyncApi2(Document document) {
+        List<? extends Tag> tags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (this.isNullOrUndefined(tags)) {
+            return;
+        }
+
+        for (Tag tag : tags) {
+            if (this._tagName.equals(tag.getName())) {
+                NodeUtil.invokeMethod(document, "removeTag", tag);
                 return;
             }
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/CreateSchemaCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/CreateSchemaCommand.java
@@ -2,6 +2,10 @@ package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Schema;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiSchema;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Definitions;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
@@ -15,6 +19,7 @@ import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.models.union.StringUnionValueImpl;
 import io.apicurio.datamodels.util.LoggerUtil;
 import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 import java.util.Map;
 
@@ -52,6 +57,8 @@ public class CreateSchemaCommand extends AbstractCommand {
             executeForOpenApi30((OpenApi30Document) document);
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             executeForOpenApi31((OpenApi31Document) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2((AsyncApiDocument) document);
         }
     }
 
@@ -114,6 +121,27 @@ public class CreateSchemaCommand extends AbstractCommand {
         components.addSchema(this._schemaName, newSchema);
     }
 
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(AsyncApiDocument doc) {
+        AsyncApiComponents components = doc.getComponents();
+        if (this.isNullOrUndefined(components)) {
+            components = doc.createComponents();
+            doc.setComponents(components);
+            this._nullParent = true;
+        }
+
+        // Check if schema already exists
+        Map<String, ? extends Schema> schemas = (Map<String, ? extends Schema>) NodeUtil.getNodeProperty(components, "schemas");
+        if (!this.isNullOrUndefined(schemas) && schemas.containsKey(this._schemaName)) {
+            this._schemaExisted = true;
+            return;
+        }
+
+        AsyncApiSchema newSchema = (AsyncApiSchema) NodeUtil.invokeMethod(components, "createSchema");
+        newSchema.setType("object");
+        NodeUtil.invokeMethod(components, "addSchema", this._schemaName, newSchema);
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -152,6 +180,16 @@ public class CreateSchemaCommand extends AbstractCommand {
                 OpenApi31Components components = doc.getComponents();
                 if (!this.isNullOrUndefined(components)) {
                     components.removeSchema(this._schemaName);
+                }
+            }
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            AsyncApiDocument doc = (AsyncApiDocument) document;
+            if (this._nullParent) {
+                doc.setComponents(null);
+            } else {
+                AsyncApiComponents components = doc.getComponents();
+                if (!this.isNullOrUndefined(components)) {
+                    NodeUtil.invokeMethod(components, "removeSchema", this._schemaName);
                 }
             }
         }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllServersCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllServersCommand.java
@@ -6,24 +6,29 @@ import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.Server;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServer;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServers;
 import io.apicurio.datamodels.models.openapi.OpenApiServer;
 import io.apicurio.datamodels.models.openapi.OpenApiServersParent;
 import io.apicurio.datamodels.paths.NodePath;
 import io.apicurio.datamodels.paths.NodePathUtil;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * A command used to delete all servers from a document.
- * 
+ *
  * @author eric.wittmann@gmail.com
  */
 public class DeleteAllServersCommand extends AbstractCommand {
 
     public NodePath _parentPath;
     public List<ObjectNode> _oldServers;
+    public List<String> _oldServerNames;
 
     public DeleteAllServersCommand() {
     }
@@ -31,7 +36,11 @@ public class DeleteAllServersCommand extends AbstractCommand {
     public DeleteAllServersCommand(OpenApiServersParent parent) {
         this._parentPath = Library.createNodePath((Node) parent);
     }
-    
+
+    public DeleteAllServersCommand(AsyncApiDocument document) {
+        this._parentPath = Library.createNodePath(document);
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
      */
@@ -40,6 +49,14 @@ public class DeleteAllServersCommand extends AbstractCommand {
         LoggerUtil.info("[DeleteAllServersCommand] Executing.");
         this._oldServers = new ArrayList<>();
 
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            executeForAsyncApi((AsyncApiDocument) document);
+        } else {
+            executeForOpenApi(document);
+        }
+    }
+
+    private void executeForOpenApi(Document document) {
         OpenApiServersParent parent = (OpenApiServersParent) NodePathUtil.resolveNodePath(this._parentPath, document);
         if (this.isNullOrUndefined(parent)) {
             return;
@@ -55,6 +72,26 @@ public class DeleteAllServersCommand extends AbstractCommand {
         parent.clearServers();
     }
 
+    private void executeForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiServers servers = doc.getServers();
+        if (this.isNullOrUndefined(servers)) {
+            return;
+        }
+
+        this._oldServerNames = new ArrayList<>();
+
+        // Save old servers with their names
+        List<String> names = servers.getItemNames();
+        if (!this.isNullOrUndefined(names)) {
+            for (String name : names) {
+                AsyncApiServer server = servers.getItem(name);
+                this._oldServerNames.add(name);
+                this._oldServers.add(Library.writeNode(server));
+            }
+        }
+        servers.clearItems();
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -65,6 +102,14 @@ public class DeleteAllServersCommand extends AbstractCommand {
             return;
         }
 
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            undoForAsyncApi((AsyncApiDocument) document);
+        } else {
+            undoForOpenApi(document);
+        }
+    }
+
+    private void undoForOpenApi(Document document) {
         OpenApiServersParent parent = (OpenApiServersParent) NodePathUtil.resolveNodePath(this._parentPath, document);
         if (this.isNullOrUndefined(parent)) {
             return;
@@ -74,6 +119,20 @@ public class DeleteAllServersCommand extends AbstractCommand {
             OpenApiServer server = parent.createServer();
             Library.readNode(oldServer, server);
             parent.addServer(server);
+        }
+    }
+
+    private void undoForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiServers servers = doc.getServers();
+        if (this.isNullOrUndefined(servers)) {
+            servers = doc.createServers();
+            doc.setServers(servers);
+        }
+
+        for (int i = 0; i < this._oldServers.size(); i++) {
+            AsyncApiServer server = servers.createServer();
+            Library.readNode(this._oldServers.get(i), server);
+            servers.addItem(this._oldServerNames.get(i), server);
         }
     }
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllTagsCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteAllTagsCommand.java
@@ -8,6 +8,8 @@ import io.apicurio.datamodels.models.Tag;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiTag;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,10 +21,10 @@ import java.util.List;
 public class DeleteAllTagsCommand extends AbstractCommand {
 
     public List<ObjectNode> _oldTags;
-    
+
     public DeleteAllTagsCommand() {
     }
-    
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
      */
@@ -30,9 +32,16 @@ public class DeleteAllTagsCommand extends AbstractCommand {
     public void execute(Document document) {
         LoggerUtil.info("[DeleteAllTagsCommand] Executing.");
 
-        OpenApiDocument doc = (OpenApiDocument) document;
-
         this._oldTags = new ArrayList<>();
+
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            executeForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2(document);
+        }
+    }
+
+    private void executeForOpenApi(OpenApiDocument doc) {
         // Save the old tags (if any)
         List<? extends Tag> tags = doc.getTags();
         if (!this.isNullOrUndefined(tags)) {
@@ -41,6 +50,18 @@ public class DeleteAllTagsCommand extends AbstractCommand {
             });
         }
         doc.clearTags();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(Document document) {
+        // Save the old tags (if any)
+        List<? extends Tag> tags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (!this.isNullOrUndefined(tags)) {
+            tags.forEach( tag -> {
+                this._oldTags.add(Library.writeNode(tag));
+            });
+        }
+        NodeUtil.invokeMethod(document, "clearTags");
     }
 
     /**
@@ -53,12 +74,26 @@ public class DeleteAllTagsCommand extends AbstractCommand {
             return;
         }
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            undoForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            undoForAsyncApi2(document);
+        }
+    }
 
+    private void undoForOpenApi(OpenApiDocument doc) {
         this._oldTags.forEach( oldTag -> {
             OpenApiTag tag = doc.createTag();
             Library.readNode(oldTag, tag);
             doc.addTag(tag);
+        });
+    }
+
+    private void undoForAsyncApi2(Document document) {
+        this._oldTags.forEach( oldTag -> {
+            Tag tag = (Tag) NodeUtil.invokeMethod(document, "createTag");
+            Library.readNode(oldTag, tag);
+            NodeUtil.invokeMethod(document, "addTag", tag);
         });
     }
 

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSchemaCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSchemaCommand.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Schema;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Definitions;
@@ -14,7 +17,9 @@ import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
 import io.apicurio.datamodels.util.LoggerUtil;
 import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +57,8 @@ public class DeleteSchemaCommand extends AbstractCommand {
             executeForOpenApi30((OpenApi30Document) document);
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             executeForOpenApi31((OpenApi31Document) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2((AsyncApiDocument) document);
         }
     }
 
@@ -106,6 +113,24 @@ public class DeleteSchemaCommand extends AbstractCommand {
         components.removeSchema(this._schemaName);
     }
 
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(AsyncApiDocument doc) {
+        AsyncApiComponents components = doc.getComponents();
+        if (this.isNullOrUndefined(components)) {
+            return;
+        }
+
+        Map<String, ? extends Schema> schemas = (Map<String, ? extends Schema>) NodeUtil.getNodeProperty(components, "schemas");
+        if (this.isNullOrUndefined(schemas) || !schemas.containsKey(this._schemaName)) {
+            return;
+        }
+
+        Schema schema = schemas.get(this._schemaName);
+        this._schemaIndex = new ArrayList<>(schemas.keySet()).indexOf(this._schemaName);
+        this._oldSchema = Library.writeNode(schema);
+        NodeUtil.invokeMethod(components, "removeSchema", this._schemaName);
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -122,6 +147,8 @@ public class DeleteSchemaCommand extends AbstractCommand {
             undoForOpenApi30((OpenApi30Document) document);
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             undoForOpenApi31((OpenApi31Document) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            undoForAsyncApi2((AsyncApiDocument) document);
         }
     }
 
@@ -159,6 +186,18 @@ public class DeleteSchemaCommand extends AbstractCommand {
         OpenApiSchema newSchema = components.createSchema();
         Library.readNode(this._oldSchema, newSchema);
         components.insertSchema(this._schemaName, newSchema, this._schemaIndex);
+    }
+
+    private void undoForAsyncApi2(AsyncApiDocument doc) {
+        AsyncApiComponents components = doc.getComponents();
+        if (this.isNullOrUndefined(components)) {
+            components = doc.createComponents();
+            doc.setComponents(components);
+        }
+
+        Schema newSchema = (Schema) NodeUtil.invokeMethod(components, "createSchema");
+        Library.readNode(this._oldSchema, newSchema);
+        NodeUtil.invokeMethod(components, "insertSchema", this._schemaName, newSchema, this._schemaIndex);
     }
 
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSecuritySchemeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteSecuritySchemeCommand.java
@@ -6,6 +6,8 @@ import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.SecurityScheme;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityDefinitions;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityScheme;
@@ -80,6 +82,18 @@ public class DeleteSecuritySchemeCommand extends AbstractCommand {
                 this._oldIndex = schemeNames.indexOf(this._schemeName);
                 components.removeSecurityScheme(this._schemeName);
             }
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getSecuritySchemes())) {
+                return;
+            }
+            SecurityScheme scheme = components.getSecuritySchemes().get(this._schemeName);
+            if (!this.isNullOrUndefined(scheme)) {
+                this._oldScheme = Library.writeNode((Node) scheme);
+                List<String> schemeNames = new ArrayList<>(components.getSecuritySchemes().keySet());
+                this._oldIndex = schemeNames.indexOf(this._schemeName);
+                components.removeSecurityScheme(this._schemeName);
+            }
         }
     }
 
@@ -116,6 +130,15 @@ public class DeleteSecuritySchemeCommand extends AbstractCommand {
             if (this.isNullOrUndefined(components)) {
                 components = ((OpenApi31Document) document).createComponents();
                 ((OpenApi31Document) document).setComponents(components);
+            }
+            SecurityScheme scheme = components.createSecurityScheme();
+            Library.readNode(this._oldScheme, scheme);
+            components.insertSecurityScheme(this._schemeName, scheme, this._oldIndex);
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((AsyncApiDocument) document).createComponents();
+                ((AsyncApiDocument) document).setComponents(components);
             }
             SecurityScheme scheme = components.createSecurityScheme();
             Library.readNode(this._oldScheme, scheme);

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteServerCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteServerCommand.java
@@ -5,11 +5,15 @@ import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServer;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiServers;
 import io.apicurio.datamodels.models.openapi.OpenApiServer;
 import io.apicurio.datamodels.models.openapi.OpenApiServersParent;
 import io.apicurio.datamodels.paths.NodePath;
 import io.apicurio.datamodels.paths.NodePathUtil;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 
 import java.util.List;
 
@@ -21,6 +25,7 @@ public class DeleteServerCommand extends AbstractCommand {
 
     public NodePath _parentPath;
     public String _serverUrl;
+    public String _serverName;
 
     public ObjectNode _oldServer;
     public int _serverIndex;
@@ -33,6 +38,11 @@ public class DeleteServerCommand extends AbstractCommand {
         this._serverUrl = serverUrl;
     }
 
+    public DeleteServerCommand(AsyncApiDocument document, String serverName) {
+        this._parentPath = Library.createNodePath(document);
+        this._serverName = serverName;
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
      */
@@ -42,6 +52,14 @@ public class DeleteServerCommand extends AbstractCommand {
         this._oldServer = null;
         this._serverIndex = -1;
 
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            executeForAsyncApi((AsyncApiDocument) document);
+        } else {
+            executeForOpenApi(document);
+        }
+    }
+
+    private void executeForOpenApi(Document document) {
         OpenApiServersParent parent = (OpenApiServersParent) NodePathUtil.resolveNodePath(this._parentPath, document);
         if (this.isNullOrUndefined(parent)) {
             return;
@@ -64,13 +82,41 @@ public class DeleteServerCommand extends AbstractCommand {
         }
     }
 
+    private void executeForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiServers servers = doc.getServers();
+        if (this.isNullOrUndefined(servers)) {
+            return;
+        }
+
+        AsyncApiServer server = servers.getItem(this._serverName);
+        if (this.isNullOrUndefined(server)) {
+            return;
+        }
+
+        this._oldServer = Library.writeNode(server);
+        this._serverIndex = servers.getItemNames().indexOf(this._serverName);
+        servers.removeItem(this._serverName);
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
     @Override
     public void undo(Document document) {
         LoggerUtil.info("[DeleteServerCommand] Reverting.");
-        if (this._serverIndex < 0 || this.isNullOrUndefined(this._oldServer)) {
+        if (this.isNullOrUndefined(this._oldServer)) {
+            return;
+        }
+
+        if (ModelTypeUtil.isAsyncApiModel(document)) {
+            undoForAsyncApi((AsyncApiDocument) document);
+        } else {
+            undoForOpenApi(document);
+        }
+    }
+
+    private void undoForOpenApi(Document document) {
+        if (this._serverIndex < 0) {
             return;
         }
 
@@ -82,6 +128,18 @@ public class DeleteServerCommand extends AbstractCommand {
         OpenApiServer newServer = parent.createServer();
         Library.readNode(this._oldServer, newServer);
         parent.insertServer(newServer, this._serverIndex);
+    }
+
+    private void undoForAsyncApi(AsyncApiDocument doc) {
+        AsyncApiServers servers = doc.getServers();
+        if (this.isNullOrUndefined(servers)) {
+            servers = doc.createServers();
+            doc.setServers(servers);
+        }
+
+        AsyncApiServer newServer = servers.createServer();
+        Library.readNode(this._oldServer, newServer);
+        servers.insertItem(this._serverName, newServer, this._serverIndex);
     }
 
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTagCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteTagCommand.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Tag;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiTag;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 import java.util.List;
 
@@ -37,7 +40,14 @@ public class DeleteTagCommand extends AbstractCommand {
         this._oldTag = null;
         this._tagIndex = -1;
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            executeForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2(document);
+        }
+    }
+
+    private void executeForOpenApi(OpenApiDocument doc) {
         List<OpenApiTag> tags = (List<OpenApiTag>) doc.getTags();
         if (this.isNullOrUndefined(tags)) {
             return;
@@ -55,6 +65,25 @@ public class DeleteTagCommand extends AbstractCommand {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(Document document) {
+        List<? extends Tag> tags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (this.isNullOrUndefined(tags)) {
+            return;
+        }
+
+        int idx = 0;
+        for (Tag tag : tags) {
+            if (this._tagName.equals(tag.getName())) {
+                this._oldTag = Library.writeNode(tag);
+                this._tagIndex = idx;
+                NodeUtil.invokeMethod(document, "removeTag", tag);
+                return;
+            }
+            idx++;
+        }
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -65,10 +94,23 @@ public class DeleteTagCommand extends AbstractCommand {
             return;
         }
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            undoForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            undoForAsyncApi2(document);
+        }
+    }
+
+    private void undoForOpenApi(OpenApiDocument doc) {
         OpenApiTag newTag = doc.createTag();
         Library.readNode(this._oldTag, newTag);
         doc.insertTag(newTag, this._tagIndex);
+    }
+
+    private void undoForAsyncApi2(Document document) {
+        Tag newTag = (Tag) NodeUtil.invokeMethod(document, "createTag");
+        Library.readNode(this._oldTag, newTag);
+        NodeUtil.invokeMethod(document, "insertTag", newTag, this._tagIndex);
     }
 
 }

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/RenameTagCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/RenameTagCommand.java
@@ -2,9 +2,12 @@ package io.apicurio.datamodels.cmd.commands;
 
 import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Tag;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
 import io.apicurio.datamodels.models.openapi.OpenApiTag;
 import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 import java.util.List;
 
@@ -35,7 +38,14 @@ public class RenameTagCommand extends AbstractCommand {
         LoggerUtil.info("[RenameTagCommand] Executing.");
         this._tagRenamed = false;
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            executeForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            executeForAsyncApi2(document);
+        }
+    }
+
+    private void executeForOpenApi(OpenApiDocument doc) {
         List<OpenApiTag> tags = (List<OpenApiTag>) doc.getTags();
         if (this.isNullOrUndefined(tags)) {
             return;
@@ -58,6 +68,30 @@ public class RenameTagCommand extends AbstractCommand {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private void executeForAsyncApi2(Document document) {
+        List<? extends Tag> tags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (this.isNullOrUndefined(tags)) {
+            return;
+        }
+
+        // Check if new name already exists
+        for (Tag tag : tags) {
+            if (this._newName.equals(tag.getName())) {
+                return;
+            }
+        }
+
+        // Find and rename the tag
+        for (Tag tag : tags) {
+            if (this._oldName.equals(tag.getName())) {
+                tag.setName(this._newName);
+                this._tagRenamed = true;
+                return;
+            }
+        }
+    }
+
     /**
      * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
      */
@@ -68,13 +102,35 @@ public class RenameTagCommand extends AbstractCommand {
             return;
         }
 
-        OpenApiDocument doc = (OpenApiDocument) document;
+        if (ModelTypeUtil.isOpenApiModel(document)) {
+            undoForOpenApi((OpenApiDocument) document);
+        } else if (ModelTypeUtil.isAsyncApi2Model(document)) {
+            undoForAsyncApi2(document);
+        }
+    }
+
+    private void undoForOpenApi(OpenApiDocument doc) {
         List<OpenApiTag> tags = (List<OpenApiTag>) doc.getTags();
         if (this.isNullOrUndefined(tags)) {
             return;
         }
 
         for (OpenApiTag tag : tags) {
+            if (this._newName.equals(tag.getName())) {
+                tag.setName(this._oldName);
+                return;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void undoForAsyncApi2(Document document) {
+        List<? extends Tag> tags = (List<? extends Tag>) NodeUtil.getNodeProperty(document, "tags");
+        if (this.isNullOrUndefined(tags)) {
+            return;
+        }
+
+        for (Tag tag : tags) {
             if (this._newName.equals(tag.getName())) {
                 tag.setName(this._oldName);
                 return;

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceSchemaDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/ReplaceSchemaDefinitionCommand.java
@@ -9,44 +9,51 @@ import io.apicurio.datamodels.models.openapi.OpenApiSchema;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Definitions;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Schema;
 import io.apicurio.datamodels.util.ModelTypeUtil;
+import io.apicurio.datamodels.util.NodeUtil;
 
 /**
  * A command used to replace a definition schema with a newer version.
  * @author eric.wittmann@gmail.com
  */
-public class ReplaceSchemaDefinitionCommand extends AbstractReplaceNodeCommand<OpenApiSchema> {
+public class ReplaceSchemaDefinitionCommand extends AbstractReplaceNodeCommand<Schema> {
 
     public ReplaceSchemaDefinitionCommand() {
     }
 
-    public ReplaceSchemaDefinitionCommand(OpenApiSchema old, OpenApiSchema replacement) {
+    public ReplaceSchemaDefinitionCommand(Schema old, Schema replacement) {
         super(old, replacement);
     }
 
     @Override
-    protected void replaceNode(Node parent, OpenApiSchema newNode) {
+    protected void replaceNode(Node parent, Schema newNode) {
         String definitionName = this._nodePath.getLastSegment().getValue();
         if (ModelTypeUtil.isOpenApi2Model(parent)) {
             OpenApi20Definitions definitions = (OpenApi20Definitions) parent;
             definitions.addItem(definitionName, (OpenApi20Schema) newNode);
+        } else if (ModelTypeUtil.isAsyncApi2Model(parent)) {
+            NodeUtil.invokeMethod(parent, "addSchema", definitionName, newNode);
         } else {
             OpenApiComponents components = (OpenApiComponents) parent;
-            components.addSchema(definitionName, newNode);
+            components.addSchema(definitionName, (OpenApiSchema) newNode);
         }
     }
 
     @Override
-    protected OpenApiSchema readNode(Node parent, ObjectNode node) {
+    protected Schema readNode(Node parent, ObjectNode node) {
         if (ModelTypeUtil.isOpenApi2Model(parent)) {
             OpenApi20Definitions definitions = (OpenApi20Definitions) parent;
             OpenApi20Schema definition = definitions.createSchema();
             Library.readNode(node, definition);
             return definition;
+        } else if (ModelTypeUtil.isAsyncApi2Model(parent)) {
+            Schema schema = (Schema) NodeUtil.invokeMethod(parent, "createSchema");
+            Library.readNode(node, schema);
+            return schema;
         } else {
             OpenApiComponents components = (OpenApiComponents) parent;
             Schema schema = components.createSchema();
             Library.readNode(node, schema);
-            return (OpenApiSchema) schema;
+            return schema;
         }
     }
 

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/UpdateSecuritySchemeCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/UpdateSecuritySchemeCommand.java
@@ -6,6 +6,8 @@ import io.apicurio.datamodels.cmd.AbstractCommand;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.SecurityScheme;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiComponents;
+import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityDefinitions;
 import io.apicurio.datamodels.models.openapi.v20.OpenApi20SecurityScheme;
@@ -90,6 +92,12 @@ public class UpdateSecuritySchemeCommand extends AbstractCommand {
                 return null;
             }
             return components.getSecuritySchemes().get(this._schemeName);
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getSecuritySchemes())) {
+                return null;
+            }
+            return components.getSecuritySchemes().get(this._schemeName);
         }
         return null;
     }
@@ -107,6 +115,11 @@ public class UpdateSecuritySchemeCommand extends AbstractCommand {
             }
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (!this.isNullOrUndefined(components)) {
+                components.removeSecurityScheme(this._schemeName);
+            }
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
             if (!this.isNullOrUndefined(components)) {
                 components.removeSecurityScheme(this._schemeName);
             }
@@ -129,6 +142,11 @@ public class UpdateSecuritySchemeCommand extends AbstractCommand {
             SecurityScheme newScheme = components.createSecurityScheme();
             Library.readNode(this._newSchemeObj, newScheme);
             components.addSecurityScheme(this._schemeName, newScheme);
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
+            SecurityScheme newScheme = components.createSecurityScheme();
+            Library.readNode(this._newSchemeObj, newScheme);
+            components.addSecurityScheme(this._schemeName, newScheme);
         }
     }
 
@@ -145,6 +163,11 @@ public class UpdateSecuritySchemeCommand extends AbstractCommand {
             components.addSecurityScheme(this._schemeName, oldScheme);
         } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            SecurityScheme oldScheme = components.createSecurityScheme();
+            Library.readNode(this._oldSchemeObj, oldScheme);
+            components.addSecurityScheme(this._schemeName, oldScheme);
+        } else if (ModelTypeUtil.isAsyncApiModel(document)) {
+            AsyncApiComponents components = ((AsyncApiDocument) document).getComponents();
             SecurityScheme oldScheme = components.createSecurityScheme();
             Library.readNode(this._oldSchemeObj, oldScheme);
             components.addSecurityScheme(this._schemeName, oldScheme);

--- a/src/main/java/io/apicurio/datamodels/util/NodeUtil.java
+++ b/src/main/java/io/apicurio/datamodels/util/NodeUtil.java
@@ -55,6 +55,30 @@ public class NodeUtil {
     }
 
     /**
+     * Invokes a method on the given target by name, matching on parameter count.
+     * Useful for calling methods on generated interfaces where the parameter types
+     * vary by version but the method signature is otherwise identical.
+     * @param target the object to invoke the method on
+     * @param methodName the name of the method
+     * @param args the arguments to pass
+     * @return the return value of the method (or null for void methods)
+     */
+    public static Object invokeMethod(Object target, String methodName, Object... args) {
+        try {
+            Method method = Arrays.stream(target.getClass().getMethods())
+                    .filter(m -> m.getName().equals(methodName) && m.getParameterCount() == args.length)
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException("Could not find method " + methodName
+                            + " with " + args.length + " parameter(s) on " + target.getClass().getSimpleName()));
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e.getCause());
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Returns the value for a given node property.
      * @param node
      * @param propertyName

--- a/src/main/ts/src/io/apicurio/datamodels/util/NodeUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/NodeUtil.ts
@@ -122,4 +122,19 @@ export class NodeUtil {
         return NodeUtil.join(delim, values);
     }
 
+    /**
+     * Invokes a method on the target object by name, passing the given arguments.
+     * @param target the object on which to invoke the method
+     * @param methodName the name of the method to invoke
+     * @param args the arguments to pass to the method
+     * @returns the return value of the method
+     */
+    public static invokeMethod(target: any, methodName: string, ...args: any[]): any {
+        const method = target[methodName];
+        if (typeof method === "function") {
+            return method.apply(target, args);
+        }
+        throw new Error(`Method '${methodName}' not found on ${target.constructor?.name || target}`);
+    }
+
 }

--- a/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.after.json
@@ -1,0 +1,20 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "ExistingSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "EmptySchema": {}
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.before.json
@@ -1,0 +1,19 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "ExistingSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-definition/asyncapi-2/add-definition.commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "__type": "AddSchemaDefinitionCommand",
+        "_newDefinitionName": "EmptySchema",
+        "_newDefinitionObj": {}
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.after.json
@@ -1,0 +1,19 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.before.json
@@ -1,0 +1,15 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-security-scheme/asyncapi-2/add-security-scheme.commands.json
@@ -1,0 +1,10 @@
+[
+    {
+        "__type": "AddSecuritySchemeCommand",
+        "_schemeName": "ApiKeyAuth",
+        "_schemeObj": {
+            "type": "apiKey",
+            "in": "header"
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.after.json
@@ -1,0 +1,21 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "my_server": {
+      "url": "kafka.prod.example.com",
+      "description": "my event railgun",
+      "protocol": "kafka"
+    },
+    "new_server": {
+      "url": "kafka2.prod.example.com",
+      "description": "New server"
+    }
+  },
+  "channels": {
+    "myevents": {}
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "my_server": {
+      "url": "kafka.prod.example.com",
+      "description": "my event railgun",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "myevents": {}
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server/asyncapi-2/add-server.commands.json
@@ -1,0 +1,9 @@
+[
+    {
+        "__type": "AddServerCommand",
+        "_parentPath": "/",
+        "_serverName": "new_server",
+        "_serverUrl": "kafka2.prod.example.com",
+        "_serverDescription": "New server"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.after.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "existing",
+      "description": "An existing tag."
+    },
+    {
+      "name": "newTag",
+      "description": "A new tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.before.json
@@ -1,0 +1,13 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "existing",
+      "description": "An existing tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-tag/asyncapi-2/add-tag.commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "__type": "AddTagCommand",
+        "_tagName": "newTag",
+        "_tagDescription": "A new tag."
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.after.json
+++ b/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.after.json
@@ -1,0 +1,22 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "ExistingSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "NewSchema": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.before.json
+++ b/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.before.json
@@ -1,0 +1,19 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "ExistingSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/create-schema/asyncapi-2/create-schema.commands.json
@@ -1,0 +1,6 @@
+[
+    {
+        "__type": "CreateSchemaCommand",
+        "_schemaName": "NewSchema"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-servers/asyncapi-2/delete-all-servers.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-servers/asyncapi-2/delete-all-servers.after.json
@@ -4,6 +4,7 @@
     "title": "example",
     "version": "1.0.0"
   },
+  "servers": {},
   "channels": {
     "myevents": {}
   }

--- a/src/test/resources/fixtures/cmd/commands/delete-all-servers/asyncapi-2/delete-all-servers.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-servers/asyncapi-2/delete-all-servers.commands.json
@@ -1,3 +1,3 @@
 [{
-    "__type": "DeleteAllServersCommand_Aai20"
+    "__type": "DeleteAllServersCommand"
 }]

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.after.json
@@ -1,0 +1,7 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "tag1",
+      "description": "First tag."
+    },
+    {
+      "name": "tag2",
+      "description": "Second tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-all-tags/asyncapi-2/delete-all-tags.commands.json
@@ -1,0 +1,5 @@
+[
+    {
+        "__type": "DeleteAllTagsCommand"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-schema-definition/asyncapi-2/delete-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-schema-definition/asyncapi-2/delete-schema-definition.commands.json
@@ -1,4 +1,4 @@
 [{
-    "__type": "DeleteSchemaDefinitionCommand_Aai20",
-    "_definitionName": "TestSchema"
+    "__type": "DeleteSchemaCommand",
+    "_schemaName": "TestSchema"
 }]

--- a/src/test/resources/fixtures/cmd/commands/delete-security-scheme/asyncapi-2/delete-security-scheme.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-security-scheme/asyncapi-2/delete-security-scheme.commands.json
@@ -1,4 +1,4 @@
 [{
-    "__type": "DeleteSecuritySchemeCommand_Aai20",
+    "__type": "DeleteSecuritySchemeCommand",
     "_schemeName": "myScheme"
 }]

--- a/src/test/resources/fixtures/cmd/commands/delete-server/asyncapi-2/delete-server.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-server/asyncapi-2/delete-server.commands.json
@@ -1,4 +1,4 @@
 [{
-    "__type": "DeleteServerCommand_Aai20",
+    "__type": "DeleteServerCommand",
     "_serverName": "my_other_server"
 }]

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.after.json
@@ -1,0 +1,13 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "tag2",
+      "description": "Second tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "tag1",
+      "description": "First tag."
+    },
+    {
+      "name": "tag2",
+      "description": "Second tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-tag/asyncapi-2/delete-tag.commands.json
@@ -1,0 +1,6 @@
+[
+    {
+        "__type": "DeleteTagCommand",
+        "_tagName": "tag1"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.after.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "newName",
+      "description": "A tag to rename."
+    },
+    {
+      "name": "other",
+      "description": "Another tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.before.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "oldName",
+      "description": "A tag to rename."
+    },
+    {
+      "name": "other",
+      "description": "Another tag."
+    }
+  ]
+}

--- a/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/rename-tag-definition/asyncapi-2/rename-tag-definition.commands.json
@@ -1,0 +1,5 @@
+[{
+    "__type": "RenameTagCommand",
+    "_oldName": "oldName",
+    "_newName": "newName"
+}]

--- a/src/test/resources/fixtures/cmd/commands/replace-schema-definition/asyncapi-2/replace-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-schema-definition/asyncapi-2/replace-schema-definition.commands.json
@@ -1,5 +1,5 @@
 [{
-    "__type": "ReplaceSchemaDefinitionCommand_Aai20",
+    "__type": "ReplaceSchemaDefinitionCommand",
     "_nodePath": "/components/schemas[MySchema2]",
     "_new": {
         "type": "object",

--- a/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.after.json
+++ b/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.after.json
@@ -1,0 +1,17 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "description": "Updated basic auth.",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.before.json
+++ b/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.before.json
@@ -1,0 +1,15 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Asyncapi test",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/update-security-scheme/asyncapi-2/update-security-scheme.commands.json
@@ -1,0 +1,10 @@
+[{
+    "__type": "UpdateSecuritySchemeCommand",
+    "_schemeName": "BasicAuth",
+    "_newSchemeObj": {
+        "type": "http",
+        "description": "Updated basic auth.",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+    }
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -124,5 +124,20 @@
     { "name": "[OpenAPI 3] {Delete Security Requirement} - Delete Security Req Doc2", "test": "commands/delete-security-requirement/openapi-3/delete-security-requirement-doc2" },
     { "name": "[OpenAPI 3] {Delete Security Requirement} - Delete Security Req Op", "test": "commands/delete-security-requirement/openapi-3/delete-security-requirement-op" },
     { "name": "[OpenAPI 3] {Update Node} - Update Node", "test": "commands/update-node/openapi-3/update-node" },
-    { "name": "[OpenAPI 3] {Ensure Child Node} - Ensure Child Node", "test": "commands/ensure-child-node/openapi-3/ensure-child-node" }
+    { "name": "[OpenAPI 3] {Ensure Child Node} - Ensure Child Node", "test": "commands/ensure-child-node/openapi-3/ensure-child-node" },
+
+    { "name": "[AsyncAPI 2] {Add Security Scheme} - Add Security Scheme", "test": "commands/add-security-scheme/asyncapi-2/add-security-scheme" },
+    { "name": "[AsyncAPI 2] {Delete Security Scheme} - Delete Security Scheme", "test": "commands/delete-security-scheme/asyncapi-2/delete-security-scheme" },
+    { "name": "[AsyncAPI 2] {Update Security Scheme} - Update Security Scheme", "test": "commands/update-security-scheme/asyncapi-2/update-security-scheme" },
+    { "name": "[AsyncAPI 2] {Add Tag} - Add Tag", "test": "commands/add-tag/asyncapi-2/add-tag" },
+    { "name": "[AsyncAPI 2] {Delete Tag} - Delete Tag", "test": "commands/delete-tag/asyncapi-2/delete-tag" },
+    { "name": "[AsyncAPI 2] {Delete All Tags} - Delete All Tags", "test": "commands/delete-all-tags/asyncapi-2/delete-all-tags" },
+    { "name": "[AsyncAPI 2] {Rename Tag} - Rename Tag", "test": "commands/rename-tag-definition/asyncapi-2/rename-tag-definition" },
+    { "name": "[AsyncAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/asyncapi-2/add-definition" },
+    { "name": "[AsyncAPI 2] {Delete Schema Definition} - Delete Schema Definition", "test": "commands/delete-schema-definition/asyncapi-2/delete-schema-definition" },
+    { "name": "[AsyncAPI 2] {Create Schema} - Create Schema", "test": "commands/create-schema/asyncapi-2/create-schema" },
+    { "name": "[AsyncAPI 2] {Replace Schema Definition} - Replace Schema Definition", "test": "commands/replace-schema-definition/asyncapi-2/replace-schema-definition" },
+    { "name": "[AsyncAPI 2] {Add Server} - Add Server", "test": "commands/add-server/asyncapi-2/add-server" },
+    { "name": "[AsyncAPI 2] {Delete Server} - Delete Server", "test": "commands/delete-server/asyncapi-2/delete-server" },
+    { "name": "[AsyncAPI 2] {Delete All Servers} - Delete All Servers", "test": "commands/delete-all-servers/asyncapi-2/delete-all-servers" }
 ]


### PR DESCRIPTION
## Summary

- Adds AsyncAPI 2.x support to 14 editor commands that were previously hardcoded for OpenAPI only
- Adds `NodeUtil.invokeMethod()` utility (Java reflection + TypeScript dynamic dispatch) to handle
  AsyncAPI's version-specific interface types generically
- Includes 14 new AsyncAPI 2.x command test fixtures with full undo coverage
- Updates 7 existing unregistered AsyncAPI test fixtures to use correct command class names

### Commands updated

**Security Schemes** (follows existing `DeleteAllSecuritySchemesCommand` pattern):
- `AddSecuritySchemeCommand` - add/undo AsyncAPI branches
- `DeleteSecuritySchemeCommand` - add/undo AsyncAPI branches
- `UpdateSecuritySchemeCommand` - add/undo AsyncAPI branches

**Tags** (document-level, AsyncAPI 2.0-2.6):
- `AddTagCommand` - add/undo AsyncAPI 2.x branches
- `DeleteTagCommand` - add/undo AsyncAPI 2.x branches
- `DeleteAllTagsCommand` - add/undo AsyncAPI 2.x branches
- `RenameTagCommand` - add/undo AsyncAPI 2.x branches

**Schema Definitions** (AsyncAPI 2.x):
- `AddSchemaDefinitionCommand` - refactored helper to support AsyncAPI 2.x
- `DeleteSchemaCommand` - add/undo AsyncAPI 2.x branches
- `CreateSchemaCommand` - add/undo AsyncAPI 2.x branches
- `ReplaceSchemaDefinitionCommand` - generalized from `OpenApiSchema` to `Schema`

**Servers** (handles AsyncAPI's map-based `MappedNode<AsyncApiServer>` vs OpenAPI's list-based model):
- `AddServerCommand` - add/undo AsyncAPI branches + new factory methods
- `DeleteServerCommand` - add/undo AsyncAPI branches
- `DeleteAllServersCommand` - add/undo AsyncAPI branches

## Test plan

- [x] All 525 Java tests pass (139 command tests including 14 new AsyncAPI tests)
- [x] All 489 TypeScript tests pass (all 7 test suites green)
- [x] Full build succeeds (`./build.sh`)
- [x] Each new test validates both execute and undo (document restored to original state)