### PR TITLE
Add AddServerVariableCommand and DeleteServerVariableCommand for server variable management (#998)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -20,6 +20,7 @@ import io.apicurio.datamodels.cmd.commands.AddSchemaPropertyCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.AddSecuritySchemeCommand;
 import io.apicurio.datamodels.cmd.commands.AddServerCommand;
+import io.apicurio.datamodels.cmd.commands.AddServerVariableCommand;
 import io.apicurio.datamodels.models.asyncapi.AsyncApiDocument;
 import io.apicurio.datamodels.cmd.commands.AddTagCommand;
 import io.apicurio.datamodels.cmd.commands.ChangeContactCommand;
@@ -61,6 +62,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteSchemaPropertyCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteSecuritySchemeCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteServerCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteServerVariableCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteTagCommand;
 import io.apicurio.datamodels.cmd.commands.EnsureChildNodeCommand;
 import io.apicurio.datamodels.cmd.commands.RenameTagCommand;
@@ -90,11 +92,14 @@ import io.apicurio.datamodels.models.openapi.OpenApiParametersParent;
 import io.apicurio.datamodels.models.openapi.OpenApiPathItem;
 import io.apicurio.datamodels.models.openapi.OpenApiResponse;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
+import io.apicurio.datamodels.models.openapi.OpenApiServer;
 import io.apicurio.datamodels.models.openapi.OpenApiServersParent;
 import io.apicurio.datamodels.models.openapi.v30.OpenApi30Operation;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Operation;
 import io.apicurio.datamodels.paths.NodePath;
 import io.apicurio.datamodels.util.CommandUtil;
+
+import java.util.List;
 
 public class CommandFactory {
 
@@ -382,6 +387,19 @@ public class CommandFactory {
 
     public static ICommand createDeleteAllServersCommand(AsyncApiDocument document) {
         return new DeleteAllServersCommand(document);
+    }
+
+    // --- Server Variable commands ---
+
+    public static ICommand createAddServerVariableCommand(OpenApiServer server,
+                                                          String variableName, String defaultValue,
+                                                          String description, List<String> enumValues) {
+        return new AddServerVariableCommand(server, variableName, defaultValue, description, enumValues);
+    }
+
+    public static ICommand createDeleteServerVariableCommand(OpenApiServer server,
+                                                             String variableName) {
+        return new DeleteServerVariableCommand(server, variableName);
     }
 
     // --- Path commands ---

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddServerVariableCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddServerVariableCommand.java
@@ -1,0 +1,96 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.Server;
+import io.apicurio.datamodels.models.ServerVariable;
+import io.apicurio.datamodels.models.openapi.OpenApiServer;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A command used to add a variable to a server.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddServerVariableCommand extends AbstractCommand {
+
+    public NodePath _serverPath;
+    public String _variableName;
+    public String _defaultValue;
+    public String _description;
+    public List<String> _enumValues;
+
+    public boolean _created;
+
+    public AddServerVariableCommand() {
+    }
+
+    public AddServerVariableCommand(OpenApiServer server, String variableName,
+                                    String defaultValue, String description,
+                                    List<String> enumValues) {
+        this._serverPath = NodePathUtil.createNodePath((Node) server);
+        this._variableName = variableName;
+        this._defaultValue = defaultValue;
+        this._description = description;
+        this._enumValues = enumValues;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddServerVariableCommand] Executing.");
+        this._created = false;
+
+        Server server = (Server) NodePathUtil.resolveNodePath(this._serverPath, document);
+        if (this.isNullOrUndefined(server)) {
+            return;
+        }
+
+        // Check if variable already exists
+        Map<String, ? extends ServerVariable> variables = (Map<String, ? extends ServerVariable>) server.getVariables();
+        if (!this.isNullOrUndefined(variables) && variables.containsKey(this._variableName)) {
+            return;
+        }
+
+        // Create the variable
+        ServerVariable variable = server.createServerVariable();
+        if (!this.isNullOrUndefined(this._defaultValue)) {
+            variable.setDefault(this._defaultValue);
+        }
+        if (!this.isNullOrUndefined(this._description)) {
+            variable.setDescription(this._description);
+        }
+        if (!this.isNullOrUndefined(this._enumValues)) {
+            variable.setEnum(this._enumValues);
+        }
+
+        server.addVariable(this._variableName, variable);
+        this._created = true;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddServerVariableCommand] Reverting.");
+        if (!this._created) {
+            return;
+        }
+
+        Server server = (Server) NodePathUtil.resolveNodePath(this._serverPath, document);
+        if (this.isNullOrUndefined(server)) {
+            return;
+        }
+
+        server.removeVariable(this._variableName);
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteServerVariableCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteServerVariableCommand.java
@@ -1,0 +1,87 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.Server;
+import io.apicurio.datamodels.models.ServerVariable;
+import io.apicurio.datamodels.models.openapi.OpenApiServer;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A command used to delete a variable from a server.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteServerVariableCommand extends AbstractCommand {
+
+    public NodePath _serverPath;
+    public String _variableName;
+
+    public ObjectNode _oldVariable;
+    public int _oldIndex;
+
+    public DeleteServerVariableCommand() {
+    }
+
+    public DeleteServerVariableCommand(OpenApiServer server, String variableName) {
+        this._serverPath = NodePathUtil.createNodePath((Node) server);
+        this._variableName = variableName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteServerVariableCommand] Executing.");
+        this._oldVariable = null;
+
+        Server server = (Server) NodePathUtil.resolveNodePath(this._serverPath, document);
+        if (this.isNullOrUndefined(server)) {
+            return;
+        }
+
+        Map<String, ? extends ServerVariable> variables = (Map<String, ? extends ServerVariable>) server.getVariables();
+        if (this.isNullOrUndefined(variables) || !variables.containsKey(this._variableName)) {
+            return;
+        }
+
+        // Save the variable and its index for undo
+        ServerVariable variable = variables.get(this._variableName);
+        this._oldVariable = Library.writeNode(variable);
+        List<String> variableNames = new ArrayList<>(variables.keySet());
+        this._oldIndex = variableNames.indexOf(this._variableName);
+
+        // Remove the variable
+        server.removeVariable(this._variableName);
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteServerVariableCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldVariable)) {
+            return;
+        }
+
+        Server server = (Server) NodePathUtil.resolveNodePath(this._serverPath, document);
+        if (this.isNullOrUndefined(server)) {
+            return;
+        }
+
+        ServerVariable newVariable = server.createServerVariable();
+        Library.readNode(this._oldVariable, newVariable);
+        server.insertVariable(this._variableName, newVariable, this._oldIndex);
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -20,6 +20,7 @@ import {AddSchemaPropertyCommand} from "../cmd/commands/AddSchemaPropertyCommand
 import {AddSecurityRequirementCommand} from "../cmd/commands/AddSecurityRequirementCommand";
 import {AddSecuritySchemeCommand} from "../cmd/commands/AddSecuritySchemeCommand";
 import {AddServerCommand} from "../cmd/commands/AddServerCommand";
+import {AddServerVariableCommand} from "../cmd/commands/AddServerVariableCommand";
 import {AddTagCommand} from "../cmd/commands/AddTagCommand";
 
 import {ChangeContactCommand} from "../cmd/commands/ChangeContactCommand";
@@ -64,6 +65,7 @@ import {DeleteSchemaPropertyCommand} from "../cmd/commands/DeleteSchemaPropertyC
 import {DeleteSecurityRequirementCommand} from "../cmd/commands/DeleteSecurityRequirementCommand";
 import {DeleteSecuritySchemeCommand} from "../cmd/commands/DeleteSecuritySchemeCommand";
 import {DeleteServerCommand} from "../cmd/commands/DeleteServerCommand";
+import {DeleteServerVariableCommand} from "../cmd/commands/DeleteServerVariableCommand";
 import {DeleteTagCommand} from "../cmd/commands/DeleteTagCommand";
 
 import {EnsureChildNodeCommand} from "../cmd/commands/EnsureChildNodeCommand";
@@ -84,7 +86,7 @@ import {UpdateSecuritySchemeCommand} from "../cmd/commands/UpdateSecuritySchemeC
 
 const pathKeys: string[] = [
     "_mediaTypePath", "_responsePath", "_responsesPath", "_parentPath", "_schemaPath", "_parameterPath", "_operationPath",
-    "_propPath", "_propertyPath", "_paramPath", "_nodePath", "_headerPath", "_messagePath", "_pathItemPath"
+    "_propPath", "_propertyPath", "_paramPath", "_nodePath", "_headerPath", "_messagePath", "_pathItemPath", "_serverPath"
 ];
 const pathListKeys: string[] = [ "_references" ];
 const cmdListKeys: string[] = [ "_commands" ];
@@ -110,6 +112,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "AddSecurityRequirementCommand": () => { return new AddSecurityRequirementCommand(); },
     "AddSecuritySchemeCommand": () => { return new AddSecuritySchemeCommand(); },
     "AddServerCommand": () => { return new AddServerCommand(); },
+    "AddServerVariableCommand": () => { return new AddServerVariableCommand(); },
     "AddTagCommand": () => { return new AddTagCommand(); },
 
     "ChangeContactCommand": () => { return new ChangeContactCommand(); },
@@ -154,6 +157,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteSecurityRequirementCommand": () => { return new DeleteSecurityRequirementCommand(); },
     "DeleteSecuritySchemeCommand": () => { return new DeleteSecuritySchemeCommand(); },
     "DeleteServerCommand": () => { return new DeleteServerCommand(); },
+    "DeleteServerVariableCommand": () => { return new DeleteServerVariableCommand(); },
     "DeleteTagCommand": () => { return new DeleteTagCommand(); },
 
     "EnsureChildNodeCommand": () => { return new EnsureChildNodeCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.after.json
@@ -1,0 +1,33 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{environment}.api.example.com/{version}",
+      "description": "Main API server",
+      "variables": {
+        "environment": {
+          "default": "production",
+          "description": "The deployment environment",
+          "enum": [
+            "production",
+            "staging",
+            "development"
+          ]
+        },
+        "version": {
+          "default": "v1",
+          "description": "API version",
+          "enum": [
+            "v1",
+            "v2"
+          ]
+        }
+      }
+    }
+  ],
+  "paths": {}
+}

