### PR TITLE
Add DeleteParameterDefinitionCommand for removing reusable parameter definitions (#986)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -50,6 +50,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteParameterDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeletePathCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteRequestBodyCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteResponseCommand;
@@ -131,6 +132,15 @@ public class CommandFactory {
 
     public static ICommand createAddParameterDefinitionCommand(String definitionName, ObjectNode from) {
         return new AddParameterDefinitionCommand(definitionName, from);
+    }
+
+    /**
+     * Creates a command to delete a reusable parameter definition.
+     * @param definitionName the name of the parameter definition to delete
+     * @return the command
+     */
+    public static ICommand createDeleteParameterDefinitionCommand(String definitionName) {
+        return new DeleteParameterDefinitionCommand(definitionName);
     }
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteParameterDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteParameterDefinitionCommand.java
@@ -1,0 +1,125 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
+import io.apicurio.datamodels.models.openapi.v20.OpenApi20Parameter;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to delete a single reusable parameter definition from a document.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteParameterDefinitionCommand extends AbstractCommand {
+
+    public String _definitionName;
+
+    public ObjectNode _oldDefinition;
+    public int _oldIndex;
+
+    public DeleteParameterDefinitionCommand() {
+    }
+
+    public DeleteParameterDefinitionCommand(String definitionName) {
+        this._definitionName = definitionName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteParameterDefinitionCommand] Executing.");
+        this._oldDefinition = null;
+
+        if (ModelTypeUtil.isOpenApi2Model(document)) {
+            OpenApi20Document doc = (OpenApi20Document) document;
+            if (this.isNullOrUndefined(doc.getParameters())) {
+                return;
+            }
+            OpenApi20Parameter param = doc.getParameters().getItem(this._definitionName);
+            if (!this.isNullOrUndefined(param)) {
+                this._oldDefinition = Library.writeNode(param);
+                this._oldIndex = doc.getParameters().getItemNames().indexOf(this._definitionName);
+                doc.getParameters().removeItem(this._definitionName);
+            }
+        } else if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getParameters())) {
+                return;
+            }
+            OpenApi30Parameter param = (OpenApi30Parameter) components.getParameters().get(this._definitionName);
+            if (!this.isNullOrUndefined(param)) {
+                this._oldDefinition = Library.writeNode((Node) param);
+                List<String> paramNames = new ArrayList<>(components.getParameters().keySet());
+                this._oldIndex = paramNames.indexOf(this._definitionName);
+                components.removeParameter(this._definitionName);
+            }
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getParameters())) {
+                return;
+            }
+            OpenApi31Parameter param = (OpenApi31Parameter) components.getParameters().get(this._definitionName);
+            if (!this.isNullOrUndefined(param)) {
+                this._oldDefinition = Library.writeNode((Node) param);
+                List<String> paramNames = new ArrayList<>(components.getParameters().keySet());
+                this._oldIndex = paramNames.indexOf(this._definitionName);
+                components.removeParameter(this._definitionName);
+            }
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteParameterDefinitionCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldDefinition)) {
+            return;
+        }
+
+        if (ModelTypeUtil.isOpenApi2Model(document)) {
+            OpenApi20Document doc = (OpenApi20Document) document;
+            if (this.isNullOrUndefined(doc.getParameters())) {
+                doc.setParameters(doc.createParameterDefinitions());
+            }
+            OpenApi20Parameter param = doc.getParameters().createParameter();
+            Library.readNode(this._oldDefinition, param);
+            doc.getParameters().insertItem(this._definitionName, param, this._oldIndex);
+        } else if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi30Document) document).createComponents();
+                ((OpenApi30Document) document).setComponents(components);
+            }
+            OpenApi30Parameter param = (OpenApi30Parameter) components.createParameter();
+            Library.readNode(this._oldDefinition, param);
+            components.insertParameter(this._definitionName, param, this._oldIndex);
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi31Document) document).createComponents();
+                ((OpenApi31Document) document).setComponents(components);
+            }
+            OpenApi31Parameter param = (OpenApi31Parameter) components.createParameter();
+            Library.readNode(this._oldDefinition, param);
+            components.insertParameter(this._definitionName, param, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -53,6 +53,7 @@ import {DeleteMediaTypeCommand} from "../cmd/commands/DeleteMediaTypeCommand";
 import {DeleteOperationCommand} from "../cmd/commands/DeleteOperationCommand";
 import {DeleteOperationSecurityRequirementCommand} from "../cmd/commands/DeleteOperationSecurityRequirementCommand";
 import {DeleteParameterCommand} from "../cmd/commands/DeleteParameterCommand";
+import {DeleteParameterDefinitionCommand} from "../cmd/commands/DeleteParameterDefinitionCommand";
 import {DeletePathCommand} from "../cmd/commands/DeletePathCommand";
 import {DeleteRequestBodyCommand} from "../cmd/commands/DeleteRequestBodyCommand";
 import {DeleteResponseCommand} from "../cmd/commands/DeleteResponseCommand";
@@ -140,6 +141,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteOperationCommand": () => { return new DeleteOperationCommand(); },
     "DeleteOperationSecurityRequirementCommand": () => { return new DeleteOperationSecurityRequirementCommand(); },
     "DeleteParameterCommand": () => { return new DeleteParameterCommand(); },
+    "DeleteParameterDefinitionCommand": () => { return new DeleteParameterDefinitionCommand(); },
     "DeletePathCommand": () => { return new DeletePathCommand(); },
     "DeleteRequestBodyCommand": () => { return new DeleteRequestBodyCommand(); },
     "DeleteResponseCommand": () => { return new DeleteResponseCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.after.json
@@ -1,0 +1,10 @@
+{
+  "swagger" : "2.0",
+  "parameters" : {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "type": "integer"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.before.json
@@ -1,0 +1,15 @@
+{
+  "swagger" : "2.0",
+  "parameters" : {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "type": "integer"
+    },
+    "pageSize": {
+      "name": "pageSize",
+      "in": "query",
+      "type": "integer"
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-2/delete-parameter-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteParameterDefinitionCommand",
+    "_definitionName": "pageSize"
+}]

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.after.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.before.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "pageSize": {
+        "name": "pageSize",
+        "in": "query",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-parameter-definition/openapi-3/delete-parameter-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteParameterDefinitionCommand",
+    "_definitionName": "pageSize"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -76,6 +76,8 @@
     { "name": "[OpenAPI 3] {Add Schema Property} - Add Property", "test": "commands/add-schema-property/openapi-3/add-schema-property" },
     { "name": "[OpenAPI 2] {Add Parameter Definition} - Add Parameter Definition", "test": "commands/add-parameter-definition/openapi-2/add-parameter-definition" },
     { "name": "[OpenAPI 3] {Add Parameter Definition} - Add Parameter Definition", "test": "commands/add-parameter-definition/openapi-3/add-parameter-definition" },
+    { "name": "[OpenAPI 2] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-2/delete-parameter-definition" },
+    { "name": "[OpenAPI 3] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-3/delete-parameter-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },
     { "name": "[OpenAPI 3] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-3/add-definition" },


### PR DESCRIPTION
## Summary

- Add `DeleteParameterDefinitionCommand` that removes a reusable parameter definition from the document's components section (OAS 2.0, 3.0, 3.1)
- Register the command in `CommandFactory` (Java) and `CommandUtil` (TypeScript) for marshall/unmarshall support
- Add test fixtures and test entries for both OAS 2.0 and OAS 3.0

## Related Issue

Fixes #986

## Test Plan

- [x] Full build passes (`./build.sh`) — all 680 tests pass
- [x] OAS 2.0 delete parameter definition test passes
- [x] OAS 3.0 delete parameter definition test passes
- [x] Command marshall/unmarshall round-trip tested automatically by the test framework