### PR TITLE
Add DeleteExampleDefinitionCommand for removing reusable example definitions (#990)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -53,6 +53,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteExampleDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteHeaderDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteParameterDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteRequestBodyDefinitionCommand;
@@ -190,6 +191,15 @@ public class CommandFactory {
      */
     public static ICommand createDeleteRequestBodyDefinitionCommand(String definitionName) {
         return new DeleteRequestBodyDefinitionCommand(definitionName);
+    }
+
+    /**
+     * Creates a command to delete a reusable example definition.
+     * @param definitionName the name of the example definition to delete
+     * @return the command
+     */
+    public static ICommand createDeleteExampleDefinitionCommand(String definitionName) {
+        return new DeleteExampleDefinitionCommand(definitionName);
     }
 
     public static ICommand createAddSchemaDefinitionCommand(String definitionName, ObjectNode from) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteExampleDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteExampleDefinitionCommand.java
@@ -1,0 +1,103 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiExample;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command used to delete a single reusable example definition from a document.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteExampleDefinitionCommand extends AbstractCommand {
+
+    public String _definitionName;
+
+    public ObjectNode _oldDefinition;
+    public int _oldIndex;
+
+    public DeleteExampleDefinitionCommand() {
+    }
+
+    public DeleteExampleDefinitionCommand(String definitionName) {
+        this._definitionName = definitionName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteExampleDefinitionCommand] Executing.");
+        this._oldDefinition = null;
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getExamples())) {
+                return;
+            }
+            OpenApiExample example = components.getExamples().get(this._definitionName);
+            if (!this.isNullOrUndefined(example)) {
+                this._oldDefinition = Library.writeNode((Node) example);
+                List<String> exampleNames = new ArrayList<>(components.getExamples().keySet());
+                this._oldIndex = exampleNames.indexOf(this._definitionName);
+                components.removeExample(this._definitionName);
+            }
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components) || this.isNullOrUndefined(components.getExamples())) {
+                return;
+            }
+            OpenApiExample example = components.getExamples().get(this._definitionName);
+            if (!this.isNullOrUndefined(example)) {
+                this._oldDefinition = Library.writeNode((Node) example);
+                List<String> exampleNames = new ArrayList<>(components.getExamples().keySet());
+                this._oldIndex = exampleNames.indexOf(this._definitionName);
+                components.removeExample(this._definitionName);
+            }
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteExampleDefinitionCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldDefinition)) {
+            return;
+        }
+
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            OpenApi30Components components = ((OpenApi30Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi30Document) document).createComponents();
+                ((OpenApi30Document) document).setComponents(components);
+            }
+            OpenApiExample example = components.createExample();
+            Library.readNode(this._oldDefinition, example);
+            components.insertExample(this._definitionName, example, this._oldIndex);
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
+            OpenApi31Components components = ((OpenApi31Document) document).getComponents();
+            if (this.isNullOrUndefined(components)) {
+                components = ((OpenApi31Document) document).createComponents();
+                ((OpenApi31Document) document).setComponents(components);
+            }
+            OpenApiExample example = components.createExample();
+            Library.readNode(this._oldDefinition, example);
+            components.insertExample(this._definitionName, example, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -56,6 +56,7 @@ import {DeleteMediaTypeCommand} from "../cmd/commands/DeleteMediaTypeCommand";
 import {DeleteOperationCommand} from "../cmd/commands/DeleteOperationCommand";
 import {DeleteOperationSecurityRequirementCommand} from "../cmd/commands/DeleteOperationSecurityRequirementCommand";
 import {DeleteParameterCommand} from "../cmd/commands/DeleteParameterCommand";
+import {DeleteExampleDefinitionCommand} from "../cmd/commands/DeleteExampleDefinitionCommand";
 import {DeleteHeaderDefinitionCommand} from "../cmd/commands/DeleteHeaderDefinitionCommand";
 import {DeleteParameterDefinitionCommand} from "../cmd/commands/DeleteParameterDefinitionCommand";
 import {DeleteRequestBodyDefinitionCommand} from "../cmd/commands/DeleteRequestBodyDefinitionCommand";
@@ -152,6 +153,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteOperationCommand": () => { return new DeleteOperationCommand(); },
     "DeleteOperationSecurityRequirementCommand": () => { return new DeleteOperationSecurityRequirementCommand(); },
     "DeleteParameterCommand": () => { return new DeleteParameterCommand(); },
+    "DeleteExampleDefinitionCommand": () => { return new DeleteExampleDefinitionCommand(); },
     "DeleteHeaderDefinitionCommand": () => { return new DeleteHeaderDefinitionCommand(); },
     "DeleteParameterDefinitionCommand": () => { return new DeleteParameterDefinitionCommand(); },
     "DeletePathCommand": () => { return new DeletePathCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.after.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "examples": {
+      "ExampleToKeep": {
+        "summary": "An example to keep",
+        "value": {
+          "name": "Keeper",
+          "color": "blue"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.before.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "examples": {
+      "ExampleToKeep": {
+        "summary": "An example to keep",
+        "value": {
+          "name": "Keeper",
+          "color": "blue"
+        }
+      },
+      "ExampleToDelete": {
+        "summary": "An example to delete",
+        "value": {
+          "name": "Goner",
+          "color": "red"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-example-definition/openapi-3/delete-example-definition.commands.json
@@ -1,0 +1,4 @@
+[{
+    "__type": "DeleteExampleDefinitionCommand",
+    "_definitionName": "ExampleToDelete"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -87,6 +87,7 @@
     { "name": "[OpenAPI 3] {Delete Header Definition} - Delete Header Definition", "test": "commands/delete-header-definition/openapi-3/delete-header-definition" },
     { "name": "[OpenAPI 3] {Delete Request Body Definition} - Delete Request Body Definition", "test": "commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition" },
     { "name": "[OpenAPI 3] {Add Example Definition} - Add Example Definition", "test": "commands/add-example-definition/openapi-3/add-example-definition" },
+    { "name": "[OpenAPI 3] {Delete Example Definition} - Delete Example Definition", "test": "commands/delete-example-definition/openapi-3/delete-example-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Clone Definition", "test": "commands/add-definition/openapi-2/clone-definition" },
     { "name": "[OpenAPI 3] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-3/add-definition" },


### PR DESCRIPTION
## Summary

- Add `DeleteExampleDefinitionCommand` to delete reusable example definitions from `components/examples` in OAS 3.0 and 3.1 documents
- Add `createDeleteExampleDefinitionCommand` factory method to `CommandFactory`
- Register the command in the TypeScript `CommandUtil` for serialization/deserialization support

## Related Issue

Fixes #990

## Test Plan

- [x] Java command test passes (execute + undo) with new fixture
- [x] TypeScript marshall test passes
- [x] Full build (`build.sh`) passes with all 708 tests green