--- a/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.before.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{environment}.api.example.com/{version}",
+      "description": "Main API server",
+      "variables": {
+        "environment": {
+          "default": "production",
+          "description": "The deployment environment",
+          "enum": [
+            "production",
+            "staging",
+            "development"
+          ]
+        }
+      }
+    }
+  ],
+  "paths": {}
+}

--- a/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-server-variable/openapi-3/add-server-variable.commands.json
@@ -1,0 +1,10 @@
+[
+    {
+        "__type": "AddServerVariableCommand",
+        "_serverPath": "/servers[0]",
+        "_variableName": "version",
+        "_defaultValue": "v1",
+        "_description": "API version",
+        "_enumValues": ["v1", "v2"]
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.after.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{environment}.api.example.com/{version}",
+      "description": "Main API server",
+      "variables": {
+        "version": {
+          "default": "v1",
+          "description": "API version",
+          "enum": [
+            "v1",
+            "v2"
+          ]
+        }
+      }
+    }
+  ],
+  "paths": {}
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.before.json
@@ -1,0 +1,33 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{environment}.api.example.com/{version}",
+      "description": "Main API server",
+      "variables": {
+        "environment": {
+          "default": "production",
+          "description": "The deployment environment",
+          "enum": [
+            "production",
+            "staging",
+            "development"
+          ]
+        },
+        "version": {
+          "default": "v1",
+          "description": "API version",
+          "enum": [
+            "v1",
+            "v2"
+          ]
+        }
+      }
+    }
+  ],
+  "paths": {}
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-server-variable/openapi-3/delete-server-variable.commands.json
@@ -1,0 +1,5 @@
+[{
+    "__type": "DeleteServerVariableCommand",
+    "_serverPath": "/servers[0]",
+    "_variableName": "environment"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -111,6 +111,8 @@
     { "name": "[OpenAPI 3] {Delete Server} - Delete Server Document", "test": "commands/delete-server/openapi-3/delete-server-document" },
     { "name": "[OpenAPI 3] {Delete Server} - Delete Server Operation", "test": "commands/delete-server/openapi-3/delete-server-operation" },
     { "name": "[OpenAPI 3] {Delete Server} - Delete Server Path Item", "test": "commands/delete-server/openapi-3/delete-server-pathItem" },
+    { "name": "[OpenAPI 3] {Add Server Variable} - Add Server Variable", "test": "commands/add-server-variable/openapi-3/add-server-variable" },
+    { "name": "[OpenAPI 3] {Delete Server Variable} - Delete Server Variable", "test": "commands/delete-server-variable/openapi-3/delete-server-variable" },
     { "name": "[OpenAPI 3] {Create Path} - Create Path", "test": "commands/create-path/openapi-3/create-path" },
     { "name": "[OpenAPI 3] {Delete Path} - Delete Path", "test": "commands/delete-path/openapi-3/delete-path" },
     { "name": "[OpenAPI 3] {Create Operation} - Create Operation", "test": "commands/create-operation/openapi-3/create-operation" },


### PR DESCRIPTION
## Summary

- Add `AddServerVariableCommand` to add template variables (with default, description, and enum values) to OAS 3.x server definitions
- Add `DeleteServerVariableCommand` to remove server variables, with full undo support via serialization and index tracking
- Register both commands in `CommandFactory` (Java) and `CommandUtil` (TypeScript), and add test fixtures

## Related Issue

Fixes #998

## Test Plan

- [ ] Verify `build.sh` passes (Java compilation, TypeScript transpilation, all tests)
- [ ] Verify add-server-variable test: loads a server with one variable, adds a second, and confirms the expected output
- [ ] Verify delete-server-variable test: loads a server with two variables, deletes one, and confirms the expected output
- [ ] Verify undo for both commands restores the original document state