### PR TITLE
Add SetExternalDocsCommand for setting external documentation on any node (#997)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -76,6 +76,7 @@ import io.apicurio.datamodels.cmd.commands.ReplacePathItemCommand;
 import io.apicurio.datamodels.cmd.commands.ReplaceResponseDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.ReplaceSchemaDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.ReplaceSecurityRequirementCommand;
+import io.apicurio.datamodels.cmd.commands.SetExternalDocsCommand;
 import io.apicurio.datamodels.cmd.commands.UpdateNodeCommand;
 import io.apicurio.datamodels.cmd.commands.UpdateSecuritySchemeCommand;
 import io.apicurio.datamodels.models.Extensible;
@@ -272,6 +273,17 @@ public class CommandFactory {
 
     public static ICommand createChangeLicenseCommand(String name, String url) {
         return new ChangeLicenseCommand(name, url);
+    }
+
+    /**
+     * Creates a command to set external documentation on a node.
+     * @param parent the parent node (Document, Tag, Operation, or Schema)
+     * @param url the external documentation URL
+     * @param description an optional description
+     * @return the command
+     */
+    public static ICommand createSetExternalDocsCommand(Node parent, String url, String description) {
+        return new SetExternalDocsCommand(parent, url, description);
     }
 
     public static ICommand createDeleteLicenseCommand(Info info) {

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/SetExternalDocsCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/SetExternalDocsCommand.java
@@ -1,0 +1,180 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.ExternalDocumentation;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.Operation;
+import io.apicurio.datamodels.models.Schema;
+import io.apicurio.datamodels.models.Tag;
+import io.apicurio.datamodels.models.openapi.OpenApiDocument;
+import io.apicurio.datamodels.models.openapi.OpenApiExternalDocumentation;
+import io.apicurio.datamodels.models.visitors.CombinedVisitorAdapter;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.NodeUtil;
+
+/**
+ * A command to set external documentation on a node (Document, Tag, Operation, or Schema).
+ * @author eric.wittmann@gmail.com
+ */
+public class SetExternalDocsCommand extends AbstractCommand {
+
+    public NodePath _parentPath;
+    public String _newUrl;
+    public String _newDescription;
+
+    public ObjectNode _oldExternalDocs;
+
+    public SetExternalDocsCommand() {
+    }
+
+    /**
+     * Constructor.
+     * @param parent the parent node (Document, Tag, Operation, or Schema)
+     * @param url the external documentation URL
+     * @param description an optional description
+     */
+    public SetExternalDocsCommand(Node parent, String url, String description) {
+        this._parentPath = NodePathUtil.createNodePath(parent);
+        this._newUrl = url;
+        this._newDescription = description;
+    }
+
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[SetExternalDocsCommand] Executing.");
+        this._oldExternalDocs = null;
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        // Read existing externalDocs for undo
+        ExternalDocsReader reader = new ExternalDocsReader();
+        parent.accept(reader);
+        if (NodeUtil.isDefined(reader.externalDocs)) {
+            this._oldExternalDocs = Library.writeNode(reader.externalDocs);
+        }
+
+        // Create new externalDocs and set properties
+        ExternalDocsCreator creator = new ExternalDocsCreator();
+        parent.accept(creator);
+        creator.externalDocs.setUrl(this._newUrl);
+        creator.externalDocs.setDescription(this._newDescription);
+    }
+
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[SetExternalDocsCommand] Reverting.");
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (NodeUtil.isDefined(this._oldExternalDocs)) {
+            // Restore old externalDocs
+            ExternalDocsCreator creator = new ExternalDocsCreator();
+            parent.accept(creator);
+            Library.readNode(this._oldExternalDocs, creator.externalDocs);
+        } else {
+            // Remove externalDocs (none existed before)
+            ExternalDocsSetter setter = new ExternalDocsSetter(null);
+            parent.accept(setter);
+        }
+    }
+
+    /**
+     * Visitor that reads the existing externalDocs from a parent node.
+     */
+    private static class ExternalDocsReader extends CombinedVisitorAdapter {
+        ExternalDocumentation externalDocs;
+
+        @Override
+        public void visitSchema(Schema node) {
+            externalDocs = node.getExternalDocs();
+        }
+
+        @Override
+        public void visitDocument(Document node) {
+            externalDocs = ((OpenApiDocument) node).getExternalDocs();
+        }
+
+        @Override
+        public void visitOperation(Operation node) {
+            externalDocs = node.getExternalDocs();
+        }
+
+        @Override
+        public void visitTag(Tag node) {
+            externalDocs = node.getExternalDocs();
+        }
+    }
+
+    /**
+     * Visitor that creates a new externalDocs child on a parent node.
+     */
+    private static class ExternalDocsCreator extends CombinedVisitorAdapter {
+        ExternalDocumentation externalDocs;
+
+        @Override
+        public void visitSchema(Schema node) {
+            externalDocs = node.createExternalDocumentation();
+            node.setExternalDocs(externalDocs);
+        }
+
+        @Override
+        public void visitDocument(Document node) {
+            externalDocs = ((OpenApiDocument) node).createExternalDocumentation();
+            ((OpenApiDocument) node).setExternalDocs((OpenApiExternalDocumentation) externalDocs);
+        }
+
+        @Override
+        public void visitOperation(Operation node) {
+            externalDocs = node.createExternalDocumentation();
+            node.setExternalDocs(externalDocs);
+        }
+
+        @Override
+        public void visitTag(Tag node) {
+            externalDocs = node.createExternalDocumentation();
+            node.setExternalDocs(externalDocs);
+        }
+    }
+
+    /**
+     * Visitor that sets externalDocs to a given value (used for setting to null during undo).
+     */
+    private static class ExternalDocsSetter extends CombinedVisitorAdapter {
+        private final ExternalDocumentation value;
+
+        ExternalDocsSetter(ExternalDocumentation value) {
+            this.value = value;
+        }
+
+        @Override
+        public void visitSchema(Schema node) {
+            node.setExternalDocs(value);
+        }
+
+        @Override
+        public void visitDocument(Document node) {
+            ((OpenApiDocument) node).setExternalDocs((OpenApiExternalDocumentation) value);
+        }
+
+        @Override
+        public void visitOperation(Operation node) {
+            node.setExternalDocs(value);
+        }
+
+        @Override
+        public void visitTag(Tag node) {
+            node.setExternalDocs(value);
+        }
+    }
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -83,6 +83,7 @@ import {ReplaceResponseDefinitionCommand} from "../cmd/commands/ReplaceResponseD
 import {ReplaceSchemaDefinitionCommand} from "../cmd/commands/ReplaceSchemaDefinitionCommand";
 import {ReplaceSecurityRequirementCommand} from "../cmd/commands/ReplaceSecurityRequirementCommand";
 
+import {SetExternalDocsCommand} from "../cmd/commands/SetExternalDocsCommand";
 import {SetPropertyCommand} from "../cmd/commands/SetPropertyCommand";
 
 import {UpdateNodeCommand} from "../cmd/commands/UpdateNodeCommand";
@@ -180,6 +181,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "ReplaceSchemaDefinitionCommand": () => { return new ReplaceSchemaDefinitionCommand(); },
     "ReplaceSecurityRequirementCommand": () => { return new ReplaceSecurityRequirementCommand(); },
 
+    "SetExternalDocsCommand": () => { return new SetExternalDocsCommand(); },
     "SetPropertyCommand": () => { return new SetPropertyCommand(); },
 
     "UpdateNodeCommand": () => { return new UpdateNodeCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.after.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.after.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Sample Pet Store App",
+    "description": "This is a sample server for a pet store.",
+    "version": "1.0.1"
+  },
+  "externalDocs": {
+    "description": "Find more info here",
+    "url": "https://example.com/docs"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "A list of pets."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.before.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.before.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Sample Pet Store App",
+    "description": "This is a sample server for a pet store.",
+    "version": "1.0.1"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "A list of pets."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/set-external-docs.commands.json
@@ -1,0 +1,8 @@
+[
+    {
+        "__type": "SetExternalDocsCommand",
+        "_parentPath": "/",
+        "_newUrl": "https://example.com/docs",
+        "_newDescription": "Find more info here"
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.after.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.after.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Sample Pet Store App",
+    "description": "This is a sample server for a pet store.",
+    "version": "1.0.1"
+  },
+  "externalDocs": {
+    "description": "Updated documentation link",
+    "url": "https://example.com/new-docs"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "A list of pets."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.before.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.before.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Sample Pet Store App",
+    "description": "This is a sample server for a pet store.",
+    "version": "1.0.1"
+  },
+  "externalDocs": {
+    "description": "Find more info here",
+    "url": "https://example.com/docs"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "A list of pets."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/set-external-docs/openapi-3/update-external-docs.commands.json
@@ -1,0 +1,8 @@
+[
+    {
+        "__type": "SetExternalDocsCommand",
+        "_parentPath": "/",
+        "_newUrl": "https://example.com/new-docs",
+        "_newDescription": "Updated documentation link"
+    }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -24,6 +24,8 @@
     { "name": "[OpenAPI 2] {Change License} - Change License", "test": "commands/change-license/openapi-2/change-license" },
     { "name": "[OpenAPI 3] {Change License} - Add License", "test": "commands/change-license/openapi-3/add-license" },
     { "name": "[OpenAPI 3] {Change License} - Change License", "test": "commands/change-license/openapi-3/change-license" },
+    { "name": "[OpenAPI 3] {Set External Docs} - Set External Docs", "test": "commands/set-external-docs/openapi-3/set-external-docs" },
+    { "name": "[OpenAPI 3] {Set External Docs} - Update External Docs", "test": "commands/set-external-docs/openapi-3/update-external-docs" },
     { "name": "[OpenAPI 2] {Delete License} - Delete License", "test": "commands/delete-license/openapi-2/delete-license" },
     { "name": "[OpenAPI 3] {Delete License} - Delete License", "test": "commands/delete-license/openapi-3/delete-license" },
     { "name": "[OpenAPI 2] {Delete Contact} - Delete Contact", "test": "commands/delete-contact/openapi-2/delete-contact" },


### PR DESCRIPTION
## Summary

- Add `SetExternalDocsCommand` that sets the `externalDocs` child object on Document, Tag, Operation, or Schema nodes
- Uses NodePath for parent resolution and visitor pattern to handle API differences across parent node types
- Includes factory method in `CommandFactory`, TypeScript registration in `CommandUtil.ts`, and test fixtures for both set and update scenarios

## Related Issue

Fixes #997

## Test Plan

- [x] Java tests pass (including undo verification for single-command tests)
- [x] TypeScript tests pass (command marshalling/unmarshalling roundtrip)
- [x] Full `build.sh` passes successfully
- [ ] Verify set-external-docs test: adds externalDocs to a document that has none
- [ ] Verify update-external-docs test: updates existing externalDocs on a document