### PR TITLE
Add AddCallbackCommand and DeleteCallbackCommand for OAS 3.x callback management (#995)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -2,6 +2,7 @@ package io.apicurio.datamodels.cmd;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.cmd.commands.AddCallbackCommand;
 import io.apicurio.datamodels.cmd.commands.AddChannelItemCommand;
 import io.apicurio.datamodels.cmd.commands.AddExampleCommand;
 import io.apicurio.datamodels.cmd.commands.AddExampleDefinitionCommand;
@@ -36,6 +37,7 @@ import io.apicurio.datamodels.cmd.commands.ChangeVersionCommand;
 import io.apicurio.datamodels.cmd.commands.CreateOperationCommand;
 import io.apicurio.datamodels.cmd.commands.CreatePathCommand;
 import io.apicurio.datamodels.cmd.commands.CreateSchemaCommand;
+import io.apicurio.datamodels.cmd.commands.DeleteCallbackCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteAllChildSchemasCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteAllExamplesCommand;
 import io.apicurio.datamodels.cmd.commands.DeleteAllHeadersCommand;
@@ -559,6 +561,29 @@ public class CommandFactory {
      */
     public static ICommand createDeleteLinkCommand(Node parent, String linkName) {
         return new DeleteLinkCommand(parent, linkName);
+    }
+
+    // --- Callback commands ---
+
+    /**
+     * Creates a command to add a callback to an operation or components.
+     * @param parent the parent node (operation or components)
+     * @param callbackName the name of the callback
+     * @param from the callback definition as a JSON object
+     * @return the command
+     */
+    public static ICommand createAddCallbackCommand(Node parent, String callbackName, ObjectNode from) {
+        return new AddCallbackCommand(parent, callbackName, from);
+    }
+
+    /**
+     * Creates a command to delete a callback from an operation or components.
+     * @param parent the parent node (operation or components)
+     * @param callbackName the name of the callback to delete
+     * @return the command
+     */
+    public static ICommand createDeleteCallbackCommand(Node parent, String callbackName) {
+        return new DeleteCallbackCommand(parent, callbackName);
     }
 
     // --- Media type commands ---

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddCallbackCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddCallbackCommand.java
@@ -1,0 +1,118 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiCallback;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Callback;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Operation;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Callback;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Operation;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+/**
+ * A command used to add a callback to an operation or to components/callbacks.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddCallbackCommand extends AbstractCommand {
+
+    public NodePath _parentPath;
+    public String _callbackName;
+    public ObjectNode _from;
+
+    public boolean _created;
+
+    public AddCallbackCommand() {
+    }
+
+    public AddCallbackCommand(Node parent, String callbackName, ObjectNode from) {
+        this._parentPath = NodePathUtil.createNodePath(parent);
+        this._callbackName = callbackName;
+        this._from = from;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddCallbackCommand] Executing.");
+        this._created = false;
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Operation) {
+            OpenApi30Operation operation30 = (OpenApi30Operation) parent;
+            if (!this.isNullOrUndefined(operation30.getCallbacks()) && operation30.getCallbacks().containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApi30Callback callback = operation30.createCallback();
+            Library.readNode(this._from, callback);
+            operation30.addCallback(this._callbackName, callback);
+            this._created = true;
+        } else if (parent instanceof OpenApi31Operation) {
+            OpenApi31Operation operation31 = (OpenApi31Operation) parent;
+            if (!this.isNullOrUndefined(operation31.getCallbacks()) && operation31.getCallbacks().containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApi31Callback callback = operation31.createCallback();
+            Library.readNode(this._from, callback);
+            operation31.addCallback(this._callbackName, callback);
+            this._created = true;
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            if (!this.isNullOrUndefined(components30.getCallbacks()) && components30.getCallbacks().containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApiCallback callback = components30.createCallback();
+            Library.readNode(this._from, callback);
+            components30.addCallback(this._callbackName, callback);
+            this._created = true;
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            if (!this.isNullOrUndefined(components31.getCallbacks()) && components31.getCallbacks().containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApiCallback callback = components31.createCallback();
+            Library.readNode(this._from, callback);
+            components31.addCallback(this._callbackName, callback);
+            this._created = true;
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddCallbackCommand] Reverting.");
+        if (!this._created) {
+            return;
+        }
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Operation) {
+            ((OpenApi30Operation) parent).removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi31Operation) {
+            ((OpenApi31Operation) parent).removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi30Components) {
+            ((OpenApi30Components) parent).removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi31Components) {
+            ((OpenApi31Components) parent).removeCallback(this._callbackName);
+        }
+    }
+
+}

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteCallbackCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/DeleteCallbackCommand.java
@@ -1,0 +1,141 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.Node;
+import io.apicurio.datamodels.models.openapi.OpenApiCallback;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Callback;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Operation;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Callback;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Operation;
+import io.apicurio.datamodels.paths.NodePath;
+import io.apicurio.datamodels.paths.NodePathUtil;
+import io.apicurio.datamodels.util.LoggerUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A command used to delete a callback from an operation or from components/callbacks.
+ * @author eric.wittmann@gmail.com
+ */
+public class DeleteCallbackCommand extends AbstractCommand {
+
+    public NodePath _parentPath;
+    public String _callbackName;
+
+    public ObjectNode _oldCallback;
+    public int _oldIndex;
+
+    public DeleteCallbackCommand() {
+    }
+
+    public DeleteCallbackCommand(Node parent, String callbackName) {
+        this._parentPath = NodePathUtil.createNodePath(parent);
+        this._callbackName = callbackName;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[DeleteCallbackCommand] Executing.");
+        this._oldCallback = null;
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Operation) {
+            OpenApi30Operation operation30 = (OpenApi30Operation) parent;
+            Map<String, OpenApi30Callback> callbacks = operation30.getCallbacks();
+            if (this.isNullOrUndefined(callbacks) || !callbacks.containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApi30Callback callback = callbacks.get(this._callbackName);
+            this._oldCallback = Library.writeNode(callback);
+            List<String> callbackNames = new ArrayList<>(callbacks.keySet());
+            this._oldIndex = callbackNames.indexOf(this._callbackName);
+            operation30.removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi31Operation) {
+            OpenApi31Operation operation31 = (OpenApi31Operation) parent;
+            Map<String, OpenApi31Callback> callbacks = operation31.getCallbacks();
+            if (this.isNullOrUndefined(callbacks) || !callbacks.containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApi31Callback callback = callbacks.get(this._callbackName);
+            this._oldCallback = Library.writeNode(callback);
+            List<String> callbackNames = new ArrayList<>(callbacks.keySet());
+            this._oldIndex = callbackNames.indexOf(this._callbackName);
+            operation31.removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            Map<String, OpenApiCallback> callbacks = components30.getCallbacks();
+            if (this.isNullOrUndefined(callbacks) || !callbacks.containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApiCallback callback = callbacks.get(this._callbackName);
+            this._oldCallback = Library.writeNode(callback);
+            List<String> callbackNames = new ArrayList<>(callbacks.keySet());
+            this._oldIndex = callbackNames.indexOf(this._callbackName);
+            components30.removeCallback(this._callbackName);
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            Map<String, OpenApiCallback> callbacks = components31.getCallbacks();
+            if (this.isNullOrUndefined(callbacks) || !callbacks.containsKey(this._callbackName)) {
+                return;
+            }
+            OpenApiCallback callback = callbacks.get(this._callbackName);
+            this._oldCallback = Library.writeNode(callback);
+            List<String> callbackNames = new ArrayList<>(callbacks.keySet());
+            this._oldIndex = callbackNames.indexOf(this._callbackName);
+            components31.removeCallback(this._callbackName);
+        }
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[DeleteCallbackCommand] Reverting.");
+        if (this.isNullOrUndefined(this._oldCallback)) {
+            return;
+        }
+
+        Node parent = NodePathUtil.resolveNodePath(this._parentPath, document);
+        if (this.isNullOrUndefined(parent)) {
+            return;
+        }
+
+        if (parent instanceof OpenApi30Operation) {
+            OpenApi30Operation operation30 = (OpenApi30Operation) parent;
+            OpenApi30Callback callback = operation30.createCallback();
+            Library.readNode(this._oldCallback, callback);
+            operation30.insertCallback(this._callbackName, callback, this._oldIndex);
+        } else if (parent instanceof OpenApi31Operation) {
+            OpenApi31Operation operation31 = (OpenApi31Operation) parent;
+            OpenApi31Callback callback = operation31.createCallback();
+            Library.readNode(this._oldCallback, callback);
+            operation31.insertCallback(this._callbackName, callback, this._oldIndex);
+        } else if (parent instanceof OpenApi30Components) {
+            OpenApi30Components components30 = (OpenApi30Components) parent;
+            OpenApiCallback callback = components30.createCallback();
+            Library.readNode(this._oldCallback, callback);
+            components30.insertCallback(this._callbackName, callback, this._oldIndex);
+        } else if (parent instanceof OpenApi31Components) {
+            OpenApi31Components components31 = (OpenApi31Components) parent;
+            OpenApiCallback callback = components31.createCallback();
+            Library.readNode(this._oldCallback, callback);
+            components31.insertCallback(this._callbackName, callback, this._oldIndex);
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -2,6 +2,7 @@ import {ICommand} from '../cmd/ICommand';
 import {NodePath} from '../paths/NodePath';
 import {NodePathUtil} from "../paths/NodePathUtil";
 
+import {AddCallbackCommand} from "../cmd/commands/AddCallbackCommand";
 import {AddChannelItemCommand} from "../cmd/commands/AddChannelItemCommand";
 import {AddExampleCommand} from "../cmd/commands/AddExampleCommand";
 import {AddExampleDefinitionCommand} from "../cmd/commands/AddExampleDefinitionCommand";
@@ -38,6 +39,7 @@ import {CreateOperationCommand} from "../cmd/commands/CreateOperationCommand";
 import {CreatePathCommand} from "../cmd/commands/CreatePathCommand";
 import {CreateSchemaCommand} from "../cmd/commands/CreateSchemaCommand";
 
+import {DeleteCallbackCommand} from "../cmd/commands/DeleteCallbackCommand";
 import {DeleteAllChildSchemasCommand} from "../cmd/commands/DeleteAllChildSchemasCommand";
 import {DeleteAllExamplesCommand} from "../cmd/commands/DeleteAllExamplesCommand";
 import {DeleteAllExtensionsCommand} from "../cmd/commands/DeleteAllExtensionsCommand";
@@ -102,6 +104,7 @@ const cmdListKeys: string[] = [ "_commands" ];
 type Supplier = () => ICommand;
 
 const commandSuppliers: { [key: string]: Supplier } = {
+    "AddCallbackCommand": () => { return new AddCallbackCommand(); },
     "AddChannelItemCommand": () => { return new AddChannelItemCommand(); },
     "AddExampleCommand": () => { return new AddExampleCommand(); },
     "AddExampleDefinitionCommand": () => { return new AddExampleDefinitionCommand(); },
@@ -138,6 +141,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "CreatePathCommand": () => { return new CreatePathCommand(); },
     "CreateSchemaCommand": () => { return new CreateSchemaCommand(); },
 
+    "DeleteCallbackCommand": () => { return new DeleteCallbackCommand(); },
     "DeleteAllChildSchemasCommand": () => { return new DeleteAllChildSchemasCommand(); },
     "DeleteAllExamplesCommand": () => { return new DeleteAllExamplesCommand(); },
     "DeleteAllExtensionsCommand": () => { return new DeleteAllExtensionsCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.after.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "callbacks": {
+          "onFooEvent": {
+            "{$request.body#/callbackUrl}": {
+              "post": {
+                "summary": "Foo Event Callback",
+                "responses": {
+                  "200": {
+                    "description": "Callback processed"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.before.json
@@ -1,0 +1,16 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-callback/openapi-3/add-callback.commands.json
@@ -1,0 +1,19 @@
+[
+    {
+        "__type": "AddCallbackCommand",
+        "_parentPath": "/paths[/foo]/get",
+        "_callbackName": "onFooEvent",
+        "_from": {
+            "{$request.body#/callbackUrl}": {
+                "post": {
+                    "summary": "Foo Event Callback",
+                    "responses": {
+                        "200": {
+                            "description": "Callback processed"
+                        }
+                    }
+                }
+            }
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.after.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.after.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "callbacks": {
+          "onBarEvent": {
+            "{$request.body#/barUrl}": {
+              "post": {
+                "summary": "Bar Event Callback",
+                "responses": {
+                  "200": {
+                    "description": "Callback processed"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.before.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.before.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Get Foo",
+        "operationId": "getFoo",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "callbacks": {
+          "onFooEvent": {
+            "{$request.body#/callbackUrl}": {
+              "post": {
+                "summary": "Foo Event Callback",
+                "responses": {
+                  "200": {
+                    "description": "Callback processed"
+                  }
+                }
+              }
+            }
+          },
+          "onBarEvent": {
+            "{$request.body#/barUrl}": {
+              "post": {
+                "summary": "Bar Event Callback",
+                "responses": {
+                  "200": {
+                    "description": "Callback processed"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/delete-callback/openapi-3/delete-callback.commands.json
@@ -1,0 +1,5 @@
+[{
+    "__type": "DeleteCallbackCommand",
+    "_parentPath": "/paths[/foo]/get",
+    "_callbackName": "onFooEvent"
+}]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -135,6 +135,8 @@
     { "name": "[OpenAPI 3] {Delete Response Header} - Delete Response Header", "test": "commands/delete-response-header/openapi-3/delete-response-header" },
     { "name": "[OpenAPI 3] {Add Link} - Add Link", "test": "commands/add-link/openapi-3/add-link" },
     { "name": "[OpenAPI 3] {Delete Link} - Delete Link", "test": "commands/delete-link/openapi-3/delete-link" },
+    { "name": "[OpenAPI 3] {Add Callback} - Add Callback", "test": "commands/add-callback/openapi-3/add-callback" },
+    { "name": "[OpenAPI 3] {Delete Callback} - Delete Callback", "test": "commands/delete-callback/openapi-3/delete-callback" },
     { "name": "[OpenAPI 3] {Add Media Type} - Add Media Type", "test": "commands/add-media-type/openapi-3/add-media-type" },
     { "name": "[OpenAPI 3] {Change Media Type Schema} - Change Media Type Schema", "test": "commands/change-media-type-schema/openapi-3/change-media-type-schema" },
     { "name": "[OpenAPI 3] {Create Schema} - Create Schema", "test": "commands/create-schema/openapi-3/create-schema" },


### PR DESCRIPTION
## Summary

- Add `AddCallbackCommand` to add a callback definition to an OAS 3.0/3.1 operation or `components/callbacks`
- Add `DeleteCallbackCommand` to remove a callback definition by name, with full undo support
- Register both commands in `CommandFactory.java` (Java) and `CommandUtil.ts` (TypeScript), and add fixture-based tests

## Related Issue

Fixes #995

## Test Plan

- [x] All 684 tests pass (`./build.sh`)
- [ ] Verify `AddCallbackCommand` adds a callback to an operation and undoes correctly
- [ ] Verify `DeleteCallbackCommand` removes a callback and restores it on undo
- [ ] Verify both commands work with OAS 3.0 and 3.1 parent types (Operation and Components)