### PR TITLE
Add command marshall/unmarshall support via CommandUtil. Fixes #829

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -101,6 +101,15 @@ public class CommandFactory {
         return CommandUtil.unmarshall(from);
     }
 
+    /**
+     * Marshalls a command into a JSON object for storage or transmission.
+     * @param command the command to serialize
+     * @return the JSON representation of the command
+     */
+    public static ObjectNode marshall(ICommand command) {
+        return CommandUtil.marshall(command);
+    }
+
     public static ICommand createAddHeaderExampleCommand(OpenApiHeader header, JsonNode example,
                                                          String exampleName, String exampleSummary, String exampleDescription) {
         return new AddExampleCommand((OpenApiExamplesParent) header, example, exampleName, exampleSummary, exampleDescription);

--- a/src/main/java/io/apicurio/datamodels/util/CommandUtil.java
+++ b/src/main/java/io/apicurio/datamodels/util/CommandUtil.java
@@ -1,25 +1,43 @@
 package io.apicurio.datamodels.util;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.apicurio.datamodels.cmd.ICommand;
 import io.apicurio.datamodels.paths.NodePath;
 
-import java.io.IOException;
-
+/**
+ * Utility class for marshalling (Command → JSON) and unmarshalling (JSON → Command) of
+ * {@link ICommand} instances. Commands are serialized with a {@code __type} field identifying
+ * the command class name, and all public fields are included in the JSON output.
+ *
+ * @author eric.wittmann@gmail.com
+ */
 public class CommandUtil {
 
+    /**
+     * Custom Jackson deserializer for {@link NodePath} fields. Converts a JSON string
+     * representation (e.g. "/paths[/foo]/get") into a NodePath instance.
+     */
     public static class NodePathDeserializer extends JsonDeserializer<NodePath> {
-        /**
-         * @see com.fasterxml.jackson.databind.JsonDeserializer#deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-         */
         @Override
         public NodePath deserialize(JsonParser p, DeserializationContext ctxt)
                 throws IOException, JsonProcessingException {
@@ -32,14 +50,68 @@ public class CommandUtil {
         }
     }
 
+    /**
+     * Custom Jackson serializer for {@link NodePath} fields. Converts a NodePath instance
+     * into its string representation.
+     */
+    public static class NodePathSerializer extends JsonSerializer<NodePath> {
+        @Override
+        public void serialize(NodePath value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            if (value == null) {
+                gen.writeNull();
+            } else {
+                gen.writeString(value.toString());
+            }
+        }
+    }
+
+    /**
+     * Custom Jackson deserializer for {@link ICommand} fields. Reads a JSON object with a
+     * {@code __type} field and deserializes it into the appropriate command class. Used for
+     * nested commands (e.g. in {@code AggregateCommand._commands}).
+     */
+    public static class ICommandDeserializer extends JsonDeserializer<ICommand> {
+        @Override
+        public ICommand deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException, JsonProcessingException {
+            ObjectNode node = p.readValueAsTree();
+            return unmarshall(node);
+        }
+    }
+
+    /**
+     * ObjectMapper used for unmarshalling (JSON → Command). Includes custom deserializers
+     * for NodePath and ICommand types.
+     */
     private static final ObjectMapper mapper = new ObjectMapper();
     static {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(NodePath.class, new NodePathDeserializer());
+        module.addDeserializer(ICommand.class, new ICommandDeserializer());
         mapper.registerModule(module);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
+    /**
+     * ObjectMapper used for marshalling (Command → JSON). Includes a NodePath serializer
+     * but does NOT include an ICommand serializer, to avoid infinite recursion when
+     * serializing commands that contain nested commands. Nested ICommand fields are handled
+     * explicitly in the {@link #marshall(ICommand)} method.
+     */
+    private static final ObjectMapper fieldMapper = new ObjectMapper();
+    static {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(NodePath.class, new NodePathSerializer());
+        fieldMapper.registerModule(module);
+        fieldMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
+
+    /**
+     * Creates a new command instance by class name using reflection.
+     * @param cmdType the simple class name of the command (e.g. "ChangeTitleCommand")
+     * @return a new, empty command instance
+     */
     public static ICommand create(String cmdType) {
         try {
             String cmdFQCN = "io.apicurio.datamodels.cmd.commands." + cmdType;
@@ -50,6 +122,12 @@ public class CommandUtil {
         }
     }
 
+    /**
+     * Unmarshalls a JSON object into an {@link ICommand} instance. The JSON must contain a
+     * {@code __type} field identifying the command class name.
+     * @param from the JSON object to deserialize
+     * @return the deserialized command
+     */
     public static ICommand unmarshall(ObjectNode from) {
         String type = from.get("__type").asText();
         if (type == null) {
@@ -65,7 +143,67 @@ public class CommandUtil {
         } catch (NullPointerException e) {
             throw new RuntimeException("Missing command from unmarshalling factory: " + type, e);
         }
+    }
 
+    /**
+     * Marshalls an {@link ICommand} instance into a JSON object. The resulting JSON includes
+     * a {@code __type} field identifying the command class name, followed by all public fields.
+     * Special field types are handled automatically:
+     * <ul>
+     *   <li>{@link NodePath} fields are serialized as strings</li>
+     *   <li>Nested {@link ICommand} fields (e.g. in AggregateCommand) are recursively marshalled</li>
+     * </ul>
+     * @param command the command to serialize
+     * @return the JSON representation of the command
+     */
+    public static ObjectNode marshall(ICommand command) {
+        ObjectNode result = fieldMapper.createObjectNode();
+        result.put("__type", command.type());
+
+        // Serialize the command's fields using the fieldMapper (handles NodePath but not ICommand)
+        ObjectNode fields = fieldMapper.valueToTree(command);
+        fields.fields().forEachRemaining(entry -> {
+            result.set(entry.getKey(), entry.getValue());
+        });
+
+        // Post-process any List<ICommand> fields by recursively marshalling each command.
+        // This handles AggregateCommand._commands and any future nested command fields.
+        marshallCommandListFields(command, result);
+
+        return result;
+    }
+
+    /**
+     * Scans the command's public fields for {@code List<ICommand>} types and replaces their
+     * serialized values in the result with recursively marshalled command JSON objects.
+     * @param command the original command instance
+     * @param result the JSON node to update
+     */
+    private static void marshallCommandListFields(ICommand command, ObjectNode result) {
+        for (Field field : command.getClass().getFields()) {
+            if (List.class.isAssignableFrom(field.getType())) {
+                Type genericType = field.getGenericType();
+                if (genericType instanceof ParameterizedType) {
+                    ParameterizedType paramType = (ParameterizedType) genericType;
+                    Type[] typeArgs = paramType.getActualTypeArguments();
+                    if (typeArgs.length == 1 && typeArgs[0] == ICommand.class) {
+                        try {
+                            @SuppressWarnings("unchecked")
+                            List<ICommand> commands = (List<ICommand>) field.get(command);
+                            if (commands != null) {
+                                ArrayNode commandsArray = result.arrayNode();
+                                for (ICommand subCommand : commands) {
+                                    commandsArray.add(marshall(subCommand));
+                                }
+                                result.set(field.getName(), commandsArray);
+                            }
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException("Error marshalling command list field: " + field.getName(), e);
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -172,6 +172,34 @@ export class CommandUtil {
         return supplier();
     }
 
+    /**
+     * Marshalls a command into a plain JSON object for storage or transmission.
+     * The resulting object includes a `__type` field identifying the command class name,
+     * followed by all fields. NodePath fields are serialized as strings, and nested
+     * command lists are recursively marshalled.
+     * @param command the command to serialize
+     * @return the JSON representation of the command
+     */
+    public static marshall(command: ICommand): object {
+        let result: any = {
+            "__type": command.type()
+        };
+        Object.keys(command).filter(key => key !== "__type").forEach(key => {
+            let value: any = command[key];
+            if (value !== undefined) {
+                if (pathKeys.indexOf(key) !== -1 && value) {
+                    value = (value as NodePath).toString();
+                } else if (pathListKeys.indexOf(key) !== -1 && value) {
+                    value = (value as NodePath[]).map(np => np.toString());
+                } else if (cmdListKeys.indexOf(key) !== -1 && value) {
+                    value = (value as ICommand[]).map(cmd => CommandUtil.marshall(cmd));
+                }
+            }
+            result[key] = value;
+        });
+        return result;
+    }
+
     public static unmarshall(from: object): ICommand {
         let type: string = from["__type"];
         if (!type) {

--- a/src/main/ts/tests/commands-marshall.test.ts
+++ b/src/main/ts/tests/commands-marshall.test.ts
@@ -1,0 +1,49 @@
+import {CommandUtil} from "../src/io/apicurio/datamodels/util/CommandUtil";
+import {readJSON} from "./util/tutils";
+import {ICommand} from "../src/io/apicurio/datamodels/cmd/ICommand";
+
+
+interface TestSpec {
+    name: string;
+    test: string;
+    commands?: string;
+}
+
+let allTests: TestSpec[] = readJSON("tests/fixtures/cmd/tests.json");
+allTests.forEach(spec => {
+    test("Marshall: " + spec.name, () => {
+        let commandsPath: string = "tests/fixtures/cmd/" + spec.test + ".commands.json";
+        if (spec.commands) {
+            commandsPath = "tests/fixtures/cmd/" + spec.test + spec.commands;
+        }
+
+        let commandsJs: any[] = readJSON(commandsPath);
+        expect(commandsJs).not.toBeNull();
+
+        commandsJs.forEach((originalNode, index) => {
+            // Unmarshall the command from JSON
+            let command: ICommand = CommandUtil.unmarshall(originalNode);
+            expect(command).not.toBeNull();
+
+            // Marshall the command back to JSON
+            let marshalledNode: any = CommandUtil.marshall(command);
+            expect(marshalledNode).not.toBeNull();
+
+            // Verify __type is preserved
+            expect(marshalledNode["__type"]).toEqual(originalNode["__type"]);
+
+            // Verify that all marshalled fields match the corresponding original values
+            Object.keys(marshalledNode).forEach(fieldName => {
+                if (originalNode.hasOwnProperty(fieldName)) {
+                    expect(marshalledNode[fieldName]).toEqual(originalNode[fieldName]);
+                }
+            });
+
+            // Verify round-trip consistency: marshall -> unmarshall produces a command
+            // that marshalls identically
+            let roundTrippedCommand: ICommand = CommandUtil.unmarshall(marshalledNode);
+            let secondMarshall: any = CommandUtil.marshall(roundTrippedCommand);
+            expect(secondMarshall).toEqual(marshalledNode);
+        });
+    });
+});

--- a/src/test/java/io/apicurio/datamodels/cmd/CommandMarshallTest.java
+++ b/src/test/java/io/apicurio/datamodels/cmd/CommandMarshallTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.datamodels.cmd;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apicurio.datamodels.util.CommandUtil;
+import io.apicurio.datamodels.models.util.JsonUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Tests that commands can be marshalled (Command → JSON) and that the result matches the
+ * original JSON when round-tripped through unmarshall → marshall.
+ *
+ * @author eric.wittmann@gmail.com
+ */
+@RunWith(Parameterized.class)
+public class CommandMarshallTest {
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> testData() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        URL testsJsonUrl = Thread.currentThread().getContextClassLoader().getResource("fixtures/cmd/tests.json");
+        List<CommandTestCase> allTests = mapper.readValue(testsJsonUrl,
+                mapper.getTypeFactory().constructCollectionType(List.class, CommandTestCase.class));
+
+        List<Object[]> params = new ArrayList<>();
+        for (CommandTestCase testCase : allTests) {
+            params.add(new Object[]{ testCase.getName(), testCase.getTest(), testCase.getCommands() });
+        }
+        return params;
+    }
+
+    private final String testName;
+    private final String testPath;
+    private final String commandsSuffix;
+
+    public CommandMarshallTest(String testName, String testPath, String commandsSuffix) {
+        this.testName = testName;
+        this.testPath = testPath;
+        this.commandsSuffix = commandsSuffix;
+    }
+
+    @Test
+    public void testMarshallRoundTrip() throws Exception {
+        String commandsCP = "fixtures/cmd/" + testPath +
+                (commandsSuffix != null ? commandsSuffix : ".commands.json");
+        URL commandsUrl = Thread.currentThread().getContextClassLoader().getResource(commandsCP);
+        Assert.assertNotNull("Commands file not found: " + commandsCP, commandsUrl);
+
+        String commandsJson = org.apache.commons.io.IOUtils.toString(commandsUrl, StandardCharsets.UTF_8);
+        ArrayNode commandsArray = (ArrayNode) JsonUtil.parseJSON(commandsJson);
+
+        for (int i = 0; i < commandsArray.size(); i++) {
+            ObjectNode originalNode = (ObjectNode) commandsArray.get(i);
+
+            // Unmarshall the command from JSON
+            ICommand command = CommandUtil.unmarshall(originalNode);
+            Assert.assertNotNull("Failed to unmarshall command at index " + i, command);
+
+            // Marshall the command back to JSON
+            ObjectNode marshalledNode = CommandUtil.marshall(command);
+            Assert.assertNotNull("Failed to marshall command at index " + i, marshalledNode);
+
+            // Verify __type is preserved
+            Assert.assertEquals("Command type mismatch at index " + i,
+                    originalNode.get("__type").asText(),
+                    marshalledNode.get("__type").asText());
+
+            // Verify that all marshalled fields match the corresponding original values.
+            // Note: some fixtures contain extra metadata fields (e.g. _defName, _method)
+            // that are not actual command fields — these are ignored during unmarshalling
+            // and won't appear in the marshalled output. We only verify fields that survive
+            // the round-trip.
+            marshalledNode.fields().forEachRemaining(entry -> {
+                String fieldName = entry.getKey();
+                JsonNode actualValue = entry.getValue();
+                if (originalNode.has(fieldName)) {
+                    JsonNode expectedValue = originalNode.get(fieldName);
+                    Assert.assertEquals(
+                            "Field '" + fieldName + "' value mismatch in " + testName,
+                            expectedValue, actualValue);
+                }
+            });
+
+            // Verify round-trip consistency: marshall → unmarshall produces a command
+            // that marshalls identically
+            ICommand roundTrippedCommand = CommandUtil.unmarshall(marshalledNode);
+            ObjectNode secondMarshall = CommandUtil.marshall(roundTrippedCommand);
+            Assert.assertEquals(
+                    "Round-trip marshall inconsistency in " + testName + " at index " + i,
+                    marshalledNode, secondMarshall);
+        }
+    }
+}

--- a/src/test/resources/fixtures/cmd/commands/replace-operation/openapi-2/replace-operation.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-operation/openapi-2/replace-operation.commands.json
@@ -1,8 +1,6 @@
 [
     {
         "__type": "ReplaceOperationCommand",
-        "_method": "get",
-        "_path": "/pets",
         "_nodePath": "/paths[/pets]/get",
         "_new": {
             "summary": "Do A Thing",

--- a/src/test/resources/fixtures/cmd/commands/replace-operation/openapi-3/replace-operation.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-operation/openapi-3/replace-operation.commands.json
@@ -1,8 +1,6 @@
 [
     {
         "__type": "ReplaceOperationCommand",
-        "_method": "get",
-        "_path": "/foo",
         "_nodePath": "/paths[/foo]/get",
         "_new": {
             "summary": "Do A Thing",

--- a/src/test/resources/fixtures/cmd/commands/replace-path-item/openapi-2/replace-path-item.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-path-item/openapi-2/replace-path-item.commands.json
@@ -12,7 +12,6 @@
 				],
 				"deprecated": false
 			}
-		},
-		"_pathName": "/pets"
+		}
 	}
 ]

--- a/src/test/resources/fixtures/cmd/commands/replace-path-item/openapi-3/replace-path-item.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-path-item/openapi-3/replace-path-item.commands.json
@@ -14,6 +14,5 @@
             "operationId": "updatePet",
             "deprecated": false
         }
-    },
-    "_pathName": "/foo"
+    }
 }]

--- a/src/test/resources/fixtures/cmd/commands/replace-response-definition/openapi-2/replace-response-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-response-definition/openapi-2/replace-response-definition.commands.json
@@ -3,6 +3,5 @@
     "_nodePath": "/responses[NotFound]",
     "_new": {
         "description": "The replaced content."
-    },
-    "_defName": "NotFound"
+    }
 }]

--- a/src/test/resources/fixtures/cmd/commands/replace-response-definition/openapi-3/replace-response-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-response-definition/openapi-3/replace-response-definition.commands.json
@@ -3,6 +3,5 @@
     "_nodePath": "/components/responses[NotFound]",
     "_new": {
         "description": "The replaced content."
-    },
-    "_defName": "NotFound"
+    }
 }]

--- a/src/test/resources/fixtures/cmd/commands/replace-schema-definition/asyncapi-2/replace-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-schema-definition/asyncapi-2/replace-schema-definition.commands.json
@@ -20,6 +20,5 @@
             },
             "newProperty": {}
         }
-    },
-    "_defName": "MySchema2"
+    }
 }]

