### PR TITLE
Add OAS 2.0 test coverage for definition name validation rules (#979)

### DIFF
--- a/src/test/resources/fixtures/validation/openapi/2.0/invalid-property-name.json
+++ b/src/test/resources/fixtures/validation/openapi/2.0/invalid-property-name.json
@@ -684,6 +684,26 @@
             "xml":{
                 "name":"##default"
             }
+        },
+        "Pet+Foo":{
+            "properties":{
+                "id":{
+                    "type":"integer",
+                    "format":"int64"
+                }
+            }
+        }
+    },
+    "parameters":{
+        "Some$Parameter":{
+            "name":"id",
+            "in":"query",
+            "type":"integer"
+        }
+    },
+    "responses":{
+        "The Response":{
+            "description":"A response with an invalid name"
         }
     },
     "externalDocs":{

--- a/src/test/resources/fixtures/validation/openapi/2.0/invalid-property-name.json.expected
+++ b/src/test/resources/fixtures/validation/openapi/2.0/invalid-property-name.json.expected
@@ -19,3 +19,6 @@
 [PATH-009] |medium| {/paths[/pathstest26/{var}/]->null} :: Path template "/pathstest26/{var}/" is semantically identical to at least one other path.
 [PATH-009] |medium| {/paths[/pathstest27/{var1}]->null} :: Path template "/pathstest27/{var1}" is semantically identical to at least one other path.
 [PATH-009] |medium| {/paths[/pathstest27/{var2}/]->null} :: Path template "/pathstest27/{var2}/" is semantically identical to at least one other path.
+[PDEF-001] |medium| {/parameters[Some$Parameter]->name} :: Parameter Definition Name is not valid.
+[RDEF-001] |medium| {/responses[The Response]->name} :: Response Definition Name is not valid.
+[SDEF-001] |medium| {/definitions[Pet+Foo]->name} :: Schema Definition Name is not valid.


### PR DESCRIPTION
## Summary

- Added invalid definition names to the OAS 2.0 `invalid-property-name.json` test fixture to trigger SDEF-001, PDEF-001, and RDEF-001 validation rules
- Added `Pet+Foo` to `definitions`, `Some$Parameter` to `parameters`, and `The Response` to `responses` sections with invalid characters (`+`, `$`, space)
- Updated the `.expected` file with the three corresponding validation violations

## Related Issue

Fixes #979

## Test Plan

- [x] Run `./build.sh` — all 668 tests pass (including 127 validation tests) with 0 failures
- [ ] Verify the new validation violations appear correctly when running `ValidationTest`
- [ ] Confirm no regressions in existing PATH, RES, and EX validation rules