### PR TITLE
Set spec version property when creating documents

### DIFF
--- a/src/main/java/io/apicurio/datamodels/Library.java
+++ b/src/main/java/io/apicurio/datamodels/Library.java
@@ -70,12 +70,21 @@ public class Library {
     }
 
     /**
-     * Creates a new, empty document of the given type.
-     * @param type
+     * Creates a new, empty document of the given type.  The returned document will have
+     * the appropriate specification version property already set (e.g. "openapi", "swagger",
+     * "asyncapi", "openrpc").
+     * @param type the model type to create
+     * @return a new, empty document
      */
     public static Document createDocument(ModelType type) {
         ModelReader reader = ModelReaderFactory.createModelReader(type);
-        return (Document) reader.readRoot(JsonUtil.objectNode());
+        ObjectNode json = JsonUtil.objectNode();
+        String versionProp = ModelTypeUtil.getVersionPropertyName(type);
+        String version = ModelTypeUtil.getVersion(type);
+        if (versionProp != null) {
+            JsonUtil.setStringProperty(json, versionProp, version);
+        }
+        return (Document) reader.readRoot(json);
     }
 
     /**

--- a/src/main/java/io/apicurio/datamodels/util/ModelTypeUtil.java
+++ b/src/main/java/io/apicurio/datamodels/util/ModelTypeUtil.java
@@ -41,6 +41,35 @@ public class ModelTypeUtil {
         return "unknown";
     }
 
+    /**
+     * Returns the JSON property name used to store the specification version
+     * for the given model type (e.g. "openapi", "asyncapi", "swagger", "openrpc").
+     * @param type the model type
+     * @return the version property name
+     */
+    public static String getVersionPropertyName(ModelType type) {
+        switch (type) {
+            case OPENAPI20:
+                return "swagger";
+            case OPENAPI30:
+            case OPENAPI31:
+                return "openapi";
+            case ASYNCAPI20:
+            case ASYNCAPI21:
+            case ASYNCAPI22:
+            case ASYNCAPI23:
+            case ASYNCAPI24:
+            case ASYNCAPI25:
+            case ASYNCAPI26:
+            case ASYNCAPI30:
+                return "asyncapi";
+            case OPENRPC13:
+            case OPENRPC14:
+                return "openrpc";
+        }
+        return null;
+    }
+
     public static boolean isOpenApiModel(Node node) {
         switch (node.root().modelType()) {
             case OPENAPI20:

--- a/src/test/java/io/apicurio/datamodels/LibraryTest.java
+++ b/src/test/java/io/apicurio/datamodels/LibraryTest.java
@@ -1,9 +1,10 @@
 package io.apicurio.datamodels;
 
+import io.apicurio.datamodels.models.ModelType;
+import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
+import io.apicurio.datamodels.models.openrpc.v14.OpenRpc14Document;
 import org.junit.Assert;
 import org.junit.Test;
-
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
 
 public class LibraryTest {
 
@@ -15,6 +16,30 @@ public class LibraryTest {
     public void testReadDocumentFromJSONString() {
         OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(EMPTY_OPENAPI);
         Assert.assertEquals("3.0.1", document.getOpenapi());
+    }
+
+    @Test
+    public void testCreateOpenApi30() {
+        OpenApi30Document document = (OpenApi30Document) Library.createDocument(ModelType.OPENAPI30);
+        document.setInfo(document.createInfo());
+        document.getInfo().setTitle("My API");
+        document.getInfo().setVersion("1.0");
+
+        Assert.assertEquals("3.0.3", document.getOpenapi());
+        Assert.assertEquals("My API", document.getInfo().getTitle());
+        Assert.assertEquals("1.0", document.getInfo().getVersion());
+    }
+
+    @Test
+    public void testCreateOpenRpc14() {
+        OpenRpc14Document document = (OpenRpc14Document) Library.createDocument(ModelType.OPENRPC14);
+        document.setInfo(document.createInfo());
+        document.getInfo().setTitle("My RPC API");
+        document.getInfo().setVersion("1.0");
+
+        Assert.assertEquals("1.4.0", document.getOpenrpc());
+        Assert.assertEquals("My RPC API", document.getInfo().getTitle());
+        Assert.assertEquals("1.0", document.getInfo().getVersion());
     }
 
 }


### PR DESCRIPTION
## Summary
- `Library.createDocument()` now automatically sets the specification version property (`openapi`, `swagger`, `asyncapi`, `openrpc`) on newly created documents
- Added `ModelTypeUtil.getVersionPropertyName()` to map each `ModelType` to its JSON version property name
- Added tests for `createDocument` covering OpenAPI 3.0 and OpenRPC 1.4

## Test plan
- [ ] Verify `Library.createDocument(ModelType.OPENAPI30)` sets `openapi` to `"3.0.3"`
- [ ] Verify `Library.createDocument(ModelType.OPENRPC14)` sets `openrpc` to `"1.4.0"`
- [ ] Run full test suite to ensure no regressions