### PR TITLE
Allow discriminator on base schemas and fix 3.1 ClassCastException (#34)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedUsageOfDiscriminatorRule.java
+++ b/src/main/java/io/apicurio/datamodels/validation/rules/invalid/value/OasUnexpectedUsageOfDiscriminatorRule.java
@@ -16,11 +16,25 @@
 
 package io.apicurio.datamodels.validation.rules.invalid.value;
 
+import java.util.List;
+
+import io.apicurio.datamodels.TraverserDirection;
+import io.apicurio.datamodels.VisitorUtil;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.Referenceable;
+import io.apicurio.datamodels.models.Schema;
 import io.apicurio.datamodels.models.openapi.OpenApiDiscriminator;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.datamodels.models.visitors.CombinedVisitorAdapter;
+import io.apicurio.datamodels.refs.ReferenceUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.datamodels.validation.ValidationRuleMetaData;
 
 /**
+ * Validates that a discriminator is only used in a schema that utilizes oneOf, anyOf, or allOf
+ * composition, or is referenced as a base schema by other schemas via allOf, oneOf, or anyOf.
+ *
  * @author eric.wittmann@gmail.com
  */
 public class OasUnexpectedUsageOfDiscriminatorRule extends AbstractInvalidPropertyValueRule {
@@ -38,9 +52,110 @@ public class OasUnexpectedUsageOfDiscriminatorRule extends AbstractInvalidProper
      */
     @Override
     public void visitDiscriminator(OpenApiDiscriminator node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node.parent();
-        boolean valid = hasValue(schema.getOneOf()) || hasValue(schema.getAnyOf()) || hasValue(schema.getAllOf());
+        Schema schema = (Schema) node.parent();
+        boolean valid = schemaHasComposition(schema) || isReferencedAsBaseSchema(schema);
         this.reportIfInvalid(valid, node, "discriminator", map());
+    }
+
+    /**
+     * Checks whether the given schema directly uses oneOf, anyOf, or allOf composition keywords.
+     * @param schema the schema to check
+     * @return true if the schema has at least one composition keyword
+     */
+    private boolean schemaHasComposition(Schema schema) {
+        if (hasValue(schema.getAllOf())) {
+            return true;
+        }
+        if (ModelTypeUtil.isOpenApi30Model(schema)) {
+            OpenApi30Schema schema30 = (OpenApi30Schema) schema;
+            return hasValue(schema30.getOneOf()) || hasValue(schema30.getAnyOf());
+        } else if (ModelTypeUtil.isOpenApi31Model(schema)) {
+            OpenApi31Schema schema31 = (OpenApi31Schema) schema;
+            return hasValue(schema31.getOneOf()) || hasValue(schema31.getAnyOf());
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the given schema is referenced by any other schema's allOf, oneOf, or anyOf,
+     * which would make it a valid "base schema" for a discriminator. This traverses the entire
+     * document tree using the Visitor pattern.
+     * @param schema the schema to check
+     * @return true if the schema is referenced as a base schema
+     */
+    private boolean isReferencedAsBaseSchema(Schema schema) {
+        BaseSchemaReferenceVisitor visitor = new BaseSchemaReferenceVisitor(schema);
+        VisitorUtil.visitTree((Node) schema.root(), visitor, TraverserDirection.down);
+        return visitor.isReferenced();
+    }
+
+    /**
+     * A visitor that traverses the document looking for schemas whose allOf, oneOf, or anyOf
+     * entries contain a $ref that resolves to the target schema.
+     */
+    private static class BaseSchemaReferenceVisitor extends CombinedVisitorAdapter {
+
+        private final Schema targetSchema;
+        private boolean referenced = false;
+
+        public BaseSchemaReferenceVisitor(Schema targetSchema) {
+            this.targetSchema = targetSchema;
+        }
+
+        public boolean isReferenced() {
+            return referenced;
+        }
+
+        @Override
+        public void visitSchema(Schema node) {
+            if (referenced) {
+                return;
+            }
+            // Check allOf (available on base Schema interface)
+            referenced = checkCompositionListForRef(node.getAllOf(), node);
+            if (referenced) {
+                return;
+            }
+            // Check oneOf and anyOf (version-specific)
+            if (ModelTypeUtil.isOpenApi30Model(node)) {
+                OpenApi30Schema schema30 = (OpenApi30Schema) node;
+                referenced = checkCompositionListForRef(schema30.getOneOf(), node);
+                if (!referenced) {
+                    referenced = checkCompositionListForRef(schema30.getAnyOf(), node);
+                }
+            } else if (ModelTypeUtil.isOpenApi31Model(node)) {
+                OpenApi31Schema schema31 = (OpenApi31Schema) node;
+                referenced = checkCompositionListForRef(schema31.getOneOf(), node);
+                if (!referenced) {
+                    referenced = checkCompositionListForRef(schema31.getAnyOf(), node);
+                }
+            }
+        }
+
+        /**
+         * Checks whether any schema in the given composition list has a $ref that resolves
+         * to the target schema.
+         * @param schemas the list of schemas to check
+         * @param fromNode the node context for resolving $ref
+         * @return true if any schema in the list references the target schema
+         */
+        private boolean checkCompositionListForRef(List<? extends Schema> schemas, Node fromNode) {
+            if (schemas == null) {
+                return false;
+            }
+            for (Schema childSchema : schemas) {
+                if (childSchema instanceof Referenceable) {
+                    String ref = ((Referenceable) childSchema).get$ref();
+                    if (ref != null) {
+                        Node resolved = ReferenceUtil.resolveRef(ref, fromNode);
+                        if (resolved == targetSchema) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
     }
 
 }

--- a/src/test/resources/fixtures/validation/openapi/3.0/discriminator-base-schema.json
+++ b/src/test/resources/fixtures/validation/openapi/3.0/discriminator-base-schema.json
@@ -1,0 +1,94 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Discriminator Base Schema Test",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "summary": "List all pets",
+                "responses": {
+                    "200": {
+                        "description": "A list of pets.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        { "$ref": "#/components/schemas/Cat" },
+                                        { "$ref": "#/components/schemas/Dog" }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sch-002": {
+            "get": {
+                "summary": "Invalid discriminator usage",
+                "responses": {
+                    "200": {
+                        "description": "A response with an invalid discriminator.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {}
+                                    },
+                                    "discriminator": {
+                                        "propertyName": "name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "required": [ "petType" ],
+                "properties": {
+                    "petType": {
+                        "type": "string"
+                    }
+                },
+                "discriminator": {
+                    "propertyName": "petType"
+                }
+            },
+            "Cat": {
+                "allOf": [
+                    { "$ref": "#/components/schemas/Pet" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "huntingSkill": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            },
+            "Dog": {
+                "allOf": [
+                    { "$ref": "#/components/schemas/Pet" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "breed": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/validation/openapi/3.0/discriminator-base-schema.json.expected
+++ b/src/test/resources/fixtures/validation/openapi/3.0/discriminator-base-schema.json.expected
@@ -1,0 +1,1 @@
+[SCH-002] |medium| {/paths[/sch-002]/get/responses[200]/content[application/json]/schema/discriminator->discriminator} :: Schema Discriminator is only allowed when using one of: ["oneOf", "anyOf", "allOf"]

--- a/src/test/resources/fixtures/validation/openapi/3.1/discriminator-base-schema.json
+++ b/src/test/resources/fixtures/validation/openapi/3.1/discriminator-base-schema.json
@@ -1,0 +1,94 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Discriminator Base Schema Test",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "summary": "List all pets",
+                "responses": {
+                    "200": {
+                        "description": "A list of pets.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        { "$ref": "#/components/schemas/Cat" },
+                                        { "$ref": "#/components/schemas/Dog" }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sch-002": {
+            "get": {
+                "summary": "Invalid discriminator usage",
+                "responses": {
+                    "200": {
+                        "description": "A response with an invalid discriminator.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {}
+                                    },
+                                    "discriminator": {
+                                        "propertyName": "name"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "required": [ "petType" ],
+                "properties": {
+                    "petType": {
+                        "type": "string"
+                    }
+                },
+                "discriminator": {
+                    "propertyName": "petType"
+                }
+            },
+            "Cat": {
+                "allOf": [
+                    { "$ref": "#/components/schemas/Pet" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "huntingSkill": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            },
+            "Dog": {
+                "allOf": [
+                    { "$ref": "#/components/schemas/Pet" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "breed": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/test/resources/fixtures/validation/openapi/3.1/discriminator-base-schema.json.expected
+++ b/src/test/resources/fixtures/validation/openapi/3.1/discriminator-base-schema.json.expected
@@ -1,0 +1,1 @@
+[SCH-002] |medium| {/paths[/sch-002]/get/responses[200]/content[application/json]/schema/discriminator->discriminator} :: Schema Discriminator is only allowed when using one of: ["oneOf", "anyOf", "allOf"]

--- a/src/test/resources/fixtures/validation/tests.json
+++ b/src/test/resources/fixtures/validation/tests.json
@@ -118,10 +118,12 @@
     { "name": "[OpenAPI 3.0] Operation Properties", "test": "openapi/3.0/operation-properties.json", "severity": "high" },
     { "name": "[OpenAPI 3.0] Data Type Reference", "test": "openapi/3.0/data-type-reference.json" },
     { "name": "[OpenAPI 3.0] OAuth Flow With Scopes", "test": "openapi/3.0/oauth-flow-scopes.json" },
+    { "name": "[OpenAPI 3.0] Discriminator Base Schema", "test": "openapi/3.0/discriminator-base-schema.json" },
 
     { "name": "[OpenAPI 3.1] Multi-typed Schema", "test": "openapi/3.1/multiple-schema-types.json" },
     { "name": "[OpenAPI 3.1] Issue 6612", "test": "openapi/3.1/issue-6612.json" },
     { "name": "[OpenAPI 3.1] Security Requirements", "test": "openapi/3.1/security-requirements.json" },
+    { "name": "[OpenAPI 3.1] Discriminator Base Schema", "test": "openapi/3.1/discriminator-base-schema.json" },
 
     { "name": "[Issues] Issue 804", "test": "openapi/issues/804/formData-params.json" },
     { "name": "[Issues] Issue 88", "test": "openapi/issues/88/response-def-description.json" },


### PR DESCRIPTION
## Summary
- Fix the SCH-002 validation rule (`OasUnexpectedUsageOfDiscriminatorRule`) to allow `discriminator` on
  "base schemas" that are referenced by other schemas via `allOf`, `oneOf`, or `anyOf` (the standard
  polymorphism/inheritance pattern from the OpenAPI spec).
- Fix a `ClassCastException` when validating OpenAPI 3.1 documents — the rule was casting to
  `OpenApi30Schema` but was registered for both 3.0 and 3.1. Now uses `ModelTypeUtil` for
  version-specific access.
- Add a `BaseSchemaReferenceVisitor` that traverses the document tree using the Visitor pattern to
  detect if a schema is used as a base schema in composition.

## Related Issue
Fixes #34

## Test Plan
- [ ] Verify existing `invalid-property-value.json` test still catches discriminator on schemas without
  any composition (inline schema, not referenced)
- [ ] Verify new `discriminator-base-schema.json` test (OpenAPI 3.0) passes: base schema `Pet` with
  discriminator referenced via `allOf` by `Cat`/`Dog` is valid, while inline discriminator without
  composition is still invalid
- [ ] Verify new `discriminator-base-schema.json` test (OpenAPI 3.1) passes with identical behavior
- [ ] Run `./build.sh` — all 127 validation tests pass