### PR TITLE
Add AddSchemaPropertyCommand for adding individual properties to a schema definition (#983)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -14,6 +14,7 @@ import io.apicurio.datamodels.cmd.commands.AddResponseCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseHeaderCommand;
 import io.apicurio.datamodels.cmd.commands.AddSchemaDefinitionCommand;
+import io.apicurio.datamodels.cmd.commands.AddSchemaPropertyCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecuritySchemeCommand;
 import io.apicurio.datamodels.cmd.commands.AddServerCommand;
@@ -129,6 +130,18 @@ public class CommandFactory {
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {
         return new AddSchemaDefinitionCommand(definitionName, from);
+    }
+
+    /**
+     * Creates a command to add a new property to a schema definition.
+     * @param schemaDefinitionName the name of the schema definition
+     * @param propertyName the name of the property to add
+     * @param propertySchema the JSON schema for the property
+     * @return the command
+     */
+    public static ICommand createAddSchemaPropertyCommand(String schemaDefinitionName,
+            String propertyName, ObjectNode propertySchema) {
+        return new AddSchemaPropertyCommand(schemaDefinitionName, propertyName, propertySchema);
     }
 
     public static ICommand createAddDocumentSecurityRequirementCommand(

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaPropertyCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddSchemaPropertyCommand.java
@@ -1,0 +1,137 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Schema;
+import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+/**
+ * A command used to add a new property to a schema definition in a document.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddSchemaPropertyCommand extends AbstractCommand {
+
+    public String _schemaDefinitionName;
+    public String _propertyName;
+    public ObjectNode _propertySchema;
+    public boolean _propertyExisted;
+    public boolean _nullProperties;
+
+    private transient AddSchemaPropertyCommandHelper _helper;
+
+    public AddSchemaPropertyCommand() {
+    }
+
+    public AddSchemaPropertyCommand(String schemaDefinitionName, String propertyName, ObjectNode propertySchema) {
+        this._schemaDefinitionName = schemaDefinitionName;
+        this._propertyName = propertyName;
+        this._propertySchema = propertySchema;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddSchemaPropertyCommand] Executing.");
+        this._helper = createHelper(document);
+
+        Schema schema = this._helper.resolveSchema(document);
+        if (this.isNullOrUndefined(schema)) {
+            LoggerUtil.info("[AddSchemaPropertyCommand] Schema definition '%s' not found.", this._schemaDefinitionName);
+            return;
+        }
+
+        // Do nothing if the property already exists.
+        if (!this.isNullOrUndefined(schema.getProperties()) && schema.getProperties().containsKey(this._propertyName)) {
+            LoggerUtil.info("[AddSchemaPropertyCommand] Property '%s' already exists on schema '%s'.", this._propertyName, this._schemaDefinitionName);
+            this._propertyExisted = true;
+            return;
+        }
+
+        this._nullProperties = this.isNullOrUndefined(schema.getProperties());
+
+        Schema newPropSchema = schema.createSchema();
+        Library.readNode(this._propertySchema, newPropSchema);
+        schema.addProperty(this._propertyName, newPropSchema);
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddSchemaPropertyCommand] Reverting.");
+        if (this._propertyExisted) {
+            return;
+        }
+
+        this._helper = createHelper(document);
+        Schema schema = this._helper.resolveSchema(document);
+        if (this.isNullOrUndefined(schema)) {
+            return;
+        }
+
+        schema.removeProperty(this._propertyName);
+        if (this._nullProperties) {
+            schema.clearProperties();
+        }
+    }
+
+    private AddSchemaPropertyCommandHelper createHelper(Document document) {
+        if (ModelTypeUtil.isOpenApi2Model(document)) {
+            return new OpenApi20Helper();
+        }
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            return new OpenApi30Helper();
+        }
+        if (ModelTypeUtil.isOpenApi31Model(document)) {
+            return new OpenApi31Helper();
+        }
+        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+    }
+
+    private interface AddSchemaPropertyCommandHelper {
+        Schema resolveSchema(Document document);
+    }
+
+    private class OpenApi20Helper implements AddSchemaPropertyCommandHelper {
+        @Override
+        public Schema resolveSchema(Document document) {
+            OpenApi20Document doc20 = (OpenApi20Document) document;
+            if (isNullOrUndefined(doc20.getDefinitions())) {
+                return null;
+            }
+            return doc20.getDefinitions().getItem(_schemaDefinitionName);
+        }
+    }
+
+    private class OpenApi30Helper implements AddSchemaPropertyCommandHelper {
+        @Override
+        public Schema resolveSchema(Document document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (isNullOrUndefined(doc30.getComponents()) || isNullOrUndefined(doc30.getComponents().getSchemas())) {
+                return null;
+            }
+            return doc30.getComponents().getSchemas().get(_schemaDefinitionName);
+        }
+    }
+
+    private class OpenApi31Helper implements AddSchemaPropertyCommandHelper {
+        @Override
+        public Schema resolveSchema(Document document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (isNullOrUndefined(doc31.getComponents()) || isNullOrUndefined(doc31.getComponents().getSchemas())) {
+                return null;
+            }
+            return doc31.getComponents().getSchemas().get(_schemaDefinitionName);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -14,6 +14,7 @@ import {AddResponseCommand} from "../cmd/commands/AddResponseCommand";
 import {AddResponseDefinitionCommand} from "../cmd/commands/AddResponseDefinitionCommand";
 import {AddResponseHeaderCommand} from "../cmd/commands/AddResponseHeaderCommand";
 import {AddSchemaDefinitionCommand} from "../cmd/commands/AddSchemaDefinitionCommand";
+import {AddSchemaPropertyCommand} from "../cmd/commands/AddSchemaPropertyCommand";
 import {AddSecurityRequirementCommand} from "../cmd/commands/AddSecurityRequirementCommand";
 import {AddSecuritySchemeCommand} from "../cmd/commands/AddSecuritySchemeCommand";
 import {AddServerCommand} from "../cmd/commands/AddServerCommand";
@@ -99,6 +100,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "AddResponseDefinitionCommand": () => { return new AddResponseDefinitionCommand(); },
     "AddResponseHeaderCommand": () => { return new AddResponseHeaderCommand(); },
     "AddSchemaDefinitionCommand": () => { return new AddSchemaDefinitionCommand(); },
+    "AddSchemaPropertyCommand": () => { return new AddSchemaPropertyCommand(); },
     "AddSecurityRequirementCommand": () => { return new AddSecurityRequirementCommand(); },
     "AddSecuritySchemeCommand": () => { return new AddSecuritySchemeCommand(); },
     "AddServerCommand": () => { return new AddServerCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.after.json
@@ -1,0 +1,20 @@
+{
+  "swagger": "2.0",
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.before.json
@@ -1,0 +1,17 @@
+{
+  "swagger": "2.0",
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-2/add-schema-property.commands.json
@@ -1,0 +1,10 @@
+[
+    {
+        "__type": "AddSchemaPropertyCommand",
+        "_schemaDefinitionName": "User",
+        "_propertyName": "status",
+        "_propertySchema": {
+            "type": "string"
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.after.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.before.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-schema-property/openapi-3/add-schema-property.commands.json
@@ -1,0 +1,10 @@
+[
+    {
+        "__type": "AddSchemaPropertyCommand",
+        "_schemaDefinitionName": "User",
+        "_propertyName": "status",
+        "_propertySchema": {
+            "type": "string"
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -72,6 +72,8 @@
     { "name": "[OpenAPI 2] {Add Response Definition} - Clone Response Definition", "test": "commands/add-response-definition/openapi-2/clone-response-definition" },
     { "name": "[OpenAPI 3] {Add Response Definition} - Add Response Definition", "test": "commands/add-response-definition/openapi-3/add-response-definition" },
     { "name": "[OpenAPI 3] {Add Response Definition} - Clone Response Definition", "test": "commands/add-response-definition/openapi-3/clone-response-definition" },
+    { "name": "[OpenAPI 2] {Add Schema Property} - Add Property", "test": "commands/add-schema-property/openapi-2/add-schema-property" },
+    { "name": "[OpenAPI 3] {Add Schema Property} - Add Property", "test": "commands/add-schema-property/openapi-3/add-schema-property" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },
     { "name": "[OpenAPI 3] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-3/add-definition" },


### PR DESCRIPTION
## Summary

- Add new `AddSchemaPropertyCommand` that adds a single named property to an existing schema definition's `properties` map, with support for OAS 2.0 (`definitions`) and OAS 3.0/3.1 (`components/schemas`)
- Add `createAddSchemaPropertyCommand` factory method to `CommandFactory` and register the command in the TypeScript `CommandUtil` for marshall/unmarshall support
- Add test fixtures and test registrations for both OpenAPI 2.0 and OpenAPI 3.0

## Related Issue

Fixes #983

## Test Plan

- [x] OAS 2.0 test: adds a `status` property to a `User` schema under `definitions`
- [x] OAS 3.0 test: adds a `status` property to a `User` schema under `components/schemas`
- [x] Both execute (before → after) and undo (after → before) are validated by the test framework
- [x] Full build passes (`./build.sh`) — all 636 tests pass (Java + TypeScript)