### PR TITLE
Add AddLinkCommand and DeleteLinkCommand for OAS 3.x link management. Fixes #996 (#1013)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -7,6 +7,7 @@ import io.apicurio.datamodels.cmd.commands.AddExampleCommand;
 import io.apicurio.datamodels.cmd.commands.AddExampleDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddExtensionCommand;
 import io.apicurio.datamodels.cmd.commands.AddHeaderDefinitionCommand;
+import io.apicurio.datamodels.cmd.commands.AddLinkCommand;
 import io.apicurio.datamodels.cmd.commands.AddMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.AddOperationSecurityRequirementCommand;
 import io.apicurio.datamodels.cmd.commands.AddParameterCommand;
@@ -49,6 +50,7 @@ import io.apicurio.datamodels.cmd.commands.DeleteAllTagsCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteContactCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteExtensionCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteLicenseCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteLinkCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteMediaTypeCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteOperationSecurityRequirementCommand;
@@ -534,6 +536,29 @@ public class CommandFactory {
     public static ICommand createDeleteResponseHeaderCommand(OpenApiHeadersParent response,
                                                              String headerName) {
         return new DeleteResponseHeaderCommand(response, headerName);
+    }
+
+    // --- Link commands ---
+
+    /**
+     * Creates a command to add a link to a response or components.
+     * @param parent the parent node (response or components)
+     * @param linkName the name of the link
+     * @param from the link definition as a JSON object
+     * @return the command
+     */
+    public static ICommand createAddLinkCommand(Node parent, String linkName, ObjectNode from) {
+        return new AddLinkCommand(parent, linkName, from);
+    }
+
+    /**
+     * Creates a command to delete a link from a response or components.
+     * @param parent the parent node (response or components)
+     * @param linkName the name of the link to delete
+     * @return the command
+     */
+    public static ICommand createDeleteLinkCommand(Node parent, String linkName) {
+        return new DeleteLinkCommand(parent, linkName);
     }
 
     // --- Media type commands ---

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddLinkCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddLinkCommand.java
@@ -1,0 +1,118 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiLink;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Link;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Response;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Link;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Response;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+/**
+ * A command used to add a link to a response or to components/links.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddLinkCommand extends AbstractCommand {
+
+    public NodePath _parentPath;
+    public String _linkName;
+    public ObjectNode _from;
+
+    public boolean _created;
+
+    public AddLinkCommand() {
+    }
+
+    public AddLinkCommand(Node parent, String linkName, ObjectNode from) {
+        this._parentPath = NodePathUtil.createNodePath(parent);
+        this._linkName = linkName;
+        this._from = from;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddLinkCommand] Executing.");
+        this._created = false;
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Response) {
+            OpenApi30Response response30 = (OpenApi30Response) parent;
+            if (!this.isNullOrUndefined(response30.getLinks()) && response30.getLinks().containsKey(this._linkName)) {
+                return;
+            }
+            OpenApi30Link link = response30.createLink();
+            Library.readNode(this._from, link);
+            response30.addLink(this._linkName, link);
+            this._created = true;
+        } else if (parent instanceof OpenApi31Response) {
+            OpenApi31Response response31 = (OpenApi31Response) parent;
+            if (!this.isNullOrUndefined(response31.getLinks()) && response31.getLinks().containsKey(this._linkName)) {
+                return;
+            }
+            OpenApi31Link link = response31.createLink();
+            Library.readNode(this._from, link);
+            response31.addLink(this._linkName, link);
+            this._created = true;
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            if (!this.isNullOrUndefined(components30.getLinks()) && components30.getLinks().containsKey(this._linkName)) {
+                return;
+            }
+            OpenApiLink link = components30.createLink();
+            Library.readNode(this._from, link);
+            components30.addLink(this._linkName, link);
+            this._created = true;
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            if (!this.isNullOrUndefined(components31.getLinks()) && components31.getLinks().containsKey(this._linkName)) {
+                return;
+            }
+            OpenApiLink link = components31.createLink();
+            Library.readNode(this._from, link);
+            components31.addLink(this._linkName, link);
+            this._created = true;
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddLinkCommand] Reverting.");
+        if (!this._created) {
+            return;
+        }
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Response) {
+            ((OpenApi30Response) parent).removeLink(this._linkName);
+        } else if (parent instanceof OpenApi31Response) {
+            ((OpenApi31Response) parent).removeLink(this._linkName);
+        } else if (parent instanceof OpenApi30Components) {
+            ((OpenApi30Components) parent).removeLink(this._linkName);
+        } else if (parent instanceof OpenApi31Components) {
+            ((OpenApi31Components) parent).removeLink(this._linkName);
+        }
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteLinkCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteLinkCommand.java
@@ -1,0 +1,141 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiLink;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Link;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Response;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Link;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Response;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A command used to delete a link from a response or from components/links.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteLinkCommand extends AbstractCommand {
+
+    public NodePath _parentPath;
+    public String _linkName;
+
+    public ObjectNode _oldLink;
+    public int _oldIndex;
+
+    public DeleteLinkCommand() {
+    }
+
+    public DeleteLinkCommand(Node parent, String linkName) {
+        this._parentPath = NodePathUtil.createNodePath(parent);
+        this._linkName = linkName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteLinkCommand] Executing.");
+        this._oldLink = null;
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Response) {
+            OpenApi30Response response30 = (OpenApi30Response) parent;
+            Map<String, OpenApi30Link> links = response30.getLinks();
+            if (this.isNullOrUndefined(links) || !links.containsKey(this._linkName)) {
+                return;
+            }
+            OpenApi30Link link = links.get(this._linkName);
+            this._oldLink = Library.writeNode(link);
+            List<String> linkNames = new ArrayList<>(links.keySet());
+            this._oldIndex = linkNames.indexOf(this._linkName);
+            response30.removeLink(this._linkName);
+        } else if (parent instanceof OpenApi31Response) {
+            OpenApi31Response response31 = (OpenApi31Response) parent;
+            Map<String, OpenApi31Link> links = response31.getLinks();
+            if (this.isNullOrUndefined(links) || !links.containsKey(this._linkName)) {
+                return;
+            }
+            OpenApi31Link link = links.get(this._linkName);
+            this._oldLink = Library.writeNode(link);
+            List<String> linkNames = new ArrayList<>(links.keySet());
+            this._oldIndex = linkNames.indexOf(this._linkName);
+            response31.removeLink(this._linkName);
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            Map<String, OpenApiLink> links = components30.getLinks();
+            if (this.isNullOrUndefined(links) || !links.containsKey(this._linkName)) {
+                return;
+            }
+            OpenApiLink link = links.get(this._linkName);
+            this._oldLink = Library.writeNode(link);
+            List<String> linkNames = new ArrayList<>(links.keySet());
+            this._oldIndex = linkNames.indexOf(this._linkName);
+            components30.removeLink(this._linkName);
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            Map<String, OpenApiLink> links = components31.getLinks();
+            if (this.isNullOrUndefined(links) || !links.containsKey(this._linkName)) {
+                return;
+            }
+            OpenApiLink link = links.get(this._linkName);
+            this._oldLink = Library.writeNode(link);
+            List<String> linkNames = new ArrayList<>(links.keySet());
+            this._oldIndex = linkNames.indexOf(this._linkName);
+            components31.removeLink(this._linkName);
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteLinkCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldLink)) {
+            return;
+        }
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Response) {
+            OpenApi30Response response30 = (OpenApi30Response) parent;
+            OpenApi30Link link = response30.createLink();
+            Library.readNode(this._oldLink, link);
+            response30.insertLink(this._linkName, link, this._oldIndex);
+        } else if (parent instanceof OpenApi31Response) {
+            OpenApi31Response response31 = (OpenApi31Response) parent;
+            OpenApi31Link link = response31.createLink();
+            Library.readNode(this._oldLink, link);
+            response31.insertLink(this._linkName, link, this._oldIndex);
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            OpenApiLink link = components30.createLink();
+            Library.readNode(this._oldLink, link);
+            components30.insertLink(this._linkName, link, this._oldIndex);
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            OpenApiLink link = components31.createLink();
+            Library.readNode(this._oldLink, link);
+            components31.insertLink(this._linkName, link, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -7,6 +7,7 @@ import {AddExampleCommand} from "../cmd/commands/AddExampleCommand";
 import {AddExampleDefinitionCommand} from "../cmd/commands/AddExampleDefinitionCommand";
 import {AddExtensionCommand} from "../cmd/commands/AddExtensionCommand";
 import {AddHeaderDefinitionCommand} from "../cmd/commands/AddHeaderDefinitionCommand";
+import {AddLinkCommand} from "../cmd/commands/AddLinkCommand";
 import {AddMediaTypeCommand} from "../cmd/commands/AddMediaTypeCommand";
 import {AddOperationSecurityRequirementCommand} from "../cmd/commands/AddOperationSecurityRequirementCommand";
 import {AddParameterCommand} from "../cmd/commands/AddParameterCommand";
@@ -52,6 +53,7 @@ import {DeleteAllTagsCommand} from "../cmd/commands/DeleteAllTagsCommand";
 import {DeleteContactCommand} from "../cmd/commands/DeleteContactCommand";
 import {DeleteExtensionCommand} from "../cmd/commands/DeleteExtensionCommand";
 import {DeleteLicenseCommand} from "../cmd/commands/DeleteLicenseCommand";
+import {DeleteLinkCommand} from "../cmd/commands/DeleteLinkCommand";
 import {DeleteMediaTypeCommand} from "../cmd/commands/DeleteMediaTypeCommand";
 import {DeleteOperationCommand} from "../cmd/commands/DeleteOperationCommand";
 import {DeleteOperationSecurityRequirementCommand} from "../cmd/commands/DeleteOperationSecurityRequirementCommand";
@@ -105,6 +107,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "AddExampleDefinitionCommand": () => { return new AddExampleDefinitionCommand(); },
     "AddExtensionCommand": () => { return new AddExtensionCommand(); },
     "AddHeaderDefinitionCommand": () => { return new AddHeaderDefinitionCommand(); },
+    "AddLinkCommand": () => { return new AddLinkCommand(); },
     "AddMediaTypeCommand": () => { return new AddMediaTypeCommand(); },
     "AddOperationSecurityRequirementCommand": () => { return new AddOperationSecurityRequirementCommand(); },
     "AddParameterCommand": () => { return new AddParameterCommand(); },
@@ -150,6 +153,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "DeleteContactCommand": () => { return new DeleteContactCommand(); },
     "DeleteExtensionCommand": () => { return new DeleteExtensionCommand(); },
     "DeleteLicenseCommand": () => { return new DeleteLicenseCommand(); },
+    "DeleteLinkCommand": () => { return new DeleteLinkCommand(); },
     "DeleteMediaTypeCommand": () => { return new DeleteMediaTypeCommand(); },
     "DeleteOperationCommand": () => { return new DeleteOperationCommand(); },
     "DeleteOperationSecurityRequirementCommand": () => { return new DeleteOperationSecurityRequirementCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.after.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "links": {
+              "GetFooById": {
+                "operationId": "getFooById",
+                "description": "The `id` value returned in the response can be used as the `fooId` parameter in `GET /foo/{fooId}`."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.before.json
@@ -1,0 +1,16 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-link/openapi-3/add-link.commands.json
@@ -1,0 +1,11 @@
+[
+    {
+        "__type": "AddLinkCommand",
+        "_parentPath": "/paths[/foo]/get/responses[200]",
+        "_linkName": "GetFooById",
+        "_from": {
+            "operationId": "getFooById",
+            "description": "The `id` value returned in the response can be used as the `fooId` parameter in `GET /foo/{fooId}`."
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.after.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "links": {
+              "GetBarById": {
+                "operationId": "getBarById",
+                "description": "Get bar by ID"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.before.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "links": {
+              "GetFooById": {
+                "operationId": "getFooById",
+                "description": "Get foo by ID"
+              },
+              "GetBarById": {
+                "operationId": "getBarById",
+                "description": "Get bar by ID"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-link/openapi-3/delete-link.commands.json
@@ -1,0 +1,5 @@
+[{
+    "__type": "DeleteLinkCommand",
+    "_parentPath": "/paths[/foo]/get/responses[200]",
+    "_linkName": "GetFooById"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -133,6 +133,8 @@
     { "name": "[OpenAPI 3] {Delete Response} - Delete Response", "test": "commands/delete-response/openapi-3/delete-response" },
     { "name": "[OpenAPI 3] {Add Response Header} - Add Response Header", "test": "commands/add-response-header/openapi-3/add-response-header" },
     { "name": "[OpenAPI 3] {Delete Response Header} - Delete Response Header", "test": "commands/delete-response-header/openapi-3/delete-response-header" },
+    { "name": "[OpenAPI 3] {Add Link} - Add Link", "test": "commands/add-link/openapi-3/add-link" },
+    { "name": "[OpenAPI 3] {Delete Link} - Delete Link", "test": "commands/delete-link/openapi-3/delete-link" },
     { "name": "[OpenAPI 3] {Add Media Type} - Add Media Type", "test": "commands/add-media-type/openapi-3/add-media-type" },
     { "name": "[OpenAPI 3] {Change Media Type Schema} - Change Media Type Schema", "test": "commands/change-media-type-schema/openapi-3/change-media-type-schema" },
     { "name": "[OpenAPI 3] {Create Schema} - Create Schema", "test": "commands/create-schema/openapi-3/create-schema" },


### PR DESCRIPTION
## Summary

- Add `AddLinkCommand` to create link definitions on responses (`OpenApi30Response`, `OpenApi31Response`) and components (`OpenApi30Components`, `OpenApi31Components`)
- Add `DeleteLinkCommand` to remove link definitions with full undo support (serializes removed link and restores at original index)
- Register both commands in `CommandFactory` (Java) and `CommandUtil` (TypeScript) with fixture-based tests

## Related Issue

Fixes #996

## Test Plan

- [x] Fixture-based tests for add-link and delete-link (execute + undo verification)
- [x] All 680 tests pass (Java + TypeScript)
- [x] Full build with transpilation succeeds (`build.sh`)