### PR TITLE
Expand documentation with guides and examples

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,564 @@
+# Examples
+
+This page contains end-to-end examples showing common use cases for the Apitomy Data Models
+library. Each example is provided in both Java and TypeScript.
+
+---
+
+## Build an OpenAPI Document from Scratch
+
+Create a complete OpenAPI 3.0 document programmatically, including info, paths, operations,
+request bodies, responses, and schema definitions.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.ModelType;
+    import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
+
+    // Create the document
+    OpenApi30Document doc = (OpenApi30Document) Library.createDocument(ModelType.OPENAPI30);
+
+    // Info
+    doc.setInfo(doc.createInfo());
+    doc.getInfo().setTitle("Pet Store API");
+    doc.getInfo().setVersion("1.0.0");
+    doc.getInfo().setDescription("A sample API for managing pets");
+
+    // Contact
+    doc.getInfo().setContact(doc.getInfo().createContact());
+    doc.getInfo().getContact().setName("API Support");
+    doc.getInfo().getContact().setEmail("support@example.com");
+
+    // Server
+    doc.addServer(doc.createServer());
+    doc.getServers().get(0).setUrl("https://api.example.com/v1");
+
+    // Paths
+    doc.setPaths(doc.createPaths());
+
+    // POST /pets
+    doc.getPaths().addItem("/pets", doc.getPaths().createPathItem());
+    var petsPath = doc.getPaths().getItem("/pets");
+    petsPath.setPost(petsPath.createOperation());
+    var createPet = petsPath.getPost();
+    createPet.setOperationId("createPet");
+    createPet.setSummary("Create a pet");
+
+    // Request body
+    createPet.setRequestBody(createPet.createRequestBody());
+    createPet.getRequestBody().setRequired(true);
+    createPet.getRequestBody().addMediaType(
+        "application/json",
+        createPet.getRequestBody().createMediaType()
+    );
+
+    // 201 response
+    createPet.addResponse("201", createPet.createResponse());
+    createPet.getResponse("201").setDescription("Pet created successfully");
+
+    // Components with a Pet schema
+    doc.setComponents(doc.createComponents());
+    doc.getComponents().addSchema("Pet", doc.getComponents().createSchema());
+    var petSchema = doc.getComponents().getSchemas().get("Pet");
+    petSchema.setType("object");
+    petSchema.addProperty("id", petSchema.createSchema());
+    petSchema.getProperties().get("id").setType("integer");
+    petSchema.addProperty("name", petSchema.createSchema());
+    petSchema.getProperties().get("name").setType("string");
+
+    // Tags
+    doc.addTag(doc.createTag());
+    doc.getTags().get(0).setName("pets");
+    doc.getTags().get(0).setDescription("Pet operations");
+
+    // Write to JSON
+    String json = Library.writeDocumentToJSONString(doc);
+    System.out.println(json);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, ModelType, OpenApi30Document } from '@apitomy/data-models';
+
+    // Create the document
+    const doc = Library.createDocument(ModelType.OPENAPI30) as OpenApi30Document;
+
+    // Info
+    doc.setInfo(doc.createInfo());
+    doc.getInfo().setTitle('Pet Store API');
+    doc.getInfo().setVersion('1.0.0');
+    doc.getInfo().setDescription('A sample API for managing pets');
+
+    // Contact
+    doc.getInfo().setContact(doc.getInfo().createContact());
+    doc.getInfo().getContact().setName('API Support');
+    doc.getInfo().getContact().setEmail('support@example.com');
+
+    // Server
+    doc.addServer(doc.createServer());
+    doc.getServers()[0].setUrl('https://api.example.com/v1');
+
+    // Paths
+    doc.setPaths(doc.createPaths());
+
+    // POST /pets
+    doc.getPaths().addItem('/pets', doc.getPaths().createPathItem());
+    const petsPath = doc.getPaths().getItem('/pets');
+    petsPath.setPost(petsPath.createOperation());
+    const createPet = petsPath.getPost();
+    createPet.setOperationId('createPet');
+    createPet.setSummary('Create a pet');
+
+    // Request body
+    createPet.setRequestBody(createPet.createRequestBody());
+    createPet.getRequestBody().setRequired(true);
+    createPet.getRequestBody().addMediaType(
+        'application/json',
+        createPet.getRequestBody().createMediaType()
+    );
+
+    // 201 response
+    createPet.addResponse('201', createPet.createResponse());
+    createPet.getResponse('201').setDescription('Pet created successfully');
+
+    // Components with a Pet schema
+    doc.setComponents(doc.createComponents());
+    doc.getComponents().addSchema('Pet', doc.getComponents().createSchema());
+    const petSchema = doc.getComponents().getSchemas().get('Pet');
+    petSchema.setType('object');
+    petSchema.addProperty('id', petSchema.createSchema());
+    petSchema.getProperties().get('id').setType('integer');
+    petSchema.addProperty('name', petSchema.createSchema());
+    petSchema.getProperties().get('name').setType('string');
+
+    // Tags
+    doc.addTag(doc.createTag());
+    doc.getTags()[0].setName('pets');
+    doc.getTags()[0].setDescription('Pet operations');
+
+    // Write to JSON
+    const json = JSON.stringify(Library.writeNode(doc), null, 2);
+    console.log(json);
+    ```
+
+---
+
+## List All API Endpoints
+
+Read a document and extract every endpoint (HTTP method + path) along with its operation
+details.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.TraverserDirection;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.models.openapi.OpenApiOperation;
+    import io.apitomy.datamodels.models.openapi.OpenApiPathItem;
+    import io.apitomy.datamodels.models.visitors.CombinedVisitorAdapter;
+    import java.util.ArrayList;
+    import java.util.List;
+
+    Document doc = Library.readDocumentFromJSONString(json);
+
+    class Endpoint {
+        String method;
+        String path;
+        String operationId;
+        String summary;
+
+        Endpoint(String method, String path, String operationId, String summary) {
+            this.method = method;
+            this.path = path;
+            this.operationId = operationId;
+            this.summary = summary;
+        }
+    }
+
+    List<Endpoint> endpoints = new ArrayList<>();
+
+    Library.visitTree(doc, new CombinedVisitorAdapter() {
+        @Override
+        public void visitOperation(OpenApiOperation node) {
+            // The parent is a PathItem — get the HTTP method from the parent property name
+            String method = node.parentPropertyName().toUpperCase();
+            // The grandparent property name is the path string
+            String path = ((OpenApiPathItem) node.parent()).mapPropertyName();
+            endpoints.add(new Endpoint(method, path, node.getOperationId(), node.getSummary()));
+        }
+    }, TraverserDirection.down);
+
+    System.out.println("Found " + endpoints.size() + " endpoints:");
+    for (Endpoint ep : endpoints) {
+        System.out.printf("  %-6s %-30s %s%n", ep.method, ep.path,
+            ep.operationId != null ? ep.operationId : "(no operationId)");
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import {
+        Library, TraverserDirection, Document,
+        CombinedVisitorAdapter, OpenApiOperation, OpenApiPathItem
+    } from '@apitomy/data-models';
+
+    const doc: Document = Library.readDocument(json);
+
+    interface Endpoint {
+        method: string;
+        path: string;
+        operationId: string | null;
+        summary: string | null;
+    }
+
+    const endpoints: Endpoint[] = [];
+
+    class EndpointCollector extends CombinedVisitorAdapter {
+        visitOperation(node: OpenApiOperation): void {
+            // The parent is a PathItem — get the HTTP method from the parent property name
+            const method = node.parentPropertyName().toUpperCase();
+            // The grandparent property name is the path string
+            const path = (node.parent() as OpenApiPathItem).mapPropertyName();
+            endpoints.push({
+                method,
+                path,
+                operationId: node.getOperationId(),
+                summary: node.getSummary(),
+            });
+        }
+    }
+
+    Library.visitTree(doc, new EndpointCollector(), TraverserDirection.down);
+
+    console.log(`Found ${endpoints.length} endpoints:`);
+    endpoints.forEach(ep => {
+        const id = ep.operationId ?? '(no operationId)';
+        console.log(`  ${ep.method.padEnd(6)} ${ep.path.padEnd(30)} ${id}`);
+    });
+    ```
+
+---
+
+## Validate and Report Problems
+
+Read a document, validate it, and produce a formatted report of all issues found.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.validation.ValidationProblem;
+    import io.apitomy.datamodels.validation.ValidationProblemSeverity;
+    import java.util.List;
+    import java.util.Map;
+    import java.util.stream.Collectors;
+
+    Document doc = Library.readDocumentFromJSONString(json);
+    List<ValidationProblem> problems = Library.validate(doc, null);
+
+    if (problems.isEmpty()) {
+        System.out.println("Document is valid.");
+    } else {
+        // Group by severity
+        Map<ValidationProblemSeverity, List<ValidationProblem>> bySeverity =
+            problems.stream().collect(Collectors.groupingBy(p -> p.severity));
+
+        // Print summary
+        System.out.println("Validation Results:");
+        System.out.println("  Errors:   " + bySeverity.getOrDefault(ValidationProblemSeverity.high, List.of()).size());
+        System.out.println("  Warnings: " + bySeverity.getOrDefault(ValidationProblemSeverity.medium, List.of()).size());
+
+        // Print details
+        System.out.println("\nProblems:");
+        for (ValidationProblem p : problems) {
+            System.out.printf("  [%s] %s%n", p.severity, p.message);
+            System.out.printf("    Path: %s%n", p.nodePath);
+            System.out.printf("    Code: %s%n", p.errorCode);
+        }
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document, ValidationProblem } from '@apitomy/data-models';
+
+    const doc: Document = Library.readDocument(json);
+    const problems: ValidationProblem[] = Library.validate(doc, null);
+
+    if (problems.length === 0) {
+        console.log('Document is valid.');
+    } else {
+        // Group by severity
+        const errors = problems.filter(p => p.severity.toString() === 'high');
+        const warnings = problems.filter(p => p.severity.toString() === 'medium');
+
+        // Print summary
+        console.log('Validation Results:');
+        console.log(`  Errors:   ${errors.length}`);
+        console.log(`  Warnings: ${warnings.length}`);
+
+        // Print details
+        console.log('\nProblems:');
+        problems.forEach(p => {
+            console.log(`  [${p.severity}] ${p.message}`);
+            console.log(`    Path: ${p.nodePath}`);
+            console.log(`    Code: ${p.errorCode}`);
+        });
+    }
+    ```
+
+---
+
+## Upgrade OpenAPI 2.0 to 3.0
+
+Read a Swagger 2.0 document, transform it to OpenAPI 3.0, and write out the result.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.models.ModelType;
+
+    // Read the Swagger 2.0 document
+    String swaggerJson = """
+        {
+          "swagger": "2.0",
+          "info": { "title": "Legacy API", "version": "1.0" },
+          "host": "api.example.com",
+          "basePath": "/v1",
+          "schemes": ["https"],
+          "consumes": ["application/json"],
+          "produces": ["application/json"],
+          "paths": {
+            "/users": {
+              "get": {
+                "operationId": "listUsers",
+                "summary": "List all users",
+                "parameters": [
+                  {
+                    "name": "limit",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Maximum number of users to return"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "A list of users",
+                    "schema": { "$ref": "#/definitions/UserList" }
+                  }
+                }
+              }
+            }
+          },
+          "definitions": {
+            "User": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "name": { "type": "string" }
+              }
+            },
+            "UserList": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/User" }
+            }
+          }
+        }
+        """;
+
+    Document swagger = Library.readDocumentFromJSONString(swaggerJson);
+    Document openApi30 = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    String result = Library.writeDocumentToJSONString(openApi30);
+    System.out.println(result);
+    // Output has "openapi": "3.0.3", "servers" array, "components/schemas", etc.
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document, ModelType } from '@apitomy/data-models';
+
+    // Read the Swagger 2.0 document
+    const swaggerJson = {
+        swagger: '2.0',
+        info: { title: 'Legacy API', version: '1.0' },
+        host: 'api.example.com',
+        basePath: '/v1',
+        schemes: ['https'],
+        consumes: ['application/json'],
+        produces: ['application/json'],
+        paths: {
+            '/users': {
+                get: {
+                    operationId: 'listUsers',
+                    summary: 'List all users',
+                    parameters: [
+                        {
+                            name: 'limit',
+                            in: 'query',
+                            type: 'integer',
+                            description: 'Maximum number of users to return',
+                        },
+                    ],
+                    responses: {
+                        '200': {
+                            description: 'A list of users',
+                            schema: { $ref: '#/definitions/UserList' },
+                        },
+                    },
+                },
+            },
+        },
+        definitions: {
+            User: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                    name: { type: 'string' },
+                },
+            },
+            UserList: {
+                type: 'array',
+                items: { $ref: '#/definitions/User' },
+            },
+        },
+    };
+
+    const swagger: Document = Library.readDocument(swaggerJson);
+    const openApi30: Document = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    const result = JSON.stringify(Library.writeNode(openApi30), null, 2);
+    console.log(result);
+    // Output has "openapi": "3.0.3", "servers" array, "components/schemas", etc.
+    ```
+
+---
+
+## Implement a Custom Reference Resolver
+
+Resolve external `$ref` references by fetching content from a map (simulating a file
+system or database).
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.models.Node;
+    import io.apitomy.datamodels.refs.IReferenceResolver;
+    import io.apitomy.datamodels.refs.ResolvedReference;
+    import com.fasterxml.jackson.databind.ObjectMapper;
+    import java.util.Map;
+
+    // Simulated external schemas
+    Map<String, String> externalSchemas = Map.of(
+        "https://schemas.example.com/address.json", """
+            {
+              "type": "object",
+              "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" },
+                "zipCode": { "type": "string" }
+              }
+            }
+            """,
+        "https://schemas.example.com/phone.json", """
+            {
+              "type": "object",
+              "properties": {
+                "number": { "type": "string" },
+                "type": { "type": "string", "enum": ["home", "work", "mobile"] }
+              }
+            }
+            """
+    );
+
+    // Create a resolver that looks up schemas from the map
+    IReferenceResolver resolver = new IReferenceResolver() {
+        private final ObjectMapper mapper = new ObjectMapper();
+
+        @Override
+        public ResolvedReference resolveRef(String reference, Node from) {
+            String schemaJson = externalSchemas.get(reference);
+            if (schemaJson == null) {
+                return null;
+            }
+            try {
+                Object json = mapper.readTree(schemaJson);
+                return ResolvedReference.fromJson(json);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    };
+
+    // Register and dereference
+    Library.addReferenceResolver(resolver);
+    Document doc = Library.readDocumentFromJSONString(apiJson);
+    Document dereferenced = Library.dereferenceDocument(doc);
+    Library.removeReferenceResolver(resolver);
+
+    // The dereferenced document has external $refs replaced with actual content
+    String result = Library.writeDocumentToJSONString(dereferenced);
+    System.out.println(result);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import {
+        Library, Document, Node,
+        IReferenceResolver, ResolvedReference
+    } from '@apitomy/data-models';
+
+    // Simulated external schemas
+    const externalSchemas: Record<string, any> = {
+        'https://schemas.example.com/address.json': {
+            type: 'object',
+            properties: {
+                street: { type: 'string' },
+                city: { type: 'string' },
+                zipCode: { type: 'string' },
+            },
+        },
+        'https://schemas.example.com/phone.json': {
+            type: 'object',
+            properties: {
+                number: { type: 'string' },
+                type: { type: 'string', enum: ['home', 'work', 'mobile'] },
+            },
+        },
+    };
+
+    // Create a resolver that looks up schemas from the map
+    class MapReferenceResolver implements IReferenceResolver {
+        resolveRef(reference: string, from: Node): ResolvedReference | null {
+            const schema = externalSchemas[reference];
+            if (!schema) {
+                return null;
+            }
+            return ResolvedReference.fromJson(schema);
+        }
+    }
+
+    // Register and dereference
+    const resolver = new MapReferenceResolver();
+    Library.addReferenceResolver(resolver);
+    const doc: Document = Library.readDocument(apiJson);
+    const dereferenced: Document = Library.dereferenceDocument(doc);
+    Library.removeReferenceResolver(resolver);
+
+    // The dereferenced document has external $refs replaced with actual content
+    const result = JSON.stringify(Library.writeNode(dereferenced), null, 2);
+    console.log(result);
+    ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,13 @@
 # Getting Started
 
 This guide walks you through installing the Apitomy Data Models library and using it to parse,
-validate, and manipulate an OpenAPI document.
+validate, and manipulate an OpenAPI document. Choose the Java or TypeScript quickstart below
+depending on your platform.
 
 ## Prerequisites
 
-- **Java**: JDK 17 or later (for the Java library)
-- **Node.js**: 18 or later (for the TypeScript library)
+- **Java**: JDK 17 or later
+- **Node.js**: 18 or later (for the TypeScript/JavaScript library)
 
 ## Installation
 
@@ -20,115 +21,220 @@ validate, and manipulate an OpenAPI document.
     </dependency>
     ```
 
+=== "Gradle"
+
+    ```groovy
+    implementation 'io.apitomy:apitomy-data-models:3.1.0'
+    ```
+
 === "npm"
 
     ```bash
     npm install @apitomy/data-models
     ```
 
-## Reading a Document
+---
 
-=== "Java"
+## Java Quickstart
 
-    ```java
-    import io.apitomy.datamodels.Library;
-    import io.apitomy.datamodels.models.Document;
+This section walks through a complete workflow in Java: reading a document, inspecting it,
+validating it, traversing it with a visitor, and writing it back out.
 
-    // Parse from a JSON string
-    Document doc = Library.readDocumentFromJSONString(jsonString);
+### Reading a Document
 
-    // Or parse with auto-detection (JSON or YAML)
-    Document doc = Library.readDocument(content);
-    ```
+Pass a JSON string to `Library.readDocumentFromJSONString()`. The library auto-detects the
+specification type and version.
 
-=== "TypeScript"
+```java
+import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.models.Document;
+import io.apitomy.datamodels.models.openapi.v3x.OpenApiDocument;
 
-    ```typescript
-    import { Library, Document } from '@apitomy/data-models';
-
-    // Parse from a JSON string
-    const doc: Document = Library.readDocumentFromJSONString(jsonString);
-    ```
-
-## Writing a Document
-
-=== "Java"
-
-    ```java
-    // Serialize to a JSON object
-    Object json = Library.writeNode(doc);
-    String jsonString = new ObjectMapper()
-        .writerWithDefaultPrettyPrinter()
-        .writeValueAsString(json);
-    ```
-
-=== "TypeScript"
-
-    ```typescript
-    // Serialize to a JSON object
-    const json = Library.writeNode(doc);
-    const jsonString = JSON.stringify(json, null, 2);
-    ```
-
-## Validating a Document
-
-=== "Java"
-
-    ```java
-    import io.apitomy.datamodels.validation.ValidationProblem;
-
-    List<ValidationProblem> problems = Library.validate(doc, null);
-    for (ValidationProblem problem : problems) {
-        System.out.println(problem.severity + ": " + problem.message);
+String json = """
+    {
+      "openapi": "3.0.3",
+      "info": {
+        "title": "Pet Store",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/pets": {
+          "get": {
+            "operationId": "listPets",
+            "summary": "List all pets",
+            "responses": {
+              "200": { "description": "A list of pets" }
+            }
+          }
+        }
+      }
     }
-    ```
+    """;
 
-=== "TypeScript"
+Document doc = Library.readDocumentFromJSONString(json);
+OpenApiDocument openApiDoc = (OpenApiDocument) doc;
+System.out.println("Title: " + openApiDoc.getInfo().getTitle());
+// Output: Title: Pet Store
+```
 
-    ```typescript
-    import { Library, ValidationProblem } from '@apitomy/data-models';
+### Validating a Document
 
-    const problems: ValidationProblem[] = Library.validate(doc, null);
-    problems.forEach(p => console.log(`${p.severity}: ${p.message}`));
-    ```
+Call `Library.validate()` to check for specification compliance issues. Pass `null` for the
+severity registry to use the defaults.
 
-## Using the Visitor Pattern
+```java
+import io.apitomy.datamodels.validation.ValidationProblem;
+import java.util.List;
 
-The visitor pattern is the primary way to query and traverse documents. Extend
-`CombinedVisitorAdapter` and override only the methods you need.
+List<ValidationProblem> problems = Library.validate(doc, null);
+for (ValidationProblem problem : problems) {
+    System.out.println("[" + problem.severity + "] " + problem.message);
+    System.out.println("  at: " + problem.nodePath);
+}
+```
 
-=== "Java"
+### Traversing with a Visitor
 
-    ```java
-    import io.apitomy.datamodels.Library;
-    import io.apitomy.datamodels.TraverserDirection;
-    import io.apitomy.datamodels.models.Schema;
-    import io.apitomy.datamodels.models.visitors.CombinedVisitorAdapter;
+Use `CombinedVisitorAdapter` to override only the visit methods you care about. Call
+`Library.visitTree()` with `TraverserDirection.down` to walk the tree top-down.
 
-    Library.visitTree(doc, new CombinedVisitorAdapter() {
-        @Override
-        public void visitSchema(Schema node) {
-            System.out.println("Schema: " + node.getTitle());
-        }
-    }, TraverserDirection.down);
-    ```
+```java
+import io.apitomy.datamodels.TraverserDirection;
+import io.apitomy.datamodels.models.openapi.OpenApiOperation;
+import io.apitomy.datamodels.models.openapi.OpenApiPathItem;
+import io.apitomy.datamodels.models.visitors.CombinedVisitorAdapter;
 
-=== "TypeScript"
+Library.visitTree(doc, new CombinedVisitorAdapter() {
+    @Override
+    public void visitPathItem(OpenApiPathItem node) {
+        System.out.println("Path: " + node.mapPropertyName());
+    }
 
-    ```typescript
-    import {
-        Library, TraverserDirection,
-        CombinedVisitorAdapter, Schema
-    } from '@apitomy/data-models';
+    @Override
+    public void visitOperation(OpenApiOperation node) {
+        System.out.println("  Operation: " + node.getOperationId());
+    }
+}, TraverserDirection.down);
+// Output:
+// Path: /pets
+//   Operation: listPets
+```
 
-    Library.visitTree(doc, new class extends CombinedVisitorAdapter {
-        visitSchema(node: Schema): void {
-            console.log('Schema:', node.getTitle());
-        }
-    }, TraverserDirection.down);
-    ```
+### Writing a Document
+
+Serialize the document back to a JSON string.
+
+```java
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+ObjectNode jsonNode = Library.writeDocument(doc);
+String output = new ObjectMapper()
+    .writerWithDefaultPrettyPrinter()
+    .writeValueAsString(jsonNode);
+System.out.println(output);
+```
+
+---
+
+## TypeScript Quickstart
+
+This section walks through the same workflow in TypeScript: reading a document, inspecting it,
+validating it, traversing it with a visitor, and writing it back out.
+
+### Reading a Document
+
+Parse the JSON yourself, then pass the object to `Library.readDocument()`. The library
+auto-detects the specification type and version.
+
+```typescript
+import {
+    Library, Document, OpenApiDocument
+} from '@apitomy/data-models';
+
+const json = {
+    openapi: '3.0.3',
+    info: {
+        title: 'Pet Store',
+        version: '1.0.0',
+    },
+    paths: {
+        '/pets': {
+            get: {
+                operationId: 'listPets',
+                summary: 'List all pets',
+                responses: {
+                    '200': { description: 'A list of pets' },
+                },
+            },
+        },
+    },
+};
+
+const doc: Document = Library.readDocument(json);
+const openApiDoc = doc as OpenApiDocument;
+console.log('Title:', openApiDoc.getInfo().getTitle());
+// Output: Title: Pet Store
+```
+
+### Validating a Document
+
+Call `Library.validate()` to check for specification compliance issues. Pass `null` for the
+severity registry to use the defaults.
+
+```typescript
+import { ValidationProblem } from '@apitomy/data-models';
+
+const problems: ValidationProblem[] = Library.validate(doc, null);
+problems.forEach(problem => {
+    console.log(`[${problem.severity}] ${problem.message}`);
+    console.log(`  at: ${problem.nodePath}`);
+});
+```
+
+### Traversing with a Visitor
+
+Extend `CombinedVisitorAdapter` to override only the visit methods you care about. Call
+`Library.visitTree()` with `TraverserDirection.down` to walk the tree top-down.
+
+```typescript
+import {
+    TraverserDirection, CombinedVisitorAdapter,
+    OpenApiOperation, OpenApiPathItem
+} from '@apitomy/data-models';
+
+class EndpointVisitor extends CombinedVisitorAdapter {
+    visitPathItem(node: OpenApiPathItem): void {
+        console.log('Path:', node.mapPropertyName());
+    }
+    visitOperation(node: OpenApiOperation): void {
+        console.log('  Operation:', node.getOperationId());
+    }
+}
+
+Library.visitTree(doc, new EndpointVisitor(), TraverserDirection.down);
+// Output:
+// Path: /pets
+//   Operation: listPets
+```
+
+### Writing a Document
+
+Serialize the document back to a plain JavaScript object, then stringify it.
+
+```typescript
+const output = Library.writeNode(doc);
+console.log(JSON.stringify(output, null, 2));
+```
+
+---
 
 ## Next Steps
 
-- [User Guide](user-guide/index.md) — Learn about visitor patterns, validation rules, and
-  commands in depth
+- [Reading & Writing](user-guide/reading-and-writing.md) — Creating documents, format detection,
+  serialization
+- [Visitor Pattern](user-guide/visitor-pattern.md) — Traversal directions, finder and collector
+  patterns
+- [Validation](user-guide/validation.md) — Severity levels, custom severity registries
+- [Commands](user-guide/commands.md) — Mutating documents with undo/redo support
+- [Examples](examples/index.md) — End-to-end use cases

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,9 @@ documents using a rich, typed object model.
 
 ## Quick Links
 
-- [Getting Started](getting-started.md) — Installation and basic usage
-- [User Guide](user-guide/index.md) — Visitor patterns, validation, commands
+- [Getting Started](getting-started.md) — Installation, Java and TypeScript quickstarts
+- [User Guide](user-guide/index.md) — Reading & writing, visitors, validation, commands, and more
+- [Examples](examples/index.md) — End-to-end use cases in Java and TypeScript
 - [GitHub Repository](https://github.com/Apitomy/apitomy-data-models) — Source code and issues
 - [Maven Central](https://central.sonatype.com/artifact/io.apitomy/apitomy-data-models) — Java
   releases

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -1,0 +1,191 @@
+# Commands
+
+The library provides a command pattern for document mutations with built-in undo/redo support.
+Every change to a document can be represented as an `ICommand` that knows how to execute
+itself and reverse its effect.
+
+## Overview
+
+Each command implements the `ICommand` interface:
+
+- `execute(document)` — applies the mutation to the document
+- `undo(document)` — reverses the mutation
+- `type()` — returns the command type name (e.g., `"ChangePropertyCommand"`)
+
+---
+
+## Creating and Executing Commands
+
+### ChangePropertyCommand
+
+The most common command modifies a simple property (string, boolean, number) on any node.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.cmd.ICommand;
+    import io.apitomy.datamodels.cmd.commands.ChangePropertyCommand;
+    import io.apitomy.datamodels.models.Node;
+
+    // Change the title of the info section
+    Node infoNode = doc.getInfo();
+    ICommand cmd = new ChangePropertyCommand<>(infoNode, "title", "Updated API Title");
+
+    // Execute the command
+    cmd.execute(doc);
+    System.out.println(doc.getInfo().getTitle()); // "Updated API Title"
+
+    // Undo the command
+    cmd.undo(doc);
+    System.out.println(doc.getInfo().getTitle()); // original title restored
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { ICommand, ChangePropertyCommand } from '@apitomy/data-models';
+
+    // Change the title of the info section
+    const infoNode = doc.getInfo();
+    const cmd: ICommand = new ChangePropertyCommand(infoNode, 'title', 'Updated API Title');
+
+    // Execute the command
+    cmd.execute(doc);
+    console.log(doc.getInfo().getTitle()); // "Updated API Title"
+
+    // Undo the command
+    cmd.undo(doc);
+    console.log(doc.getInfo().getTitle()); // original title restored
+    ```
+
+---
+
+## CommandFactory
+
+`CommandFactory` provides convenience methods for creating, marshalling, and unmarshalling
+commands.
+
+### Creating Commands via Factory
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.cmd.CommandFactory;
+    import com.fasterxml.jackson.databind.node.ObjectNode;
+
+    // Create a command to add a schema definition
+    ObjectNode schemaJson = mapper.createObjectNode();
+    schemaJson.put("type", "object");
+    ICommand cmd = CommandFactory.createAddSchemaDefinitionCommand("Pet", schemaJson);
+    cmd.execute(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { CommandFactory } from '@apitomy/data-models';
+
+    // Create a command to add a schema definition
+    const schemaJson = { type: 'object' };
+    const cmd = CommandFactory.createAddSchemaDefinitionCommand('Pet', schemaJson);
+    cmd.execute(doc);
+    ```
+
+### Marshalling Commands to JSON
+
+Commands can be serialized to JSON for storage, transmission, or replay. This is useful for
+implementing collaborative editing or change logs.
+
+=== "Java"
+
+    ```java
+    // Serialize a command to JSON
+    ObjectNode commandJson = CommandFactory.marshall(cmd);
+
+    // Deserialize a command from JSON
+    ICommand restored = CommandFactory.unmarshall(commandJson);
+    restored.execute(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Serialize a command to JSON
+    const commandJson = CommandFactory.marshall(cmd);
+
+    // Deserialize a command from JSON
+    const restored: ICommand = CommandFactory.unmarshall(commandJson);
+    restored.execute(doc);
+    ```
+
+### Command JSON Format
+
+Marshalled commands use a `__type` field to identify the command type, and fields prefixed
+with `_` for command properties:
+
+```json
+{
+    "__type": "ChangePropertyCommand",
+    "_nodePath": "/info",
+    "_property": "title",
+    "_newValue": "Updated API Title"
+}
+```
+
+---
+
+## AggregateCommand
+
+Use `AggregateCommand` to batch multiple commands into a single undoable operation.
+Undoing the aggregate undoes all of its child commands in reverse order.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.cmd.commands.AggregateCommand;
+
+    AggregateCommand batch = new AggregateCommand("update-metadata", doc.getInfo());
+
+    batch.addCommand(new ChangePropertyCommand<>(doc.getInfo(), "title", "New Title"));
+    batch.addCommand(new ChangePropertyCommand<>(doc.getInfo(), "version", "2.0.0"));
+    batch.addCommand(new ChangePropertyCommand<>(doc.getInfo(), "description", "Updated desc"));
+
+    // Execute all three changes
+    batch.execute(doc);
+
+    // Undo all three changes at once
+    batch.undo(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { AggregateCommand, ChangePropertyCommand } from '@apitomy/data-models';
+
+    const batch = new AggregateCommand('update-metadata', doc.getInfo());
+
+    batch.addCommand(new ChangePropertyCommand(doc.getInfo(), 'title', 'New Title'));
+    batch.addCommand(new ChangePropertyCommand(doc.getInfo(), 'version', '2.0.0'));
+    batch.addCommand(new ChangePropertyCommand(doc.getInfo(), 'description', 'Updated desc'));
+
+    // Execute all three changes
+    batch.execute(doc);
+
+    // Undo all three changes at once
+    batch.undo(doc);
+    ```
+
+---
+
+## Available Command Categories
+
+The library provides commands for all common document mutations:
+
+| Category | Commands | Description |
+|----------|---------|-------------|
+| **Add** | `AddPathItemCommand`, `AddOperationCommand`, `AddParameterCommand`, `AddResponseCommand`, `AddSchemaDefinitionCommand`, `AddServerCommand`, `AddSecuritySchemeCommand`, `AddTagCommand`, `AddMediaTypeCommand`, `AddCallbackCommand`, `AddExtensionCommand`, `AddExampleCommand` | Add new elements to the document |
+| **Delete** | `DeletePathCommand`, `DeleteOperationCommand`, `DeleteParameterCommand`, `DeleteResponseCommand`, `DeleteSchemaCommand`, `DeleteServerCommand`, `DeleteSecuritySchemeCommand`, `DeleteTagCommand`, `DeleteMediaTypeCommand`, `DeleteAllPropertiesCommand`, `DeleteAllOperationsCommand` | Remove elements from the document |
+| **Change** | `ChangePropertyCommand`, `ChangeDescriptionCommand`, `ChangeTitleCommand`, `ChangeVersionCommand`, `ChangeContactCommand`, `ChangeLicenseCommand`, `ChangeExtensionCommand`, `ChangeMediaTypeSchemaCommand` | Modify existing properties |
+| **Replace** | `ReplacePathItemCommand`, `ReplaceOperationCommand`, `ReplaceSchemaDefinitionCommand`, `ReplaceResponseDefinitionCommand`, `ReplaceSecurityRequirementCommand` | Replace entire elements |
+| **Refactor** | `RefactorSchemaDefinitionCommand`, `RefactorResponseDefinitionCommand`, `RefactorParameterDefinitionCommand`, `RenameTagCommand` | Restructure or rename elements |
+| **Aggregate** | `AggregateCommand` | Batch multiple commands into one |

--- a/docs/user-guide/dereferencing.md
+++ b/docs/user-guide/dereferencing.md
@@ -1,0 +1,172 @@
+# Dereferencing
+
+Dereferencing inlines external `$ref` references in a document. After dereferencing, every
+`$ref` that pointed to an external resource is replaced with the actual content, resulting
+in a self-contained document.
+
+## Basic Usage
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+
+    // Read a document that may contain external $refs
+    Document doc = Library.readDocumentFromJSONString(json);
+
+    // Dereference it — returns a new document with all external refs inlined
+    Document dereferenced = Library.dereferenceDocument(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document } from '@apitomy/data-models';
+
+    // Read a document that may contain external $refs
+    const doc: Document = Library.readDocument(json);
+
+    // Dereference it — returns a new document with all external refs inlined
+    const dereferenced: Document = Library.dereferenceDocument(doc);
+    ```
+
+!!! note
+    `dereferenceDocument()` returns a **new** document. The original document is not modified.
+
+---
+
+## Strict Mode
+
+By default, unresolvable references are silently skipped. Enable strict mode to preserve them
+as-is (the `$ref` remains in the output).
+
+=== "Java"
+
+    ```java
+    Document dereferenced = Library.dereferenceDocument(doc, true);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const dereferenced = Library.dereferenceDocument(doc, true);
+    ```
+
+---
+
+## Custom Reference Resolvers
+
+By default, the library can only resolve local references (e.g.,
+`#/components/schemas/Pet`). To resolve external references — pointing to files, URLs, or
+other sources — implement `IReferenceResolver`.
+
+### Implementing IReferenceResolver
+
+A resolver receives a reference string and the node it was found on, and returns a
+`ResolvedReference` (or `null` if it can't handle that reference).
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.refs.IReferenceResolver;
+    import io.apitomy.datamodels.refs.ResolvedReference;
+    import io.apitomy.datamodels.models.Node;
+
+    class FileReferenceResolver implements IReferenceResolver {
+        @Override
+        public ResolvedReference resolveRef(String reference, Node from) {
+            if (!reference.startsWith("./")) {
+                return null; // not a relative file reference
+            }
+
+            // Read the referenced file
+            String content = readFile(reference);
+            Object json = new ObjectMapper().readTree(content);
+
+            // Return as a JSON reference
+            return ResolvedReference.fromJson(json);
+        }
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { IReferenceResolver, ResolvedReference, Node } from '@apitomy/data-models';
+
+    class FileReferenceResolver implements IReferenceResolver {
+        resolveRef(reference: string, from: Node): ResolvedReference | null {
+            if (!reference.startsWith('./')) {
+                return null; // not a relative file reference
+            }
+
+            // Read the referenced file
+            const content = readFileSync(reference, 'utf-8');
+            const json = JSON.parse(content);
+
+            // Return as a JSON reference
+            return ResolvedReference.fromJson(json);
+        }
+    }
+    ```
+
+### ResolvedReference Factory Methods
+
+`ResolvedReference` provides three factory methods depending on the type of content:
+
+| Method | Use When |
+|--------|----------|
+| `ResolvedReference.fromNode(node)` | The reference resolves to another node already in an Apitomy data model |
+| `ResolvedReference.fromJson(json)` | The reference resolves to a JSON/YAML object (parsed as a plain object) |
+| `ResolvedReference.fromJson(json, mediaType)` | Same as above, with an explicit media type (e.g., `application/vnd.apache.avro+json`) |
+| `ResolvedReference.fromText(text, mediaType)` | The reference resolves to non-JSON text (e.g., Protobuf, GraphQL) |
+
+### Registering and Removing Resolvers
+
+Register a resolver globally before dereferencing or validating.
+
+=== "Java"
+
+    ```java
+    // Register
+    IReferenceResolver resolver = new FileReferenceResolver();
+    Library.addReferenceResolver(resolver);
+
+    // Dereference using the registered resolver
+    Document dereferenced = Library.dereferenceDocument(doc);
+
+    // Remove when no longer needed
+    Library.removeReferenceResolver(resolver);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Register
+    const resolver = new FileReferenceResolver();
+    Library.addReferenceResolver(resolver);
+
+    // Dereference using the registered resolver
+    const dereferenced = Library.dereferenceDocument(doc);
+
+    // Remove when no longer needed
+    Library.removeReferenceResolver(resolver);
+    ```
+
+### Passing a Resolver Directly
+
+Alternatively, pass a resolver directly to `dereferenceDocument()` without registering it
+globally.
+
+=== "Java"
+
+    ```java
+    Document dereferenced = Library.dereferenceDocument(doc, new FileReferenceResolver(), true);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const dereferenced = Library.dereferenceDocument(doc, new FileReferenceResolver(), true);
+    ```

--- a/docs/user-guide/document-transformation.md
+++ b/docs/user-guide/document-transformation.md
@@ -1,0 +1,156 @@
+# Document Transformation
+
+The library can transform documents between specification versions. This is useful for
+upgrading older API definitions to newer versions of the specification.
+
+## Basic Usage
+
+Call `Library.transformDocument()` with the source document and the target `ModelType`.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.models.ModelType;
+
+    // Read an OpenAPI 2.0 (Swagger) document
+    Document swagger = Library.readDocumentFromJSONString(swaggerJson);
+
+    // Transform to OpenAPI 3.0
+    Document openApi30 = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    // Write out the transformed document
+    String output = Library.writeDocumentToJSONString(openApi30);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document, ModelType } from '@apitomy/data-models';
+
+    // Read an OpenAPI 2.0 (Swagger) document
+    const swagger: Document = Library.readDocument(swaggerJson);
+
+    // Transform to OpenAPI 3.0
+    const openApi30: Document = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    // Write out the transformed document
+    const output = JSON.stringify(Library.writeNode(openApi30), null, 2);
+    ```
+
+!!! note
+    `transformDocument()` returns a **new** document. The original document is not modified.
+
+---
+
+## Supported Transformations
+
+### OpenAPI Upgrades
+
+| From | To | Description |
+|------|----|-------------|
+| OpenAPI 2.0 | OpenAPI 3.0 | Converts `definitions` to `components/schemas`, `basePath` + `host` to `servers`, path-level `parameters` to operation-level, etc. |
+| OpenAPI 2.0 | OpenAPI 3.1 | Same as above, plus OpenAPI 3.1-specific changes |
+| OpenAPI 2.0 | OpenAPI 3.2 | Same as above, plus OpenAPI 3.2-specific changes |
+| OpenAPI 3.0 | OpenAPI 3.1 | Adjusts schema handling for JSON Schema 2020-12 alignment |
+| OpenAPI 3.0 | OpenAPI 3.2 | Same as above, plus OpenAPI 3.2-specific changes |
+| OpenAPI 3.1 | OpenAPI 3.2 | Minimal changes for 3.2 compatibility |
+
+### AsyncAPI Upgrades
+
+| From | To | Description |
+|------|----|-------------|
+| AsyncAPI 2.x | AsyncAPI 2.y (y > x) | Incremental upgrades within the 2.x series |
+
+---
+
+## Multi-Step Upgrades
+
+You can chain transformations to upgrade through multiple versions. However, a single call
+to `transformDocument()` with the final target version is equivalent — the library handles
+intermediate conversions internally.
+
+=== "Java"
+
+    ```java
+    // Direct upgrade from 2.0 to 3.2 in one step
+    Document openApi32 = Library.transformDocument(swagger, ModelType.OPENAPI32);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Direct upgrade from 2.0 to 3.2 in one step
+    const openApi32 = Library.transformDocument(swagger, ModelType.OPENAPI32);
+    ```
+
+---
+
+## Example: Upgrading a Swagger 2.0 Document
+
+=== "Java"
+
+    ```java
+    String swaggerJson = """
+        {
+          "swagger": "2.0",
+          "info": { "title": "Pet Store", "version": "1.0" },
+          "host": "api.example.com",
+          "basePath": "/v1",
+          "schemes": ["https"],
+          "paths": {
+            "/pets": {
+              "get": {
+                "operationId": "listPets",
+                "produces": ["application/json"],
+                "responses": {
+                  "200": { "description": "A list of pets" }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    Document swagger = Library.readDocumentFromJSONString(swaggerJson);
+    Document openApi30 = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    // The result now has:
+    // - "openapi": "3.0.3" instead of "swagger": "2.0"
+    // - "servers" array instead of "host" + "basePath" + "schemes"
+    // - Response content uses "content" with media types
+    String result = Library.writeDocumentToJSONString(openApi30);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const swaggerJson = {
+        swagger: '2.0',
+        info: { title: 'Pet Store', version: '1.0' },
+        host: 'api.example.com',
+        basePath: '/v1',
+        schemes: ['https'],
+        paths: {
+            '/pets': {
+                get: {
+                    operationId: 'listPets',
+                    produces: ['application/json'],
+                    responses: {
+                        '200': { description: 'A list of pets' }
+                    }
+                }
+            }
+        }
+    };
+
+    const swagger = Library.readDocument(swaggerJson);
+    const openApi30 = Library.transformDocument(swagger, ModelType.OPENAPI30);
+
+    // The result now has:
+    // - "openapi": "3.0.3" instead of "swagger": "2.0"
+    // - "servers" array instead of "host" + "basePath" + "schemes"
+    // - Response content uses "content" with media types
+    const result = JSON.stringify(Library.writeNode(openApi30), null, 2);
+    ```

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,139 +1,57 @@
 # User Guide
 
 This guide covers the core concepts and patterns for working with the Apitomy Data Models
-library.
+library. Each section focuses on a single feature area with practical examples in both Java
+and TypeScript.
 
-!!! note "Under Development"
-    This user guide is under active development. New sections will be added over time.
+## Topics
 
-## Table of Contents
+### [Reading & Writing](reading-and-writing.md)
 
-- [Visitor Pattern](#visitor-pattern)
-- [Validation](#validation)
-- [Commands](#commands)
-- [Supported Specifications](#supported-specifications)
+Parse documents from JSON strings, create new documents programmatically using factory methods,
+serialize documents back to JSON, and clone documents.
 
----
+### [Visitor Pattern](visitor-pattern.md)
 
-## Visitor Pattern
+Traverse and query document trees using the visitor pattern. Covers `CombinedVisitorAdapter`
+for typed visits, `AllNodeVisitor` for uniform handling, traversal directions (top-down and
+bottom-up), and common patterns like finders and collectors.
 
-The visitor pattern is the primary mechanism for querying, analyzing, and transforming document
-models. It replaces direct `instanceof` checks and manual tree walking.
+### [Validation](validation.md)
 
-### Base Classes
+Validate documents against their specification rules. Covers the validation engine, problem
+severity levels, error codes, and custom severity registries.
 
-- **`CombinedVisitorAdapter`** — no-op implementations for all 67+ visit methods. Extend and
-  override only the methods you need.
-- **`AllNodeVisitor`** — funnels every `visitXxx()` call into a single abstract `visitNode()`.
-  Use when you need uniform handling of all node types.
+### [Commands](commands.md)
 
-### Traversal
+Mutate documents using the command pattern with built-in undo/redo support. Covers creating
+commands, executing and undoing them, marshalling commands to/from JSON, and combining
+multiple commands into a single undoable operation.
 
-```java
-// Traverse a subtree depth-first (top-down)
-Library.visitTree(node, visitor, TraverserDirection.down);
+### [Node Paths](node-paths.md)
 
-// Dispatch to a single node (no traversal)
-node.accept(visitor);
+Navigate documents using XPath-like node paths. Covers path syntax, creating paths from nodes,
+parsing paths from strings, and resolving paths back to nodes.
 
-// Resolve a NodePath string to a Node
-Node node = Library.resolveNodePath(document, nodePath);
-```
+### [Dereferencing](dereferencing.md)
 
-### Common Patterns
+Inline external `$ref` references by resolving them. Covers the built-in dereferencer,
+strict mode, and implementing custom reference resolvers for external content.
 
-**Finder** — query by criteria:
+### [Document Transformation](document-transformation.md)
 
-```java
-Library.visitTree(doc, new CombinedVisitorAdapter() {
-    @Override
-    public void visitOperation(Operation node) {
-        if ("getUserById".equals(node.getOperationId())) {
-            // Found it
-        }
-    }
-}, TraverserDirection.down);
-```
-
-**Collector** — aggregate data across the tree:
-
-```java
-List<String> paths = new ArrayList<>();
-Library.visitTree(doc, new CombinedVisitorAdapter() {
-    @Override
-    public void visitPathItem(OpenApiPathItem node) {
-        paths.add(node.mapPropertyName());
-    }
-}, TraverserDirection.down);
-```
-
----
-
-## Validation
-
-The library includes a built-in validation engine with hundreds of rules for detecting problems
-in API specifications.
-
-### Basic Usage
-
-```java
-List<ValidationProblem> problems = Library.validate(doc, null);
-```
-
-Each `ValidationProblem` includes:
-
-- **`severity`** — Error, Warning, Information, or Hint
-- **`message`** — Human-readable description of the problem
-- **`nodePath`** — Path to the node where the problem was found
-- **`errorCode`** — Machine-readable error code
-
-### Severity Levels
-
-| Severity | Description |
-|----------|-------------|
-| Error | Violations of the specification that must be fixed |
-| Warning | Potential issues that should be reviewed |
-| Information | Suggestions for improvement |
-| Hint | Minor style or convention notes |
-
----
-
-## Commands
-
-The library provides a command pattern for document mutations that supports undo/redo
-operations.
-
-### Using Commands
-
-```java
-import io.apitomy.datamodels.cmd.commands.CommandFactory;
-
-// Create a command
-ICommand command = CommandFactory.createChangePropertyCommand(
-    node, "description", "New description"
-);
-
-// Execute it
-command.execute(document);
-
-// Undo it
-command.undo(document);
-```
-
-### Available Command Categories
-
-- **Add** — add paths, schemas, operations, parameters, responses, etc.
-- **Delete** — remove any document element
-- **Change** — modify properties, rename elements
-- **Aggregate** — combine multiple commands into a single undoable operation
+Transform documents between specification versions, such as upgrading from OpenAPI 2.0 to 3.0
+or from OpenAPI 3.0 to 3.1.
 
 ---
 
 ## Supported Specifications
 
+The library auto-detects the specification type and version when parsing a document.
+
 | Specification | Versions |
 |--------------|----------|
 | OpenAPI | 2.0, 3.0.x, 3.1.x, 3.2.x |
-| AsyncAPI | 2.0–2.6, 3.0, 3.1 |
-
-The library auto-detects the specification type and version when parsing a document.
+| AsyncAPI | 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.0, 3.1 |
+| OpenRPC | 1.3, 1.4 |
+| JSON Schema | Draft 4, Draft 6, Draft 7, 2019-09, 2020-12 |

--- a/docs/user-guide/node-paths.md
+++ b/docs/user-guide/node-paths.md
@@ -1,0 +1,182 @@
+# Node Paths
+
+Node paths provide an XPath-like syntax for identifying and navigating to specific nodes
+within a document tree. They are used extensively by the command system to reference nodes
+and are useful for diagnostics, logging, and programmatic navigation.
+
+## Path Syntax
+
+A node path is a `/`-separated sequence of segments, where each segment is either a property
+name, a map key in brackets, or an array index in brackets.
+
+| Path | Meaning |
+|------|---------|
+| `/` | The root document |
+| `/info` | The `info` property of the root |
+| `/info/title` | The `title` property of the info object |
+| `/paths[/pets]` | The `/pets` entry in the `paths` map |
+| `/paths[/pets]/get` | The GET operation on the `/pets` path |
+| `/paths[/pets]/get/responses[200]` | The `200` response of that operation |
+| `/components/schemas[Pet]` | The `Pet` schema definition |
+| `/tags[0]` | The first element in the `tags` array |
+
+---
+
+## Creating a Path from a Node
+
+Given any node in the document tree, create a path that identifies it.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.paths.NodePath;
+
+    NodePath path = Library.createNodePath(doc.getInfo());
+    System.out.println(path.toString()); // "/info"
+
+    NodePath schemaPath = Library.createNodePath(
+        doc.getComponents().getSchemas().get("Pet")
+    );
+    System.out.println(schemaPath.toString()); // "/components/schemas[Pet]"
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, NodePath } from '@apitomy/data-models';
+
+    const path: NodePath = Library.createNodePath(doc.getInfo());
+    console.log(path.toString()); // "/info"
+
+    const schemaPath = Library.createNodePath(
+        doc.getComponents().getSchemas().get('Pet')
+    );
+    console.log(schemaPath.toString()); // "/components/schemas[Pet]"
+    ```
+
+---
+
+## Parsing a Path from a String
+
+Parse a path string into a `NodePath` object.
+
+=== "Java"
+
+    ```java
+    NodePath path = NodePath.parse("/paths[/pets]/get/responses[200]");
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const path: NodePath = NodePath.parse('/paths[/pets]/get/responses[200]');
+    ```
+
+---
+
+## Resolving a Path to a Node
+
+Given a `NodePath` and a document, resolve the path to the actual node it points to.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.models.Node;
+
+    NodePath path = NodePath.parse("/info");
+    Node infoNode = Library.resolveNodePath(path, doc);
+    System.out.println(infoNode); // the Info node
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Node } from '@apitomy/data-models';
+
+    const path = NodePath.parse('/info');
+    const infoNode: Node = Library.resolveNodePath(path, doc);
+    console.log(infoNode); // the Info node
+    ```
+
+---
+
+## Round-Trip
+
+Paths can be round-tripped: create a path from a node, convert it to a string, parse the
+string, and resolve it back to the same node.
+
+=== "Java"
+
+    ```java
+    // Start with a node
+    Node originalNode = doc.getInfo();
+
+    // Create a path
+    NodePath path = Library.createNodePath(originalNode);
+
+    // Convert to string and back
+    String pathString = path.toString();
+    NodePath parsedPath = NodePath.parse(pathString);
+
+    // Resolve back to the same node
+    Node resolvedNode = Library.resolveNodePath(parsedPath, doc);
+    assert originalNode == resolvedNode; // same object reference
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Start with a node
+    const originalNode = doc.getInfo();
+
+    // Create a path
+    const path = Library.createNodePath(originalNode);
+
+    // Convert to string and back
+    const pathString: string = path.toString();
+    const parsedPath = NodePath.parse(pathString);
+
+    // Resolve back to the same node
+    const resolvedNode = Library.resolveNodePath(parsedPath, doc);
+    // resolvedNode === originalNode
+    ```
+
+---
+
+## Working with Path Segments
+
+A `NodePath` is composed of `NodePathSegment` objects. You can inspect individual segments
+to understand the structure of a path.
+
+=== "Java"
+
+    ```java
+    NodePath path = NodePath.parse("/paths[/pets]/get/responses[200]");
+
+    for (var segment : path.toSegments()) {
+        System.out.println(segment);
+    }
+    // Output:
+    // paths
+    // [/pets]
+    // get
+    // responses
+    // [200]
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const path = NodePath.parse('/paths[/pets]/get/responses[200]');
+
+    path.toSegments().forEach(segment => {
+        console.log(segment);
+    });
+    // Output:
+    // paths
+    // [/pets]
+    // get
+    // responses
+    // [200]
+    ```

--- a/docs/user-guide/reading-and-writing.md
+++ b/docs/user-guide/reading-and-writing.md
@@ -1,0 +1,254 @@
+# Reading & Writing Documents
+
+This page covers how to parse, create, serialize, and clone documents.
+
+## Reading a Document
+
+The library auto-detects the specification type and version by examining top-level properties
+like `openapi`, `asyncapi`, `swagger`, `openrpc`, and `$schema`.
+
+### From a JSON String
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.Document;
+
+    String json = "{ \"openapi\": \"3.0.3\", \"info\": { \"title\": \"My API\", \"version\": \"1.0\" } }";
+    Document doc = Library.readDocumentFromJSONString(json);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document } from '@apitomy/data-models';
+
+    const jsonString = '{ "openapi": "3.0.3", "info": { "title": "My API", "version": "1.0" } }';
+    const doc: Document = Library.readDocumentFromJSONString(jsonString);
+    ```
+
+### From a Parsed JSON Object
+
+If you already have a parsed JSON object, pass it directly.
+
+=== "Java"
+
+    ```java
+    import com.fasterxml.jackson.databind.ObjectMapper;
+    import com.fasterxml.jackson.databind.node.ObjectNode;
+    import io.apitomy.datamodels.Library;
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode json = (ObjectNode) mapper.readTree(jsonString);
+    Document doc = Library.readDocument(json);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, Document } from '@apitomy/data-models';
+
+    const json = JSON.parse(jsonString);
+    const doc: Document = Library.readDocument(json);
+    ```
+
+### Casting to a Specific Type
+
+After reading, cast the document to the specific type for typed access to its properties.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
+
+    OpenApi30Document openApiDoc = (OpenApi30Document) doc;
+    String title = openApiDoc.getInfo().getTitle();
+    String version = openApiDoc.getInfo().getVersion();
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { OpenApi30Document } from '@apitomy/data-models';
+
+    const openApiDoc = doc as OpenApi30Document;
+    const title = openApiDoc.getInfo().getTitle();
+    const version = openApiDoc.getInfo().getVersion();
+    ```
+
+---
+
+## Creating a New Document
+
+Use `Library.createDocument()` with a `ModelType` to create a new, empty document. Then
+populate it using typed setters and `createXxx()` factory methods.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.models.ModelType;
+    import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
+
+    OpenApi30Document doc = (OpenApi30Document) Library.createDocument(ModelType.OPENAPI30);
+
+    // Set the info section
+    doc.setInfo(doc.createInfo());
+    doc.getInfo().setTitle("Pet Store");
+    doc.getInfo().setVersion("1.0.0");
+    doc.getInfo().setDescription("A sample API for pets");
+
+    // Add a path
+    doc.setPaths(doc.createPaths());
+    doc.getPaths().addItem("/pets", doc.getPaths().createPathItem());
+
+    // Add a GET operation to the path
+    var pathItem = doc.getPaths().getItem("/pets");
+    pathItem.setGet(pathItem.createOperation());
+    pathItem.getGet().setOperationId("listPets");
+    pathItem.getGet().setSummary("List all pets");
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, ModelType, OpenApi30Document } from '@apitomy/data-models';
+
+    const doc = Library.createDocument(ModelType.OPENAPI30) as OpenApi30Document;
+
+    // Set the info section
+    doc.setInfo(doc.createInfo());
+    doc.getInfo().setTitle('Pet Store');
+    doc.getInfo().setVersion('1.0.0');
+    doc.getInfo().setDescription('A sample API for pets');
+
+    // Add a path
+    doc.setPaths(doc.createPaths());
+    doc.getPaths().addItem('/pets', doc.getPaths().createPathItem());
+
+    // Add a GET operation to the path
+    const pathItem = doc.getPaths().getItem('/pets');
+    pathItem.setGet(pathItem.createOperation());
+    pathItem.getGet().setOperationId('listPets');
+    pathItem.getGet().setSummary('List all pets');
+    ```
+
+### Available Model Types
+
+| ModelType | Specification |
+|-----------|--------------|
+| `OPENAPI20` | OpenAPI 2.0 (Swagger) |
+| `OPENAPI30` | OpenAPI 3.0.x |
+| `OPENAPI31` | OpenAPI 3.1.x |
+| `OPENAPI32` | OpenAPI 3.2.x |
+| `ASYNCAPI20` – `ASYNCAPI26` | AsyncAPI 2.0 through 2.6 |
+| `ASYNCAPI30`, `ASYNCAPI31` | AsyncAPI 3.0, 3.1 |
+| `OPENRPC13`, `OPENRPC14` | OpenRPC 1.3, 1.4 |
+| `JSDRAFT4`, `JSDRAFT6`, `JSDRAFT7` | JSON Schema Draft 4, 6, 7 |
+| `JS201909`, `JS202012` | JSON Schema 2019-09, 2020-12 |
+
+---
+
+## Writing a Document
+
+### To a JSON Object
+
+=== "Java"
+
+    ```java
+    import com.fasterxml.jackson.databind.node.ObjectNode;
+
+    ObjectNode json = Library.writeDocument(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const json = Library.writeNode(doc);
+    ```
+
+### To a JSON String
+
+=== "Java"
+
+    ```java
+    String jsonString = Library.writeDocumentToJSONString(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const jsonString = JSON.stringify(Library.writeNode(doc), null, 2);
+    ```
+
+### Writing a Single Node
+
+You can also serialize any individual node in the tree, not just the root document.
+
+=== "Java"
+
+    ```java
+    import com.fasterxml.jackson.databind.node.ObjectNode;
+
+    ObjectNode infoJson = Library.writeNode(doc.getInfo());
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const infoJson = Library.writeNode(doc.getInfo());
+    ```
+
+---
+
+## Cloning a Document
+
+Create a deep copy of a document. The clone is fully independent of the original.
+
+=== "Java"
+
+    ```java
+    Document clone = Library.cloneDocument(doc);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const clone: Document = Library.cloneDocument(doc);
+    ```
+
+---
+
+## Extra Properties
+
+API specifications allow vendor extensions (properties prefixed with `x-`). These are
+preserved as "extra properties" on each node.
+
+=== "Java"
+
+    ```java
+    import com.fasterxml.jackson.databind.node.TextNode;
+
+    // Add a custom extension
+    doc.getInfo().addExtraProperty("x-api-owner", new TextNode("platform-team"));
+
+    // Read it back
+    String owner = doc.getInfo().getExtraProperty("x-api-owner").asText();
+
+    // List all extensions on a node
+    List<String> extensions = doc.getInfo().getExtraPropertyNames();
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Add a custom extension
+    doc.getInfo().addExtraProperty('x-api-owner', 'platform-team');
+
+    // Read it back
+    const owner = doc.getInfo().getExtraProperty('x-api-owner');
+
+    // List all extensions on a node
+    const extensions: string[] = doc.getInfo().getExtraPropertyNames();
+    ```

--- a/docs/user-guide/validation.md
+++ b/docs/user-guide/validation.md
@@ -1,0 +1,195 @@
+# Validation
+
+The library includes a built-in validation engine with hundreds of rules for detecting
+specification compliance issues in OpenAPI, AsyncAPI, and OpenRPC documents.
+
+## Basic Usage
+
+Call `Library.validate()` to validate a document. Pass `null` for the severity registry to
+use the default severity levels.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.validation.ValidationProblem;
+    import java.util.List;
+
+    List<ValidationProblem> problems = Library.validate(doc, null);
+    for (ValidationProblem problem : problems) {
+        System.out.println("[" + problem.severity + "] " + problem.message);
+        System.out.println("  Path: " + problem.nodePath);
+        System.out.println("  Code: " + problem.errorCode);
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, ValidationProblem } from '@apitomy/data-models';
+
+    const problems: ValidationProblem[] = Library.validate(doc, null);
+    problems.forEach(problem => {
+        console.log(`[${problem.severity}] ${problem.message}`);
+        console.log(`  Path: ${problem.nodePath}`);
+        console.log(`  Code: ${problem.errorCode}`);
+    });
+    ```
+
+## ValidationProblem Fields
+
+Each `ValidationProblem` includes the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `errorCode` | `String` | Machine-readable error code (e.g., `INF-001`) |
+| `nodePath` | `NodePath` | Path to the node where the problem was found |
+| `property` | `String` | The property name that caused the problem |
+| `message` | `String` | Human-readable description of the problem |
+| `severity` | `ValidationProblemSeverity` | Severity level of the problem |
+
+## Severity Levels
+
+| Severity | Description |
+|----------|-------------|
+| **Error** | Violations of the specification that must be fixed |
+| **Warning** | Potential issues that should be reviewed |
+| **Information** | Suggestions for improvement |
+| **Hint** | Minor style or convention notes |
+
+## Error Code Prefixes
+
+Validation error codes follow a consistent naming convention. The prefix indicates the type
+of rule:
+
+| Prefix | Meaning | Example |
+|--------|---------|---------|
+| `REQ` | Required property is missing | `REQ-001` |
+| `INF` | Invalid format | `INF-001` |
+| `INV` | Invalid value | `INV-001` |
+| `UNQ` | Uniqueness violation | `UNQ-001` |
+| `MUT` | Mutual exclusivity violation | `MUT-001` |
+
+---
+
+## Validating a Subtree
+
+You can validate any node in the tree, not just the root document. This validates only that
+node and its descendants.
+
+=== "Java"
+
+    ```java
+    // Validate just the info section
+    List<ValidationProblem> infoProblems = Library.validate(doc.getInfo(), null);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    // Validate just the info section
+    const infoProblems = Library.validate(doc.getInfo(), null);
+    ```
+
+---
+
+## Custom Severity Registry
+
+You can customize the severity of any validation rule by implementing
+`IValidationSeverityRegistry`. This is useful when you want to treat certain warnings as
+errors, or suppress rules entirely by downgrading them to hints.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.validation.IValidationSeverityRegistry;
+    import io.apitomy.datamodels.validation.ValidationProblemSeverity;
+
+    class StrictSeverityRegistry implements IValidationSeverityRegistry {
+        @Override
+        public ValidationProblemSeverity lookupSeverity(
+                String ruleCode,
+                ValidationProblemSeverity defaultSeverity) {
+            // Upgrade all warnings to errors
+            if (defaultSeverity == ValidationProblemSeverity.warning) {
+                return ValidationProblemSeverity.high;
+            }
+            return defaultSeverity;
+        }
+    }
+
+    List<ValidationProblem> problems = Library.validate(doc, new StrictSeverityRegistry());
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import {
+        IValidationSeverityRegistry,
+        ValidationProblemSeverity
+    } from '@apitomy/data-models';
+
+    class StrictSeverityRegistry implements IValidationSeverityRegistry {
+        lookupSeverity(
+            ruleCode: string,
+            defaultSeverity: ValidationProblemSeverity
+        ): ValidationProblemSeverity {
+            // Upgrade all warnings to errors
+            if (defaultSeverity === ValidationProblemSeverity.warning) {
+                return ValidationProblemSeverity.high;
+            }
+            return defaultSeverity;
+        }
+    }
+
+    const problems = Library.validate(doc, new StrictSeverityRegistry());
+    ```
+
+---
+
+## Validation with External References
+
+When your document contains external `$ref` references, the validation engine may need to
+resolve them to fully validate the document. Register a reference resolver before validating.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.refs.IReferenceResolver;
+    import io.apitomy.datamodels.refs.ResolvedReference;
+    import io.apitomy.datamodels.models.Node;
+
+    // Register a resolver that can fetch external references
+    Library.addReferenceResolver(new IReferenceResolver() {
+        @Override
+        public ResolvedReference resolveRef(String reference, Node from) {
+            // Resolve external references (e.g., from a file or URL)
+            // Return null for references you can't resolve
+            return null;
+        }
+    });
+
+    // Now validate — external refs will be resolved during validation
+    List<ValidationProblem> problems = Library.validate(doc, null);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { IReferenceResolver, ResolvedReference, Node } from '@apitomy/data-models';
+
+    // Register a resolver that can fetch external references
+    Library.addReferenceResolver({
+        resolveRef(reference: string, from: Node): ResolvedReference {
+            // Resolve external references (e.g., from a file or URL)
+            // Return null for references you can't resolve
+            return null;
+        }
+    });
+
+    // Now validate — external refs will be resolved during validation
+    const problems = Library.validate(doc, null);
+    ```
+
+See [Dereferencing](dereferencing.md) for more details on implementing custom reference
+resolvers.

--- a/docs/user-guide/visitor-pattern.md
+++ b/docs/user-guide/visitor-pattern.md
@@ -1,0 +1,324 @@
+# Visitor Pattern
+
+The visitor pattern is the primary mechanism for querying, analyzing, and transforming
+document models. It replaces manual tree walking and `instanceof` checks with a structured,
+type-safe traversal.
+
+## Overview
+
+The library provides two base visitor classes:
+
+- **`CombinedVisitorAdapter`** — provides no-op implementations for all visit methods
+  (e.g., `visitInfo()`, `visitOperation()`, `visitSchema()`). Extend it and override only the
+  methods you need. This is the most common choice.
+- **`AllNodeVisitor`** — funnels every `visitXxx()` call into a single abstract `visitNode()`
+  method. Use when you need uniform handling regardless of node type.
+
+## Traversal Directions
+
+The library supports two traversal directions:
+
+- **`TraverserDirection.down`** — depth-first, top-down. Starts at the given node and visits
+  all descendants. This is the most common direction.
+- **`TraverserDirection.up`** — bottom-up. Starts at the given node and walks up through
+  its ancestors to the root.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.TraverserDirection;
+
+    // Top-down: visit the document and all its children
+    Library.visitTree(doc, visitor, TraverserDirection.down);
+
+    // Bottom-up: walk from a node up to the root
+    Library.visitTree(someNode, visitor, TraverserDirection.up);
+
+    // Visit a single node (no traversal)
+    Library.visitNode(someNode, visitor);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { Library, TraverserDirection } from '@apitomy/data-models';
+
+    // Top-down: visit the document and all its children
+    Library.visitTree(doc, visitor, TraverserDirection.down);
+
+    // Bottom-up: walk from a node up to the root
+    Library.visitTree(someNode, visitor, TraverserDirection.up);
+
+    // Visit a single node (no traversal)
+    Library.visitNode(someNode, visitor);
+    ```
+
+---
+
+## CombinedVisitorAdapter
+
+`CombinedVisitorAdapter` provides typed visit methods for every node type across all
+supported specifications. Override only the methods relevant to your task.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.models.openapi.OpenApiOperation;
+    import io.apitomy.datamodels.models.openapi.OpenApiPathItem;
+    import io.apitomy.datamodels.models.visitors.CombinedVisitorAdapter;
+
+    Library.visitTree(doc, new CombinedVisitorAdapter() {
+        @Override
+        public void visitPathItem(OpenApiPathItem node) {
+            System.out.println("Path: " + node.mapPropertyName());
+        }
+
+        @Override
+        public void visitOperation(OpenApiOperation node) {
+            System.out.println("  " + node.getOperationId());
+        }
+    }, TraverserDirection.down);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import {
+        CombinedVisitorAdapter, OpenApiOperation, OpenApiPathItem
+    } from '@apitomy/data-models';
+
+    class EndpointPrinter extends CombinedVisitorAdapter {
+        visitPathItem(node: OpenApiPathItem): void {
+            console.log('Path:', node.mapPropertyName());
+        }
+        visitOperation(node: OpenApiOperation): void {
+            console.log(' ', node.getOperationId());
+        }
+    }
+
+    Library.visitTree(doc, new EndpointPrinter(), TraverserDirection.down);
+    ```
+
+---
+
+## AllNodeVisitor
+
+`AllNodeVisitor` routes every visit call to a single `visitNode()` method. Use this when
+you need to handle all node types uniformly.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.models.Node;
+    import io.apitomy.datamodels.models.visitors.AllNodeVisitor;
+
+    class NodeCounter extends AllNodeVisitor {
+        int count = 0;
+
+        @Override
+        protected void visitNode(Node node) {
+            count++;
+        }
+    }
+
+    NodeCounter counter = new NodeCounter();
+    Library.visitTree(doc, counter, TraverserDirection.down);
+    System.out.println("Total nodes: " + counter.count);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { AllNodeVisitor, Node } from '@apitomy/data-models';
+
+    class NodeCounter extends AllNodeVisitor {
+        count = 0;
+
+        visitNode(node: Node): void {
+            this.count++;
+        }
+    }
+
+    const counter = new NodeCounter();
+    Library.visitTree(doc, counter, TraverserDirection.down);
+    console.log('Total nodes:', counter.count);
+    ```
+
+---
+
+## Common Patterns
+
+### Finder
+
+Locate a specific node by criteria.
+
+=== "Java"
+
+    ```java
+    class OperationFinder extends CombinedVisitorAdapter {
+        OpenApiOperation found;
+        private final String operationId;
+
+        OperationFinder(String operationId) {
+            this.operationId = operationId;
+        }
+
+        @Override
+        public void visitOperation(OpenApiOperation node) {
+            if (operationId.equals(node.getOperationId())) {
+                found = node;
+            }
+        }
+    }
+
+    OperationFinder finder = new OperationFinder("listPets");
+    Library.visitTree(doc, finder, TraverserDirection.down);
+    if (finder.found != null) {
+        System.out.println("Found: " + finder.found.getSummary());
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    class OperationFinder extends CombinedVisitorAdapter {
+        found: OpenApiOperation | null = null;
+
+        constructor(private operationId: string) { super(); }
+
+        visitOperation(node: OpenApiOperation): void {
+            if (node.getOperationId() === this.operationId) {
+                this.found = node;
+            }
+        }
+    }
+
+    const finder = new OperationFinder('listPets');
+    Library.visitTree(doc, finder, TraverserDirection.down);
+    if (finder.found) {
+        console.log('Found:', finder.found.getSummary());
+    }
+    ```
+
+### Collector
+
+Gather data across the entire tree.
+
+=== "Java"
+
+    ```java
+    class SchemaCollector extends CombinedVisitorAdapter {
+        List<String> schemaNames = new ArrayList<>();
+
+        @Override
+        public void visitSchema(Schema node) {
+            if (node.mapPropertyName() != null) {
+                schemaNames.add(node.mapPropertyName());
+            }
+        }
+    }
+
+    SchemaCollector collector = new SchemaCollector();
+    Library.visitTree(doc, collector, TraverserDirection.down);
+    System.out.println("Schemas: " + collector.schemaNames);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    class SchemaCollector extends CombinedVisitorAdapter {
+        schemaNames: string[] = [];
+
+        visitSchema(node: Schema): void {
+            if (node.mapPropertyName()) {
+                this.schemaNames.push(node.mapPropertyName());
+            }
+        }
+    }
+
+    const collector = new SchemaCollector();
+    Library.visitTree(doc, collector, TraverserDirection.down);
+    console.log('Schemas:', collector.schemaNames);
+    ```
+
+### Detecting Extra Properties
+
+Find all vendor extensions (`x-` properties) across the document.
+
+=== "Java"
+
+    ```java
+    class ExtensionDetector extends AllNodeVisitor {
+        List<String> extensions = new ArrayList<>();
+
+        @Override
+        protected void visitNode(Node node) {
+            for (String name : node.getExtraPropertyNames()) {
+                extensions.add(Library.createNodePath(node) + " -> " + name);
+            }
+        }
+    }
+
+    ExtensionDetector detector = new ExtensionDetector();
+    Library.visitTree(doc, detector, TraverserDirection.down);
+    detector.extensions.forEach(System.out::println);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    class ExtensionDetector extends AllNodeVisitor {
+        extensions: string[] = [];
+
+        visitNode(node: Node): void {
+            node.getExtraPropertyNames().forEach(name => {
+                this.extensions.push(`${Library.createNodePath(node)} -> ${name}`);
+            });
+        }
+    }
+
+    const detector = new ExtensionDetector();
+    Library.visitTree(doc, detector, TraverserDirection.down);
+    detector.extensions.forEach(ext => console.log(ext));
+    ```
+
+### Walking Up the Tree
+
+Use `TraverserDirection.up` to find ancestors of a node. For example, finding which path
+an operation belongs to.
+
+=== "Java"
+
+    ```java
+    class PathFinder extends CombinedVisitorAdapter {
+        String pathName;
+
+        @Override
+        public void visitPathItem(OpenApiPathItem node) {
+            pathName = node.mapPropertyName();
+        }
+    }
+
+    // Given an operation node, walk up to find its parent path
+    PathFinder pathFinder = new PathFinder();
+    Library.visitTree(operationNode, pathFinder, TraverserDirection.up);
+    System.out.println("Operation belongs to path: " + pathFinder.pathName);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    class PathFinder extends CombinedVisitorAdapter {
+        pathName: string | null = null;
+
+        visitPathItem(node: OpenApiPathItem): void {
+            this.pathName = node.mapPropertyName();
+        }
+    }
+
+    // Given an operation node, walk up to find its parent path
+    const pathFinder = new PathFinder();
+    Library.visitTree(operationNode, pathFinder, TraverserDirection.up);
+    console.log('Operation belongs to path:', pathFinder.pathName);
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,14 @@ nav:
   - Getting Started: getting-started.md
   - User Guide:
     - user-guide/index.md
+    - Reading & Writing: user-guide/reading-and-writing.md
+    - Visitor Pattern: user-guide/visitor-pattern.md
+    - Validation: user-guide/validation.md
+    - Commands: user-guide/commands.md
+    - Node Paths: user-guide/node-paths.md
+    - Dereferencing: user-guide/dereferencing.md
+    - Document Transformation: user-guide/document-transformation.md
+  - Examples: examples/index.md
 
 docs_dir: ./docs
 site_dir: ./site


### PR DESCRIPTION
## Summary
- Rewrite getting-started guide with separate Java and TypeScript quickstart sections
- Add 7 user guide pages covering reading & writing, visitor pattern, validation, commands, node paths, dereferencing, and document transformation — all with dual Java/TS examples
- Add examples page with 5 end-to-end use cases (build from scratch, list endpoints, validate, upgrade versions, custom reference resolver)
- Update user guide index to link all new pages and expand supported specs table to include OpenRPC and JSON Schema

## Test plan
- [ ] Run `mkdocs serve` and verify all pages render correctly
- [ ] Verify tabbed Java/TypeScript code blocks work on each page
- [ ] Check all internal links resolve
- [ ] Review code examples for API accuracy