### PR TITLE
Add DeleteHeaderDefinitionCommand for removing reusable header definitions (#988)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -53,6 +53,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteHeaderDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeletePathCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteRequestBodyCommand;
@@ -169,6 +170,15 @@ public class CommandFactory {
      */
     public static ICommand createDeleteParameterDefinitionCommand(String definitionName) {
         return new DeleteParameterDefinitionCommand(definitionName);
+    }
+
+    /**
+     * Creates a command to delete a reusable header definition.
+     * @param definitionName the name of the header definition to delete
+     * @return the command
+     */
+    public static ICommand createDeleteHeaderDefinitionCommand(String definitionName) {
+        return new DeleteHeaderDefinitionCommand(definitionName);
     }
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteHeaderDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteHeaderDefinitionCommand.java
@@ -1,0 +1,103 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiHeader;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to delete a single reusable header definition from a document.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteHeaderDefinitionCommand extends AbstractCommand {
+
+    public String _definitionName;
+
+    public ObjectNode _oldDefinition;
+    public int _oldIndex;
+
+    public DeleteHeaderDefinitionCommand() {
+    }
+
+    public DeleteHeaderDefinitionCommand(String definitionName) {
+        this._definitionName = definitionName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteHeaderDefinitionCommand] Executing.");
+        this._oldDefinition = null;
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getHeaders())) {
+                return;
+            }
+            OpenApiHeader header = components.getHeaders().get(this._definitionName);
+            if (!this.isNullOrUndefined(header)) {
+                this._oldDefinition = Library.writeNode((Node) header);
+                List<String> headerNames = new ArrayList<>(components.getHeaders().keySet());
+                this._oldIndex = headerNames.indexOf(this._definitionName);
+                components.removeHeader(this._definitionName);
+            }
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getHeaders())) {
+                return;
+            }
+            OpenApiHeader header = components.getHeaders().get(this._definitionName);
+            if (!this.isNullOrUndefined(header)) {
+                this._oldDefinition = Library.writeNode((Node) header);
+                List<String> headerNames = new ArrayList<>(components.getHeaders().keySet());
+                this._oldIndex = headerNames.indexOf(this._definitionName);
+                components.removeHeader(this._definitionName);
+            }
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteHeaderDefinitionCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldDefinition)) {
+            return;
+        }
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi30Document) document).createComponents();
+                ((OpenApi30Document) document).setComponents(components);
+            }
+            OpenApiHeader header = components.createHeader();
+            Library.readNode(this._oldDefinition, header);
+            components.insertHeader(this._definitionName, header, this._oldIndex);
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi31Document) document).createComponents();
+                ((OpenApi31Document) document).setComponents(components);
+            }
+            OpenApiHeader header = components.createHeader();
+            Library.readNode(this._oldDefinition, header);
+            components.insertHeader(this._definitionName, header, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -56,6 +56,7 @@ import {DeleteMediaTypeCommand} from "../cmd/commands/DeleteMediaTypeCommand";
 import {DeleteOperationCommand} from "../cmd/commands/DeleteOperationCommand";
 import {DeleteOperationSecurityRequirementCommand} from "../cmd/commands/DeleteOperationSecurityRequirementCommand";
 import {DeleteParameterCommand} from "../cmd/commands/DeleteParameterCommand";
+import {DeleteHeaderDefinitionCommand} from "../cmd/commands/DeleteHeaderDefinitionCommand";
 import {DeleteParameterDefinitionCommand} from "../cmd/commands/DeleteParameterDefinitionCommand";
 import {DeletePathCommand} from "../cmd/commands/DeletePathCommand";
 import {DeleteRequestBodyCommand} from "../cmd/commands/DeleteRequestBodyCommand";
@@ -149,6 +150,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteOperationCommand": () => { return new DeleteOperationCommand(); },
     "DeleteOperationSecurityRequirementCommand": () => { return new DeleteOperationSecurityRequirementCommand(); },
     "DeleteParameterCommand": () => { return new DeleteParameterCommand(); },
+    "DeleteHeaderDefinitionCommand": () => { return new DeleteHeaderDefinitionCommand(); },
     "DeleteParameterDefinitionCommand": () => { return new DeleteParameterDefinitionCommand(); },
     "DeletePathCommand": () => { return new DeletePathCommand(); },
     "DeleteRequestBodyCommand": () => { return new DeleteRequestBodyCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.after.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "headers": {
+      "X-Rate-Limit": {
+        "description": "The number of allowed requests in the current period",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.before.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "headers": {
+      "X-Rate-Limit": {
+        "description": "The number of allowed requests in the current period",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "X-Request-Id": {
+        "description": "A unique identifier for the request",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-header-definition/openapi-3/delete-header-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteHeaderDefinitionCommand",
+    "_definitionName": "X-Request-Id"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -84,6 +84,7 @@
     { "name": "[OpenAPI 3] {Add Header Definition} - Add Header Definition (no components)", "test": "commands/add-header-definition/openapi-3/add-header-definition-no-components" },
     { "name": "[OpenAPI 2] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-2/delete-parameter-definition" },
     { "name": "[OpenAPI 3] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-3/delete-parameter-definition" },
+    { "name": "[OpenAPI 3] {Delete Header Definition} - Delete Header Definition", "test": "commands/delete-header-definition/openapi-3/delete-header-definition" },
     { "name": "[OpenAPI 3] {Add Example Definition} - Add Example Definition", "test": "commands/add-example-definition/openapi-3/add-example-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },


### PR DESCRIPTION
## Summary
- Add `DeleteHeaderDefinitionCommand` to remove reusable header definitions from `components/headers` in OAS 3.x documents
- Register the command in `CommandFactory` (Java) and `CommandUtil` (TypeScript) for marshalling/unmarshalling
- Add test fixtures and register the test case in `tests.json`

## Related Issue
Fixes #988

## Test Plan
- [x] Build passes (`./build.sh`) including Java compilation, TypeScript transpilation, and all tests
- [ ] Verify the command correctly removes a header definition from components
- [ ] Verify undo restores the header definition at the correct index