### PR TITLE
Add AddParameterDefinitionCommand for adding reusable parameter definitions (#985)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -8,6 +8,7 @@ import io.apicurio.datamodels.cmd.commands.AddExtensionCommand;
 import io.apicurio.datamodels.cmd.commands.AddMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.AddOperationSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.AddParameterCommand;
+import io.apicurio.datamodels.cmd.commands.AddParameterDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddPathItemCommand;
 import io.apicurio.datamodels.cmd.commands.AddRequestBodyCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseCommand;
@@ -126,6 +127,10 @@ public class CommandFactory {
 
     public static ICommand createAddResponseDefinitionCommand(String definitionName, ObjectNode from) {
         return new AddResponseDefinitionCommand(definitionName, from);
+    }
+
+    public static ICommand createAddParameterDefinitionCommand(String definitionName, ObjectNode from) {
+        return new AddParameterDefinitionCommand(definitionName, from);
     }
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddParameterDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddParameterDefinitionCommand.java
@@ -1,0 +1,239 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.openapi.OpenApiDocument;
+import io.apicurio.datamodels.models.openapi.OpenApiParameter;
+import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
+import io.apicurio.datamodels.models.openapi.v20.OpenApi20Parameter;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+/**
+ * A command used to add a new parameter definition in a document.  Source for the new
+ * definition must be provided.  This source will be converted to an openapi
+ * parameter definition object and then added to the data model.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddParameterDefinitionCommand extends AbstractCommand {
+
+    public boolean _defExisted;
+    public String _newDefinitionName;
+    public ObjectNode _newDefinitionObj;
+    public boolean _nullDefinitionsParent;
+
+    private transient AddParameterDefinitionCommandHelper _helper;
+
+    public AddParameterDefinitionCommand() {
+    }
+
+    public AddParameterDefinitionCommand(String definitionName, ObjectNode obj) {
+        this._newDefinitionName = definitionName;
+        this._newDefinitionObj = obj;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddParameterDefinitionCommand] Executing.");
+        this._helper = createHelper(document);
+
+        OpenApiDocument doc = (OpenApiDocument) document;
+
+        // Do nothing if the definition already exists.
+        if (this._helper.defExists(doc)) {
+            LoggerUtil.info("[AddParameterDefinitionCommand] Definition with name %s already exists.", this._newDefinitionName);
+            this._defExisted = true;
+            return;
+        }
+
+        this._nullDefinitionsParent = this._helper.prepareDocumentForDef(doc);
+
+        OpenApiParameter definition = this._helper.createParameterDefinition(doc);
+        this._helper.addDefinition(doc, definition);
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddParameterDefinitionCommand] Reverting.");
+        if (this._defExisted) {
+            return;
+        }
+
+        this._helper = createHelper(document);
+
+        OpenApiDocument doc = (OpenApiDocument) document;
+        this._helper.removeDefinition(doc);
+    }
+
+    private AddParameterDefinitionCommandHelper createHelper(Document document) {
+        if (ModelTypeUtil.isOpenApi2Model(document)) {
+            return new OpenApi20Helper();
+        }
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            return new OpenApi30Helper();
+        }
+        if (ModelTypeUtil.isOpenApi31Model(document)) {
+            return new OpenApi31Helper();
+        }
+        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+    }
+
+    private interface AddParameterDefinitionCommandHelper {
+
+        boolean defExists(OpenApiDocument document);
+        boolean prepareDocumentForDef(OpenApiDocument document);
+        OpenApiParameter createParameterDefinition(OpenApiDocument document);
+        void addDefinition(OpenApiDocument document, OpenApiParameter definition);
+        void removeDefinition(OpenApiDocument document);
+
+    }
+
+    private class OpenApi20Helper implements AddParameterDefinitionCommandHelper {
+        @Override
+        public boolean defExists(OpenApiDocument document) {
+            OpenApi20Document doc = (OpenApi20Document) document;
+            if (!isNullOrUndefined(doc.getParameters())) {
+                return !isNullOrUndefined(doc.getParameters().getItem(_newDefinitionName));
+            }
+            return false;
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(OpenApiDocument document) {
+            OpenApi20Document doc20 = (OpenApi20Document) document;
+            if (isNullOrUndefined(doc20.getParameters())) {
+                doc20.setParameters(doc20.createParameterDefinitions());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public OpenApiParameter createParameterDefinition(OpenApiDocument document) {
+            OpenApi20Document doc20 = (OpenApi20Document) document;
+            OpenApi20Parameter definition = doc20.getParameters().createParameter();
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(OpenApiDocument document, OpenApiParameter definition) {
+            OpenApi20Document doc20 = (OpenApi20Document) document;
+            OpenApi20Parameter def20 = (OpenApi20Parameter) definition;
+            doc20.getParameters().addItem(_newDefinitionName, def20);
+        }
+
+        @Override
+        public void removeDefinition(OpenApiDocument document) {
+            OpenApi20Document doc20 = (OpenApi20Document) document;
+            if (_nullDefinitionsParent) {
+                doc20.setParameters(null);
+            } else {
+                doc20.getParameters().removeItem(_newDefinitionName);
+            }
+        }
+    }
+
+    private class OpenApi30Helper implements AddParameterDefinitionCommandHelper {
+        @Override
+        public boolean defExists(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (isNullOrUndefined(doc30.getComponents())) {
+                return false;
+            }
+            return !isNullOrUndefined(doc30.getComponents().getParameters().get(_newDefinitionName));
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (isNullOrUndefined(doc30.getComponents())) {
+                doc30.setComponents(doc30.createComponents());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public OpenApiParameter createParameterDefinition(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            OpenApi30Parameter definition = (OpenApi30Parameter) doc30.getComponents().createParameter();
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(OpenApiDocument document, OpenApiParameter definition) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            doc30.getComponents().addParameter(_newDefinitionName, definition);
+        }
+
+        @Override
+        public void removeDefinition(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (_nullDefinitionsParent) {
+                doc30.setComponents(null);
+            } else {
+                doc30.getComponents().removeParameter(_newDefinitionName);
+            }
+        }
+    }
+
+    private class OpenApi31Helper implements AddParameterDefinitionCommandHelper {
+        @Override
+        public boolean defExists(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (isNullOrUndefined(doc31.getComponents())) {
+                return false;
+            }
+            return !isNullOrUndefined(doc31.getComponents().getParameters().get(_newDefinitionName));
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (isNullOrUndefined(doc31.getComponents())) {
+                doc31.setComponents(doc31.createComponents());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public OpenApiParameter createParameterDefinition(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            OpenApi31Parameter definition = (OpenApi31Parameter) doc31.getComponents().createParameter();
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(OpenApiDocument document, OpenApiParameter definition) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            doc31.getComponents().addParameter(_newDefinitionName, definition);
+        }
+
+        @Override
+        public void removeDefinition(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (_nullDefinitionsParent) {
+                doc31.setComponents(null);
+            } else {
+                doc31.getComponents().removeParameter(_newDefinitionName);
+            }
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -8,6 +8,7 @@ import {AddExtensionCommand} from "../cmd/commands/AddExtensionCommand";
 import {AddMediaTypeCommand} from "../cmd/commands/AddMediaTypeCommand";
 import {AddOperationSecurityRequirementCommand} from "../cmd/commands/AddOperationSecurityRequirementCommand";
 import {AddParameterCommand} from "../cmd/commands/AddParameterCommand";
+import {AddParameterDefinitionCommand} from "../cmd/commands/AddParameterDefinitionCommand";
 import {AddPathItemCommand} from "../cmd/commands/AddPathItemCommand";
 import {AddRequestBodyCommand} from "../cmd/commands/AddRequestBodyCommand";
 import {AddResponseCommand} from "../cmd/commands/AddResponseCommand";
@@ -94,6 +95,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "AddMediaTypeCommand": () => { return new AddMediaTypeCommand(); },
     "AddOperationSecurityRequirementCommand": () => { return new AddOperationSecurityRequirementCommand(); },
     "AddParameterCommand": () => { return new AddParameterCommand(); },
+    "AddParameterDefinitionCommand": () => { return new AddParameterDefinitionCommand(); },
     "AddPathItemCommand": () => { return new AddPathItemCommand(); },
     "AddRequestBodyCommand": () => { return new AddRequestBodyCommand(); },
     "AddResponseCommand": () => { return new AddResponseCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.after.json
@@ -1,0 +1,15 @@
+{
+  "swagger" : "2.0",
+  "parameters" : {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "type": "integer"
+    },
+    "pageSize": {
+      "name": "pageSize",
+      "in": "query",
+      "type": "integer"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.before.json
@@ -1,0 +1,10 @@
+{
+  "swagger" : "2.0",
+  "parameters" : {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "type": "integer"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-2/add-parameter-definition.commands.json
@@ -1,0 +1,11 @@
+[
+    {
+        "__type": "AddParameterDefinitionCommand",
+        "_newDefinitionName" : "pageSize",
+        "_newDefinitionObj" : {
+            "name": "pageSize",
+            "in": "query",
+            "type": "integer"
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.after.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "pageSize": {
+        "name": "pageSize",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.before.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-parameter-definition/openapi-3/add-parameter-definition.commands.json
@@ -1,0 +1,13 @@
+[
+    {
+        "__type": "AddParameterDefinitionCommand",
+        "_newDefinitionName" : "pageSize",
+        "_newDefinitionObj" : {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+                "type": "integer"
+            }
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -74,6 +74,8 @@
     { "name": "[OpenAPI 3] {Add Response Definition} - Clone Response Definition", "test": "commands/add-response-definition/openapi-3/clone-response-definition" },
     { "name": "[OpenAPI 2] {Add Schema Property} - Add Property", "test": "commands/add-schema-property/openapi-2/add-schema-property" },
     { "name": "[OpenAPI 3] {Add Schema Property} - Add Property", "test": "commands/add-schema-property/openapi-3/add-schema-property" },
+    { "name": "[OpenAPI 2] {Add Parameter Definition} - Add Parameter Definition", "test": "commands/add-parameter-definition/openapi-2/add-parameter-definition" },
+    { "name": "[OpenAPI 3] {Add Parameter Definition} - Add Parameter Definition", "test": "commands/add-parameter-definition/openapi-3/add-parameter-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },
     { "name": "[OpenAPI 3] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-3/add-definition" },


### PR DESCRIPTION
## Summary

- Add `AddParameterDefinitionCommand` that adds reusable parameter definitions to OAS 2.0 top-level `parameters` and OAS 3.x `components/parameters`, following the same pattern as `AddResponseDefinitionCommand`
- Register the command in `CommandFactory.java` (factory method) and `CommandUtil.ts` (supplier for marshall/unmarshall)
- Add test fixtures for both OAS 2.0 and OAS 3.0 with corresponding entries in `tests.json`

## Related Issue

Fixes #985

## Test Plan

- [ ] Run `./build.sh` to verify Java compilation and all tests pass
- [ ] Verify OAS 2.0 test: execute adds parameter to top-level `parameters`, undo removes it
- [ ] Verify OAS 3.0 test: execute adds parameter to `components/parameters`, undo removes it
- [ ] Verify command marshall/unmarshall round-trip works via the existing test framework