### PR TITLE
Add AddRequestBodyDefinitionCommand for reusable request body definitions (#991)

### DIFF
--- a/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/CommandFactory.java
@@ -15,6 +15,7 @@ import io.apicurio.datamodels.cmd.commands.AddParameterCommand;
 import io.apicurio.datamodels.cmd.commands.AddParameterDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddPathItemCommand;
 import io.apicurio.datamodels.cmd.commands.AddRequestBodyCommand;
+import io.apicurio.datamodels.cmd.commands.AddRequestBodyDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseDefinitionCommand;
 import io.apicurio.datamodels.cmd.commands.AddResponseHeaderCommand;
@@ -187,6 +188,16 @@ public class CommandFactory {
      */
     public static ICommand createDeleteHeaderDefinitionCommand(String definitionName) {
         return new DeleteHeaderDefinitionCommand(definitionName);
+    }
+
+    /**
+     * Creates a command to add a request body definition to the document.
+     * @param definitionName the name of the request body definition
+     * @param from the source object for the request body definition
+     * @return the command
+     */
+    public static ICommand createAddRequestBodyDefinitionCommand(String definitionName, ObjectNode from) {
+        return new AddRequestBodyDefinitionCommand(definitionName, from);
     }
 
     /**

--- a/src/main/java/io/apicurio/datamodels/cmd/commands/AddRequestBodyDefinitionCommand.java
+++ b/src/main/java/io/apicurio/datamodels/cmd/commands/AddRequestBodyDefinitionCommand.java
@@ -1,0 +1,186 @@
+package io.apicurio.datamodels.cmd.commands;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.cmd.AbstractCommand;
+import io.apicurio.datamodels.models.Document;
+import io.apicurio.datamodels.models.openapi.OpenApiDocument;
+import io.apicurio.datamodels.models.openapi.OpenApiRequestBody;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.util.LoggerUtil;
+import io.apicurio.datamodels.util.ModelTypeUtil;
+
+/**
+ * A command used to add a new request body definition in a document.  Source for the new
+ * definition must be provided.  This source will be converted to an openapi
+ * request body definition object and then added to the data model.
+ * @author eric.wittmann@gmail.com
+ */
+public class AddRequestBodyDefinitionCommand extends AbstractCommand {
+
+    public boolean _defExisted;
+    public String _newDefinitionName;
+    public ObjectNode _newDefinitionObj;
+    public boolean _nullDefinitionsParent;
+
+    private transient AddRequestBodyDefinitionCommandHelper _helper;
+
+    public AddRequestBodyDefinitionCommand() {
+    }
+
+    public AddRequestBodyDefinitionCommand(String definitionName, ObjectNode obj) {
+        this._newDefinitionName = definitionName;
+        this._newDefinitionObj = obj;
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#execute(Document)
+     */
+    @Override
+    public void execute(Document document) {
+        LoggerUtil.info("[AddRequestBodyDefinitionCommand] Executing.");
+        this._helper = createHelper(document);
+
+        OpenApiDocument doc = (OpenApiDocument) document;
+
+        // Do nothing if the definition already exists.
+        if (this._helper.defExists(doc)) {
+            LoggerUtil.info("[AddRequestBodyDefinitionCommand] Definition with name %s already exists.", this._newDefinitionName);
+            this._defExisted = true;
+            return;
+        }
+
+        this._nullDefinitionsParent = this._helper.prepareDocumentForDef(doc);
+
+        OpenApiRequestBody definition = this._helper.createRequestBodyDefinition(doc);
+        this._helper.addDefinition(doc, definition);
+    }
+
+    /**
+     * @see io.apicurio.datamodels.cmd.ICommand#undo(Document)
+     */
+    @Override
+    public void undo(Document document) {
+        LoggerUtil.info("[AddRequestBodyDefinitionCommand] Reverting.");
+        if (this._defExisted) {
+            return;
+        }
+
+        this._helper = createHelper(document);
+
+        OpenApiDocument doc = (OpenApiDocument) document;
+        this._helper.removeDefinition(doc);
+    }
+
+    private AddRequestBodyDefinitionCommandHelper createHelper(Document document) {
+        if (ModelTypeUtil.isOpenApi30Model(document)) {
+            return new OpenApi30Helper();
+        }
+        if (ModelTypeUtil.isOpenApi31Model(document)) {
+            return new OpenApi31Helper();
+        }
+        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+    }
+
+    private interface AddRequestBodyDefinitionCommandHelper {
+
+        boolean defExists(OpenApiDocument document);
+        boolean prepareDocumentForDef(OpenApiDocument document);
+        OpenApiRequestBody createRequestBodyDefinition(OpenApiDocument document);
+        void addDefinition(OpenApiDocument document, OpenApiRequestBody definition);
+        void removeDefinition(OpenApiDocument document);
+
+    }
+
+    private class OpenApi30Helper implements AddRequestBodyDefinitionCommandHelper {
+        @Override
+        public boolean defExists(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (isNullOrUndefined(doc30.getComponents())) {
+                return false;
+            }
+            return !isNullOrUndefined(doc30.getComponents().getRequestBodies().get(_newDefinitionName));
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (isNullOrUndefined(doc30.getComponents())) {
+                doc30.setComponents(doc30.createComponents());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public OpenApiRequestBody createRequestBodyDefinition(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            OpenApiRequestBody definition = doc30.getComponents().createRequestBody();
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(OpenApiDocument document, OpenApiRequestBody definition) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            doc30.getComponents().addRequestBody(_newDefinitionName, definition);
+        }
+
+        @Override
+        public void removeDefinition(OpenApiDocument document) {
+            OpenApi30Document doc30 = (OpenApi30Document) document;
+            if (_nullDefinitionsParent) {
+                doc30.setComponents(null);
+            } else {
+                doc30.getComponents().removeRequestBody(_newDefinitionName);
+            }
+        }
+    }
+
+    private class OpenApi31Helper implements AddRequestBodyDefinitionCommandHelper {
+        @Override
+        public boolean defExists(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (isNullOrUndefined(doc31.getComponents())) {
+                return false;
+            }
+            return !isNullOrUndefined(doc31.getComponents().getRequestBodies().get(_newDefinitionName));
+        }
+
+        @Override
+        public boolean prepareDocumentForDef(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (isNullOrUndefined(doc31.getComponents())) {
+                doc31.setComponents(doc31.createComponents());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public OpenApiRequestBody createRequestBodyDefinition(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            OpenApiRequestBody definition = doc31.getComponents().createRequestBody();
+            Library.readNode(_newDefinitionObj, definition);
+            return definition;
+        }
+
+        @Override
+        public void addDefinition(OpenApiDocument document, OpenApiRequestBody definition) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            doc31.getComponents().addRequestBody(_newDefinitionName, definition);
+        }
+
+        @Override
+        public void removeDefinition(OpenApiDocument document) {
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (_nullDefinitionsParent) {
+                doc31.setComponents(null);
+            } else {
+                doc31.getComponents().removeRequestBody(_newDefinitionName);
+            }
+        }
+    }
+
+}

--- a/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
+++ b/src/main/ts/src/io/apicurio/datamodels/util/CommandUtil.ts
@@ -15,6 +15,7 @@ import {AddParameterCommand} from "../cmd/commands/AddParameterCommand";
 import {AddParameterDefinitionCommand} from "../cmd/commands/AddParameterDefinitionCommand";
 import {AddPathItemCommand} from "../cmd/commands/AddPathItemCommand";
 import {AddRequestBodyCommand} from "../cmd/commands/AddRequestBodyCommand";
+import {AddRequestBodyDefinitionCommand} from "../cmd/commands/AddRequestBodyDefinitionCommand";
 import {AddResponseCommand} from "../cmd/commands/AddResponseCommand";
 import {AddResponseDefinitionCommand} from "../cmd/commands/AddResponseDefinitionCommand";
 import {AddResponseHeaderCommand} from "../cmd/commands/AddResponseHeaderCommand";
@@ -117,6 +118,7 @@ const commandSuppliers: { [key: string]: Supplier } = {
     "AddParameterDefinitionCommand": () => { return new AddParameterDefinitionCommand(); },
     "AddPathItemCommand": () => { return new AddPathItemCommand(); },
     "AddRequestBodyCommand": () => { return new AddRequestBodyCommand(); },
+    "AddRequestBodyDefinitionCommand": () => { return new AddRequestBodyDefinitionCommand(); },
     "AddResponseCommand": () => { return new AddResponseCommand(); },
     "AddResponseDefinitionCommand": () => { return new AddResponseDefinitionCommand(); },
     "AddResponseHeaderCommand": () => { return new AddResponseHeaderCommand(); },

--- a/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.after.json
+++ b/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.after.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "requestBodies": {
+      "UserBody": {
+        "description": "A request body containing user information",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "PetBody": {
+        "description": "A request body containing pet information",
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "petName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.before.json
+++ b/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.before.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "requestBodies": {
+      "UserBody": {
+        "description": "A request body containing user information",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.commands.json
+++ b/src/test/resources/fixtures/cmd/commands/add-requestbody-definition/openapi-3/add-requestbody-definition.commands.json
@@ -1,0 +1,22 @@
+[
+    {
+        "__type": "AddRequestBodyDefinitionCommand",
+        "_newDefinitionName" : "PetBody",
+        "_newDefinitionObj" : {
+            "description": "A request body containing pet information",
+            "required": false,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "petName": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+]

--- a/src/test/resources/fixtures/cmd/tests.json
+++ b/src/test/resources/fixtures/cmd/tests.json
@@ -88,6 +88,7 @@
     { "name": "[OpenAPI 3] {Delete Parameter Definition} - Delete Parameter Definition", "test": "commands/delete-parameter-definition/openapi-3/delete-parameter-definition" },
     { "name": "[OpenAPI 3] {Delete Header Definition} - Delete Header Definition", "test": "commands/delete-header-definition/openapi-3/delete-header-definition" },
     { "name": "[OpenAPI 3] {Delete Request Body Definition} - Delete Request Body Definition", "test": "commands/delete-requestbody-definition/openapi-3/delete-requestbody-definition" },
+    { "name": "[OpenAPI 3] {Add Request Body Definition} - Add Request Body Definition", "test": "commands/add-requestbody-definition/openapi-3/add-requestbody-definition" },
     { "name": "[OpenAPI 3] {Add Example Definition} - Add Example Definition", "test": "commands/add-example-definition/openapi-3/add-example-definition" },
     { "name": "[OpenAPI 3] {Delete Example Definition} - Delete Example Definition", "test": "commands/delete-example-definition/openapi-3/delete-example-definition" },
     { "name": "[OpenAPI 2] {Add Schema Definition} - Add Definition", "test": "commands/add-definition/openapi-2/add-definition" },


### PR DESCRIPTION
## Summary

- Add `AddRequestBodyDefinitionCommand` that creates reusable request body definitions in `components/requestBodies` (OAS 3.x only), following the `AddHeaderDefinitionCommand` pattern with OAS 3.0/3.1 helpers
- Add factory method `createAddRequestBodyDefinitionCommand` to `CommandFactory`
- Register the command in the TypeScript `CommandUtil.ts` for the transpiled TS build
- Add fixture-based test (before/after/commands JSON) and test entry in `tests.json`

## Related Issue

Fixes #991

## Test Plan

- [x] All 686 tests pass (Java + TypeScript) via `build.sh`
- [ ] Verify the new command adds a request body definition to `components/requestBodies`
- [ ] Verify undo removes the added definition
- [ ] Verify adding a duplicate definition name is a no-op