### PR TITLE
Implement OAuth2 scope name validation rule (SCPS-001) (#29)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/name/OasInvalidPropertyNameRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/name/OasInvalidPropertyNameRule.java
@@ -33,7 +33,11 @@ import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 public abstract class OasInvalidPropertyNameRule extends ValidationRule {
 
     private static final String DEFINITION_NAME_MATCH_REGEX = "^[a-zA-Z0-9\\.\\-_]+$";
-    
+    // RFC 6749 Section 3.3: scope-token = 1*NQCHAR where NQCHAR = %x21 / %x23-5B / %x5D-7E
+    // This allows all printable ASCII characters except space (%x20), double-quote (%x22),
+    // and backslash (%x5C).
+    private static final String SCOPE_NAME_MATCH_REGEX = "^[\\x21\\x23-\\x5B\\x5D-\\x7E]+$";
+
     /**
      * Constructor.
      * @param ruleInfo
@@ -47,17 +51,17 @@ public abstract class OasInvalidPropertyNameRule extends ValidationRule {
      * @param name
      */
     protected boolean isValidDefinitionName(String name) {
-        // TODO should this be different for OAS 2.0 vs. 3.x??  Only 3.x dictates the format to some extent (I think).
         return RegexUtil.matches(name, DEFINITION_NAME_MATCH_REGEX);
     }
 
     /**
-     * Returns true if the scope name is valid.
+     * Returns true if the scope name is valid per RFC 6749 Section 3.3.
+     * Scope tokens must consist of printable ASCII characters excluding
+     * space, double-quote, and backslash.
      * @param scope
      */
     protected boolean isValidScopeName(String scope) {
-        // TODO implement some reasonable rules for this
-        return true;
+        return RegexUtil.matches(scope, SCOPE_NAME_MATCH_REGEX);
     }
 
     /**

--- a/src/test/resources/fixtures/validation/openapi/2.0/invalid-scope-name.json
+++ b/src/test/resources/fixtures/validation/openapi/2.0/invalid-scope-name.json
@@ -1,0 +1,31 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Invalid Scope Name Test",
+        "version": "1.0.0"
+    },
+    "paths": {},
+    "securityDefinitions": {
+        "valid_oauth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://example.com/oauth/authorize",
+            "flow": "implicit",
+            "scopes": {
+                "read:pets": "Read pets",
+                "write:pets": "Write pets",
+                "https://example.com/scope": "URI-style scope"
+            }
+        },
+        "invalid_oauth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://example.com/oauth/authorize",
+            "flow": "implicit",
+            "scopes": {
+                "valid-scope": "This scope name is valid",
+                "scope with spaces": "Scope name with spaces is invalid per RFC 6749",
+                "scope\"quoted": "Scope name with double-quote is invalid per RFC 6749",
+                "scope\\slashed": "Scope name with backslash is invalid per RFC 6749"
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/validation/openapi/2.0/invalid-scope-name.json.expected
+++ b/src/test/resources/fixtures/validation/openapi/2.0/invalid-scope-name.json.expected
@@ -1,0 +1,3 @@
+[SCPS-001] |medium| {/securityDefinitions[invalid_oauth]/scopes->scopes} :: 'scope with spaces' is not a valid scope name.
+[SCPS-001] |medium| {/securityDefinitions[invalid_oauth]/scopes->scopes} :: 'scope"quoted' is not a valid scope name.
+[SCPS-001] |medium| {/securityDefinitions[invalid_oauth]/scopes->scopes} :: 'scope\slashed' is not a valid scope name.

--- a/src/test/resources/fixtures/validation/tests.json
+++ b/src/test/resources/fixtures/validation/tests.json
@@ -88,6 +88,7 @@
 	{ "name": "[OpenAPI 2.0] Info [Invalid Property Value]", "test": "openapi/2.0/info-invalid-property-format.json" },
 	{ "name": "[OpenAPI 2.0] Info [Required Properties]", "test": "openapi/2.0/info-required-properties.json" },
 	{ "name": "[OpenAPI 2.0] Invalid Property Name", "test": "openapi/2.0/invalid-property-name.json" },
+	{ "name": "[OpenAPI 2.0] Invalid Scope Name", "test": "openapi/2.0/invalid-scope-name.json" },
 	{ "name": "[OpenAPI 2.0] Invalid Reference [All]", "test": "openapi/2.0/invalid-reference.json" },
 	{ "name": "[OpenAPI 2.0] Mutually Exclusive [All]", "test": "openapi/2.0/mutually-exclusive.json" },
 	{ "name": "[OpenAPI 2.0] Operation ID", "test": "openapi/2.0/operation-id.json", "severity": "high" },


### PR DESCRIPTION
## Summary
- Implement `isValidScopeName()` in `OasInvalidPropertyNameRule` with a regex derived from RFC 6749
  Section 3.3: scope tokens must consist of printable ASCII characters excluding space, double-quote,
  and backslash
- Remove stale TODO comments from `isValidDefinitionName()` (already implemented) and
  `isValidScopeName()`
- Add OAS 2.0 validation test fixture for invalid scope names (SCPS-001)

## Related Issue
Fixes #29

## Test Plan
- [x] New test `[OpenAPI 2.0] Invalid Scope Name` validates that scope names containing spaces,
  double-quotes, and backslashes are flagged as invalid
- [x] Valid scope names (e.g. `read:pets`, `write:pets`, URI-style scopes) pass validation
- [x] Full build passes (`./build.sh`) including all 125 Java validation tests and 491 TypeScript tests