### PR TITLE
Add DeleteRequestBodyDefinitionCommand for removing reusable request body definitions (#992)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -55,6 +55,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteOperationSecurityRequirementCom
 import io.apicurio.datamodels.cmd.commands.DeleteParameterCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteHeaderDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterDefinitionCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteRequestBodyDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeletePathCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteRequestBodyCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteResponseCommand;
@@ -179,6 +180,15 @@ public class CommandFactory {
      */
     public static ICommand createDeleteHeaderDefinitionCommand(String definitionName) {
         return new DeleteHeaderDefinitionCommand(definitionName);
+    }
+
+    /**
+     * Creates a command to delete a reusable request body definition.
+     * @param definitionName the name of the request body definition to delete
+     * @return the command
+     */
+    public static ICommand createDeleteRequestBodyDefinitionCommand(String definitionName) {
+        return new DeleteRequestBodyDefinitionCommand(definitionName);
     }
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteRequestBodyDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteRequestBodyDefinitionCommand.java
@@ -1,0 +1,103 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiRequestBody;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to delete a single reusable request body definition from a document.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteRequestBodyDefinitionCommand extends AbstractCommand {
+
+    public String _definitionName;
+
+    public ObjectNode _oldDefinition;
+    public int _oldIndex;
+
+    public DeleteRequestBodyDefinitionCommand() {
+    }
+
+    public DeleteRequestBodyDefinitionCommand(String definitionName) {
+        this._definitionName = definitionName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteRequestBodyDefinitionCommand] Executing.");
+        this._oldDefinition = null;
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getRequestBodies())) {
+                return;
+            }
+            OpenApiRequestBody requestBody = components.getRequestBodies().get(this._definitionName);
+            if (!this.isNullOrUndefined(requestBody)) {
+                this._oldDefinition = Library.writeNode((Node) requestBody);
+                List<String> requestBodyNames = new ArrayList<>(components.getRequestBodies().keySet());
+                this._oldIndex = requestBodyNames.indexOf(this._definitionName);
+                components.removeRequestBody(this._definitionName);
+            }
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getRequestBodies())) {
+                return;
+            }
+            OpenApiRequestBody requestBody = components.getRequestBodies().get(this._definitionName);
+            if (!this.isNullOrUndefined(requestBody)) {
+                this._oldDefinition = Library.writeNode((Node) requestBody);
+                List<String> requestBodyNames = new ArrayList<>(components.getRequestBodies().keySet());
+                this._oldIndex = requestBodyNames.indexOf(this._definitionName);
+                components.removeRequestBody(this._definitionName);
+            }
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteRequestBodyDefinitionCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldDefinition)) {
+            return;
+        }
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi30Document) document).createComponents();
+                ((OpenApi30Document) document).setComponents(components);
+            }
+            OpenApiRequestBody requestBody = components.createRequestBody();
+            Library.readNode(this._oldDefinition, requestBody);
+            components.insertRequestBody(this._definitionName, requestBody, this._oldIndex);
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi31Document) document).createComponents();
+                ((OpenApi31Document) document).setComponents(components);
+            }
+            OpenApiRequestBody requestBody = components.createRequestBody();
+            Library.readNode(this._oldDefinition, requestBody);
+            components.insertRequestBody(this._definitionName, requestBody, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -58,6 +58,7 @@ import {DeleteOperationSecurityRequirementCommand} from "../cmd/commands/DeleteO
 import {DeleteParameterCommand} from "../cmd/commands/DeleteParameterCommand";
 import {DeleteHeaderDefinitionCommand} from "../cmd/commands/DeleteHeaderDefinitionCommand";
 import {DeleteParameterDefinitionCommand} from "../cmd/commands/DeleteParameterDefinitionCommand";
+import {DeleteRequestBodyDefinitionCommand} from "../cmd/commands/DeleteRequestBodyDefinitionCommand";
 import {DeletePathCommand} from "../cmd/commands/DeletePathCommand";
 import {DeleteRequestBodyCommand} from "../cmd/commands/DeleteRequestBodyCommand";
 import {DeleteResponseCommand} from "../cmd/commands/DeleteResponseCommand";
@@ -154,6 +155,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteParameterDefinitionCommand": () => { return new DeleteParameterDefinitionCommand(); },
     "DeletePathCommand": () => { return new DeletePathCommand(); },
     "DeleteRequestBodyCommand": () => { return new DeleteRequestBodyCommand(); },
+    "DeleteRequestBodyDefinitionCommand": () => { return new DeleteRequestBodyDefinitionCommand(); },
     "DeleteResponseCommand": () => { return new DeleteResponseCommand(); },
     "DeleteResponseHeaderCommand": () => { return new DeleteResponseHeaderCommand(); },
     "DeleteSchemaCommand": () => { return new DeleteSchemaCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.after.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "requestBodies": {
+      "UserBody": {
+        "description": "A request body containing user information",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.before.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "requestBodies": {
+      "UserBody": {
+        "description": "A request body containing user information",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "PetBody": {
+        "description": "A request body containing pet information",
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "petName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteRequestBodyDefinitionCommand",
+    "_definitionName": "PetBody"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -85,6 +85,7 @@
     { "name": "[OpenAPI 2] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-2/delete-parameter-definition" },
     { "name": "[OpenAPI 3] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-3/delete-parameter-definition" },
     { "name": "[OpenAPI 3] {Delete Header Definition} - Delete Header Definition", "test": "commands/delete-header-definition/openapi-3/delete-header-definition" },
+    { "name": "[OpenAPI 3] {Delete Request Body Definition} - Delete Request Body Definition", "test": "commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition" },
     { "name": "[OpenAPI 3] {Add Example Definition} - Add Example Definition", "test": "commands/add-example-definition/openapi-3/add-example-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },


### PR DESCRIPTION
## Summary

- Add `DeleteRequestBodyDefinitionCommand` to delete reusable request body definitions from `components/requestBodies` in OAS 3.0/3.1 documents
- Register the command in `CommandFactory` (Java) and `CommandUtil` (TypeScript) for serialization/deserialization support
- Add test fixtures and test entry for execute and undo verification

## Related Issue

Fixes #992

## Test Plan

- [x] Build passes (`build.sh` — all 702 tests pass, 0 failures)
- [ ] Run `mvn test -pl . -Dtest=CommandTest` to verify command execute and undo
- [ ] Verify the command correctly removes a request body definition from components
- [ ] Verify undo restores the removed definition at the original index