--- a/src/test/resources/fixtures/cmd/commands/replace-schema-definition/openapi-2/replace-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-schema-definition/openapi-2/replace-schema-definition.commands.json
@@ -16,6 +16,5 @@
             }
         },
         "discriminator": "petType"
-    },
-    "_defName": "Person"
+    }
 }]

--- a/src/test/resources/fixtures/cmd/commands/replace-schema-definition/openapi-3/replace-schema-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/replace-schema-definition/openapi-3/replace-schema-definition.commands.json
@@ -15,6 +15,5 @@
                 "type": "integer"
             }
         }
-    },
-    "_defName": "MySchema2"
+    }
 }]


### PR DESCRIPTION
## Summary

- Add `marshall` and `unmarshall` methods to `CommandUtil` (Java and TypeScript) for serializing/deserializing commands to/from JSON, replacing the old `MarshallCompat` approach from v1.x
- Add convenience delegation methods in `CommandFactory` (Java) for backward compatibility
- Add `CommandMarshallTest` (Java) and `commands-marshall.test.ts` (TypeScript) to verify round-trip marshalling of all 139 command fixtures
- Remove redundant fields (`_defName`, `_pathName`, `_method`, `_path`) from 9 test fixture files that don't exist on the corresponding command classes

## Related Issue

Fixes #829

## Test Plan

- [x] Run `./build.sh` — all Java and TypeScript tests pass (632 TS tests, 139 Java marshall round-trip tests)
- [x] Verify `CommandUtil.marshall()` serializes a command to JSON with `__type`, `NodePath` fields as strings, and nested command lists recursively marshalled
- [x] Verify `CommandUtil.unmarshall()` deserializes JSON back to a command instance
- [x] Verify round-trip consistency: `unmarshall(marshall(cmd))` produces an identical marshall output