### PR TITLE
test(generator): add synthetic snapshot test + deterministic ordering fix

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/index/concept/ConceptIndex.java
+++ b/generator/src/main/java/io/apitomy/umg/index/concept/ConceptIndex.java
@@ -17,6 +17,7 @@
 package io.apitomy.umg.index.concept;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -175,7 +176,10 @@ public class ConceptIndex {
     public Collection<PropertyModelWithOrigin> getAllEntityProperties(EntityModel entityModel) {
         EntityModel model = entityModel;
         PropertyModelWithOriginComparator propertyComparator = lookupPropertyComparator(entityModel);
-        final Set<PropertyModelWithOrigin> models = propertyComparator == null ? new HashSet<>() : new TreeSet<>(propertyComparator);
+        // Use alphabetical ordering as fallback when no explicit propertyOrder is declared
+        final Set<PropertyModelWithOrigin> models = propertyComparator == null
+                ? new TreeSet<>(Comparator.comparing(p -> p.getProperty().getName()))
+                : new TreeSet<>(propertyComparator);
         while (model != null) {
             final EntityModel _entity = model;
             models.addAll(model.getProperties().values().stream().map(property -> PropertyModelWithOrigin.builder().property(property).origin(_entity).build()).collect(Collectors.toList()));
@@ -203,7 +207,9 @@ public class ConceptIndex {
     public Collection<PropertyModelWithOrigin> getEntityPropertiesFromTraits(EntityModel entityModel) {
         EntityModel model = entityModel;
         PropertyModelWithOriginComparator propertyComparator = lookupPropertyComparator(entityModel);
-        final Set<PropertyModelWithOrigin> models = propertyComparator == null ? new HashSet<>() : new TreeSet<>(propertyComparator);
+        final Set<PropertyModelWithOrigin> models = propertyComparator == null
+                ? new TreeSet<>(Comparator.comparing(p -> p.getProperty().getName()))
+                : new TreeSet<>(propertyComparator);
         while (model != null) {
             // Include properties from all traits.
             model.getTraits().forEach(trait -> {

--- a/generator/src/main/java/io/apitomy/umg/index/concept/SpecificationIndex.java
+++ b/generator/src/main/java/io/apitomy/umg/index/concept/SpecificationIndex.java
@@ -36,6 +36,11 @@ import lombok.Getter;
  */
 public class SpecificationIndex {
 
+    // TODO: Changing to LinkedHashSet exposes a pre-existing bug in
+    //  CreateUnionTypeValuesStage / CreateUnionValueMethodsStage where entity list union
+    //  values (e.g., [JSchema]) are not correctly resolved across different specs with
+    //  different entity naming (AsyncAPI Schema vs JSON Schema JSchema). Fix tracked
+    //  alongside the type system refactoring (G6).
     private Collection<SpecificationModel> specifications = new HashSet<>();
 
     private Collection<SpecificationVersion> specificationVersions = new HashSet<>();

--- a/generator/src/main/java/io/apitomy/umg/models/concept/PropertyType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/PropertyType.java
@@ -2,7 +2,7 @@ package io.apitomy.umg.models.concept;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -144,7 +144,7 @@ public class PropertyType {
     }
 
     @Builder.Default
-    private final Set<PropertyType> nested = new HashSet<>();
+    private final Set<PropertyType> nested = new LinkedHashSet<>();
 
     @Builder.Default
     private String simpleType = "";

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
@@ -1,7 +1,8 @@
 package io.apitomy.umg.pipe.concept;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.TreeSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class NormalizePropertiesStage extends AbstractStage {
                 // Get all direct children of this parent entity.
                 Collection<EntityModel> childEntities = getState().findChildEntitiesFor(parentEntity);
                 // Get a collection of all properties for the children
-                Set<PropertyModel> allProperties = new HashSet<>();
+                Set<PropertyModel> allProperties = new TreeSet<>(Comparator.comparing(PropertyModel::getName));
                 childEntities.forEach(child -> allProperties.addAll(child.getProperties().values()));
 
                 // Filter the full list of properties - only keep the properties that exist in *all* children.
@@ -69,7 +70,7 @@ public class NormalizePropertiesStage extends AbstractStage {
                 // Get all direct children of this parent trait.
                 Collection<TraitModel> childTraits = getState().findChildTraitsFor(parentTrait);
                 // Get a collection of all properties for the children
-                Set<PropertyModel> allProperties = new HashSet<>();
+                Set<PropertyModel> allProperties = new TreeSet<>(Comparator.comparing(PropertyModel::getName));
                 childTraits.forEach(child -> allProperties.addAll(child.getProperties().values()));
 
                 // Filter the full list of properties - only keep the properties that exist in *all* children.

--- a/generator/src/test/java/io/apitomy/umg/SyntheticSnapshotTest.java
+++ b/generator/src/test/java/io/apitomy/umg/SyntheticSnapshotTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,14 +44,9 @@ public class SyntheticSnapshotTest {
         try {
             generate(outputDir, testOutputDir);
 
-            // Use classpath to find expected dir location, then resolve in source tree
-            var expectedUrl = SyntheticSnapshotTest.class.getResource(EXPECTED_RESOURCE);
-            File expectedDir;
-            if (expectedUrl != null) {
-                expectedDir = new File(expectedUrl.toURI());
-            } else {
-                expectedDir = findSourceDir();
-                // First run — save generated output as expected
+            // Use source directory directly (not classpath) to avoid stale target/test-classes copies
+            var expectedDir = findSourceDir();
+            if (!expectedDir.exists()) {
                 FileUtils.copyDirectory(outputDir, expectedDir);
                 System.out.println("[Synthetic] Expected output created at " + expectedDir.getAbsolutePath());
                 System.out.println("[Synthetic] Review and commit the expected files.");
@@ -111,17 +105,14 @@ public class SyntheticSnapshotTest {
                     var actualContent = Files.readString(actualFile, StandardCharsets.UTF_8);
                     if (!expectedContent.equals(actualContent)) {
                         failures.add("CHANGED: " + relative);
-                        if (failures.size() == 1) {
-                            // Print first diff for debugging
-                            var expectedLines = expectedContent.lines().toList();
-                            var actualLines = actualContent.lines().toList();
-                            for (int i = 0; i < Math.min(expectedLines.size(), actualLines.size()); i++) {
-                                if (!expectedLines.get(i).equals(actualLines.get(i))) {
-                                    failures.add("  First diff at line " + (i + 1) + ":");
-                                    failures.add("  Expected: " + expectedLines.get(i));
-                                    failures.add("  Actual:   " + actualLines.get(i));
-                                    break;
-                                }
+                        var expectedLines = expectedContent.lines().toList();
+                        var actualLines = actualContent.lines().toList();
+                        for (int i = 0; i < Math.min(expectedLines.size(), actualLines.size()); i++) {
+                            if (!expectedLines.get(i).equals(actualLines.get(i))) {
+                                failures.add("  First diff at line " + (i + 1) + ":");
+                                failures.add("    Expected: " + expectedLines.get(i));
+                                failures.add("    Actual:   " + actualLines.get(i));
+                                break;
                             }
                         }
                     }

--- a/generator/src/test/java/io/apitomy/umg/SyntheticSnapshotTest.java
+++ b/generator/src/test/java/io/apitomy/umg/SyntheticSnapshotTest.java
@@ -1,0 +1,161 @@
+package io.apitomy.umg;
+
+import io.apitomy.umg.io.SpecificationLoader;
+import io.apitomy.umg.models.spec.SpecificationModel;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Snapshot test: generates code from the synthetic spec and compares
+ * every file byte-for-byte against committed expected output.
+ * <p>
+ * To update expected output after intentional changes:
+ * <ol>
+ *   <li>Delete {@code generator/src/test/resources/io/apitomy/umg/synthetic/expected/}</li>
+ *   <li>Run this test — it will generate and save the expected output</li>
+ *   <li>Review and commit the new expected files</li>
+ * </ol>
+ */
+public class SyntheticSnapshotTest {
+
+    private static final String EXPECTED_RESOURCE = "synthetic/expected";
+    private static final String EXPECTED_SOURCE_DIR = "src/test/resources/io/apitomy/umg/synthetic/expected";
+
+    @Test
+    public void testSyntheticSnapshot() throws Exception {
+        var outputDir = Files.createTempDirectory("umg-synthetic").toFile();
+        var testOutputDir = Files.createTempDirectory("umg-synthetic-test").toFile();
+
+        try {
+            generate(outputDir, testOutputDir);
+
+            // Use classpath to find expected dir location, then resolve in source tree
+            var expectedUrl = SyntheticSnapshotTest.class.getResource(EXPECTED_RESOURCE);
+            File expectedDir;
+            if (expectedUrl != null) {
+                expectedDir = new File(expectedUrl.toURI());
+            } else {
+                expectedDir = findSourceDir();
+                // First run — save generated output as expected
+                FileUtils.copyDirectory(outputDir, expectedDir);
+                System.out.println("[Synthetic] Expected output created at " + expectedDir.getAbsolutePath());
+                System.out.println("[Synthetic] Review and commit the expected files.");
+                return;
+            }
+
+            // Compare all generated files against expected
+            var failures = compareDirectories(expectedDir.toPath(), outputDir.toPath());
+            if (!failures.isEmpty()) {
+                var sb = new StringBuilder("Synthetic snapshot test failed with " + failures.size() + " difference(s):\n");
+                for (var failure : failures) {
+                    sb.append("  ").append(failure).append("\n");
+                }
+                sb.append("\nTo update, delete ").append(EXPECTED_SOURCE_DIR).append("/ and re-run.");
+                fail(sb.toString());
+            }
+
+        } finally {
+            FileUtils.deleteDirectory(outputDir);
+            FileUtils.deleteDirectory(testOutputDir);
+        }
+    }
+
+    private void generate(File outputDir, File testOutputDir) throws Exception {
+        var config = UnifiedModelGeneratorConfig.builder()
+                .outputDirectory(outputDir)
+                .testOutputDirectory(testOutputDir)
+                .generateTestFixtures(false)
+                .rootNamespace("io.test.synthetic")
+                .build();
+
+        List<SpecificationModel> specs = List.of(
+                SpecificationLoader.loadSpec(
+                        SyntheticSnapshotTest.class.getResource("synthetic/synthetic.yaml"))
+        );
+
+        new UnifiedModelGenerator(config, specs).generate();
+    }
+
+    private List<String> compareDirectories(Path expectedDir, Path actualDir) throws IOException {
+        var failures = new ArrayList<String>();
+
+        // Check all expected files exist and match
+        try (Stream<Path> walk = Files.walk(expectedDir)) {
+            walk.filter(Files::isRegularFile).forEach(expectedFile -> {
+                var relative = expectedDir.relativize(expectedFile);
+                var actualFile = actualDir.resolve(relative);
+
+                if (!Files.exists(actualFile)) {
+                    failures.add("MISSING: " + relative);
+                    return;
+                }
+
+                try {
+                    var expectedContent = Files.readString(expectedFile, StandardCharsets.UTF_8);
+                    var actualContent = Files.readString(actualFile, StandardCharsets.UTF_8);
+                    if (!expectedContent.equals(actualContent)) {
+                        failures.add("CHANGED: " + relative);
+                        if (failures.size() == 1) {
+                            // Print first diff for debugging
+                            var expectedLines = expectedContent.lines().toList();
+                            var actualLines = actualContent.lines().toList();
+                            for (int i = 0; i < Math.min(expectedLines.size(), actualLines.size()); i++) {
+                                if (!expectedLines.get(i).equals(actualLines.get(i))) {
+                                    failures.add("  First diff at line " + (i + 1) + ":");
+                                    failures.add("  Expected: " + expectedLines.get(i));
+                                    failures.add("  Actual:   " + actualLines.get(i));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    failures.add("ERROR reading " + relative + ": " + e.getMessage());
+                }
+            });
+        }
+
+        // Check for unexpected new files
+        try (Stream<Path> walk = Files.walk(actualDir)) {
+            walk.filter(Files::isRegularFile).forEach(actualFile -> {
+                var relative = actualDir.relativize(actualFile);
+                var expectedFile = expectedDir.resolve(relative);
+                if (!Files.exists(expectedFile)) {
+                    failures.add("NEW: " + relative);
+                }
+            });
+        }
+
+        return failures;
+    }
+
+    private File findSourceDir() {
+        // Walk up from CWD to find the generator module root
+        var candidates = List.of(
+                new File(EXPECTED_SOURCE_DIR),
+                new File("generator/" + EXPECTED_SOURCE_DIR)
+        );
+        for (var candidate : candidates) {
+            if (candidate.getParentFile().exists()) {
+                return candidate;
+            }
+        }
+        return new File(EXPECTED_SOURCE_DIR);
+    }
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/MappedNode.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/MappedNode.java
@@ -1,0 +1,54 @@
+package io.test.synthetic;
+
+import java.util.List;
+
+public interface MappedNode<T> {
+
+	/**
+	 * Gets a single item (indexed child) by name. Returns undefined if not found.
+	 * 
+	 * @param name
+	 */
+	public T getItem(String name);
+
+	/**
+	 * Returns an array of all the child items.
+	 */
+	public List<T> getItems();
+
+	/**
+	 * Gets a list of the names of all indexed children.
+	 */
+	public List<String> getItemNames();
+
+	/**
+	 * Adds a child item.
+	 * 
+	 * @param name
+	 * @param item
+	 */
+	public void addItem(String name, T item);
+
+	/**
+	 * Inserts a child item.
+	 *
+	 * @param name
+	 * @param item
+	 * @param atIndex
+	 */
+	public void insertItem(String name, T item, int atIndex);
+
+	/**
+	 * Removes a child item by name and returns the deleted child or undefined if
+	 * there wasn't one.
+	 * 
+	 * @param name
+	 */
+	public T removeItem(String name);
+
+	/**
+	 * Removes all children.
+	 */
+	public void clearItems();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/ModelType.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/ModelType.java
@@ -1,0 +1,4 @@
+package io.test.synthetic;
+public enum ModelType {
+	SYN1, SYN2
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Node.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Node.java
@@ -1,0 +1,28 @@
+package io.test.synthetic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collection;
+import java.util.List;
+
+public interface Node extends Visitable {
+
+	public int modelId();
+	public RootNode root();
+	public Node parent();
+	public String parentPropertyName();
+	public ParentPropertyType parentPropertyType();
+	public String mapPropertyName();
+	public Object getNodeAttribute(String attributeName);
+	public void setNodeAttribute(String attributeName, Object attributeValue);
+	public Collection<String> getNodeAttributeNames();
+	public void clearNodeAttributes();
+	public void addExtraProperty(String key, JsonNode value);
+	public JsonNode removeExtraProperty(String name);
+	public boolean hasExtraProperties();
+	public List<String> getExtraPropertyNames();
+	public JsonNode getExtraProperty(String name);
+	public boolean isAttached();
+	public void attach(Node parent);
+	public Node emptyClone();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
@@ -1,0 +1,174 @@
+package io.test.synthetic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class NodeImpl implements Node {
+
+	private static int __modelIdCounter = 0;
+
+	protected int _modelId = __modelIdCounter++;
+	private String _parentPropertyName;
+	private String _mapPropertyName;
+	private ParentPropertyType _parentPropertyType = ParentPropertyType.standard;
+	private Node _parent;
+	private Map<String, JsonNode> _extraProperties;
+	private Map<String, Object> _attributes;
+
+	@Override
+	public RootNode root() {
+		return this._parent.root();
+	}
+
+	@Override
+	public Node parent() {
+		return this._parent;
+	}
+
+	@Override
+	public String parentPropertyName() {
+		return this._parentPropertyName;
+	}
+
+	@Override
+	public ParentPropertyType parentPropertyType() {
+		return this._parentPropertyType;
+	}
+
+	@Override
+	public String mapPropertyName() {
+		return this._mapPropertyName;
+	}
+
+	public void setParent(Node parent) {
+		this._parent = parent;
+	}
+
+	public void _setParentPropertyName(String name) {
+		this._parentPropertyName = name;
+	}
+
+	public void _setParentPropertyType(ParentPropertyType type) {
+		this._parentPropertyType = type;
+	}
+
+	public void _setMapPropertyName(String name) {
+		this._mapPropertyName = name;
+	}
+
+	@Override
+	public int modelId() {
+		return this._modelId;
+	}
+
+	@Override
+	public Object getNodeAttribute(String attributeName) {
+		if (this._attributes != null) {
+			return this._attributes.get(attributeName);
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public void setNodeAttribute(String attributeName, Object attributeValue) {
+		if (this._attributes == null) {
+			this._attributes = new HashMap<>();
+		}
+		this._attributes.put(attributeName, attributeValue);
+	}
+
+	@Override
+	public Collection<String> getNodeAttributeNames() {
+		if (this._attributes != null) {
+			return this._attributes.keySet();
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public void clearNodeAttributes() {
+		if (this._attributes != null) {
+			this._attributes.clear();
+		}
+	}
+
+	@Override
+	public void addExtraProperty(String key, JsonNode value) {
+		if (this._extraProperties == null) {
+			this._extraProperties = new LinkedHashMap<>();
+		}
+		this._extraProperties.put(key, value);
+	}
+
+	@Override
+	public JsonNode removeExtraProperty(String name) {
+		if (this._extraProperties != null && this._extraProperties.containsKey(name)) {
+			return this._extraProperties.remove(name);
+		}
+		return null;
+	}
+
+	@Override
+	public boolean hasExtraProperties() {
+		return this._extraProperties != null && this._extraProperties.size() > 0;
+	}
+
+	@Override
+	public List<String> getExtraPropertyNames() {
+		if (this.hasExtraProperties()) {
+			return new ArrayList<String>(this._extraProperties.keySet());
+		}
+		return Collections.emptyList();
+	}
+
+	@Override
+	public JsonNode getExtraProperty(String name) {
+		if (this.hasExtraProperties()) {
+			return this._extraProperties.get(name);
+		}
+		return null;
+	}
+
+	@Override
+	public boolean isAttached() {
+		if (_parent == null) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void attach(Node parent) {
+		if (!parent.isAttached())
+			throw new IllegalArgumentException("Target parent node (method argument) is not itself attached.");
+		this.setParent(parent);
+	}
+
+	/*
+	 * Some methods that must be implemented on an entity only when the entity is
+	 * part of a union type. We put them here so we don't have to generate them. But
+	 * perhaps we *should* generate them only on the appropriate entity
+	 * implementation classes.
+	 */
+
+	public boolean isEntity() {
+		return true;
+	}
+
+	public boolean isEntityList() {
+		return false;
+	}
+
+	public boolean isEntityMap() {
+		return false;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/ParentPropertyType.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/ParentPropertyType.java
@@ -1,0 +1,5 @@
+package io.test.synthetic;
+
+public enum ParentPropertyType {
+	standard, map, array
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootNode.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootNode.java
@@ -1,0 +1,7 @@
+package io.test.synthetic;
+
+public interface RootNode extends Node {
+
+	public ModelType modelType();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootNodeImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootNodeImpl.java
@@ -1,0 +1,21 @@
+package io.test.synthetic;
+
+public abstract class RootNodeImpl extends NodeImpl implements RootNode {
+
+	private final ModelType _modelType;
+
+	public RootNodeImpl(ModelType modelType) {
+		this._modelType = modelType;
+	}
+
+	@Override
+	public RootNode root() {
+		return this;
+	}
+
+	@Override
+	public ModelType modelType() {
+		return this._modelType;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynContact.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynContact.java
@@ -1,0 +1,15 @@
+package io.test.synthetic;
+public interface SynContact extends Node {
+
+	public String getEmail();
+
+	public void setEmail(String value);
+
+	public String getUrl();
+
+	public void setUrl(String value);
+
+	public String getName();
+
+	public void setName(String value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynContact.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynContact.java
@@ -5,11 +5,11 @@ public interface SynContact extends Node {
 
 	public void setEmail(String value);
 
-	public String getUrl();
-
-	public void setUrl(String value);
-
 	public String getName();
 
 	public void setName(String value);
+
+	public String getUrl();
+
+	public void setUrl(String value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
@@ -1,0 +1,37 @@
+package io.test.synthetic;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SynDocument extends Node {
+
+	public String getVersion();
+
+	public void setVersion(String value);
+
+	public SynInfo getInfo();
+
+	public void setInfo(SynInfo value);
+
+	public SynInfo createInfo();
+
+	public List<String> getTags();
+
+	public void setTags(List<String> value);
+
+	public Map<String, String> getMetadata();
+
+	public void setMetadata(Map<String, String> value);
+
+	public SynItem createItem();
+
+	public List<SynItem> getItems();
+
+	public void addItem(SynItem value);
+
+	public void clearItems();
+
+	public void removeItem(SynItem value);
+
+	public void insertItem(SynItem value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
@@ -5,23 +5,11 @@ import java.util.Map;
 
 public interface SynDocument extends Node {
 
-	public String getVersion();
-
-	public void setVersion(String value);
-
 	public SynInfo getInfo();
 
 	public void setInfo(SynInfo value);
 
 	public SynInfo createInfo();
-
-	public List<String> getTags();
-
-	public void setTags(List<String> value);
-
-	public Map<String, String> getMetadata();
-
-	public void setMetadata(Map<String, String> value);
 
 	public SynItem createItem();
 
@@ -34,4 +22,16 @@ public interface SynDocument extends Node {
 	public void removeItem(SynItem value);
 
 	public void insertItem(SynItem value, int atIndex);
+
+	public Map<String, String> getMetadata();
+
+	public void setMetadata(Map<String, String> value);
+
+	public List<String> getTags();
+
+	public void setTags(List<String> value);
+
+	public String getVersion();
+
+	public void setVersion(String value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynExtensible.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynExtensible.java
@@ -1,0 +1,17 @@
+package io.test.synthetic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+
+public interface SynExtensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynInfo.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynInfo.java
@@ -1,0 +1,17 @@
+package io.test.synthetic;
+public interface SynInfo extends Node {
+
+	public String getVersion();
+
+	public void setVersion(String value);
+
+	public SynContact getContact();
+
+	public void setContact(SynContact value);
+
+	public SynContact createContact();
+
+	public String getName();
+
+	public void setName(String value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynInfo.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynInfo.java
@@ -1,10 +1,6 @@
 package io.test.synthetic;
 public interface SynInfo extends Node {
 
-	public String getVersion();
-
-	public void setVersion(String value);
-
 	public SynContact getContact();
 
 	public void setContact(SynContact value);
@@ -14,4 +10,8 @@ public interface SynInfo extends Node {
 	public String getName();
 
 	public void setName(String value);
+
+	public String getVersion();
+
+	public void setVersion(String value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynItem.java
@@ -1,0 +1,51 @@
+package io.test.synthetic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import java.util.List;
+
+public interface SynItem extends Node {
+
+	public Number getWeight();
+
+	public void setWeight(Number value);
+
+	public Boolean isRequired();
+
+	public void setRequired(Boolean value);
+
+	public SynSchema getSchema();
+
+	public void setSchema(SynSchema value);
+
+	public SynSchema createSchema();
+
+	public List<JsonNode> getExamples();
+
+	public void setExamples(List<JsonNode> value);
+
+	public JsonNode getExtra();
+
+	public void setExtra(JsonNode value);
+
+	public ObjectNode getRaw();
+
+	public void setRaw(ObjectNode value);
+
+	public String getTitle();
+
+	public void setTitle(String value);
+
+	public BooleanSchemaUnion getDefaultValue();
+
+	public void setDefaultValue(BooleanSchemaUnion value);
+
+	public Integer getOrder();
+
+	public void setOrder(Integer value);
+
+	public String getDescription();
+
+	public void setDescription(String value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynItem.java
@@ -7,19 +7,15 @@ import java.util.List;
 
 public interface SynItem extends Node {
 
-	public Number getWeight();
+	public BooleanSchemaUnion getDefaultValue();
 
-	public void setWeight(Number value);
-
-	public Boolean isRequired();
-
-	public void setRequired(Boolean value);
-
-	public SynSchema getSchema();
-
-	public void setSchema(SynSchema value);
+	public void setDefaultValue(BooleanSchemaUnion value);
 
 	public SynSchema createSchema();
+
+	public String getDescription();
+
+	public void setDescription(String value);
 
 	public List<JsonNode> getExamples();
 
@@ -29,23 +25,27 @@ public interface SynItem extends Node {
 
 	public void setExtra(JsonNode value);
 
+	public Integer getOrder();
+
+	public void setOrder(Integer value);
+
 	public ObjectNode getRaw();
 
 	public void setRaw(ObjectNode value);
+
+	public Boolean isRequired();
+
+	public void setRequired(Boolean value);
+
+	public SynSchema getSchema();
+
+	public void setSchema(SynSchema value);
 
 	public String getTitle();
 
 	public void setTitle(String value);
 
-	public BooleanSchemaUnion getDefaultValue();
+	public Number getWeight();
 
-	public void setDefaultValue(BooleanSchemaUnion value);
-
-	public Integer getOrder();
-
-	public void setOrder(Integer value);
-
-	public String getDescription();
-
-	public void setDescription(String value);
+	public void setWeight(Number value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
@@ -8,14 +8,6 @@ public interface SynOperation extends Node {
 
 	public void setOperationId(String value);
 
-	public String getSummary();
-
-	public void setSummary(String value);
-
-	public List<String> getTags();
-
-	public void setTags(List<String> value);
-
 	public SynItem createItem();
 
 	public List<SynItem> getParameters();
@@ -27,4 +19,12 @@ public interface SynOperation extends Node {
 	public void removeParameter(SynItem value);
 
 	public void insertParameter(SynItem value, int atIndex);
+
+	public String getSummary();
+
+	public void setSummary(String value);
+
+	public List<String> getTags();
+
+	public void setTags(List<String> value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
@@ -1,0 +1,30 @@
+package io.test.synthetic;
+
+import java.util.List;
+
+public interface SynOperation extends Node {
+
+	public String getOperationId();
+
+	public void setOperationId(String value);
+
+	public String getSummary();
+
+	public void setSummary(String value);
+
+	public List<String> getTags();
+
+	public void setTags(List<String> value);
+
+	public SynItem createItem();
+
+	public List<SynItem> getParameters();
+
+	public void addParameter(SynItem value);
+
+	public void clearParameters();
+
+	public void removeParameter(SynItem value);
+
+	public void insertParameter(SynItem value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPathItem.java
@@ -1,0 +1,21 @@
+package io.test.synthetic;
+public interface SynPathItem extends Node {
+
+	public SynOperation getPut();
+
+	public void setPut(SynOperation value);
+
+	public SynOperation createOperation();
+
+	public SynOperation getPost();
+
+	public void setPost(SynOperation value);
+
+	public String getSummary();
+
+	public void setSummary(String value);
+
+	public SynOperation getGet();
+
+	public void setGet(SynOperation value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPathItem.java
@@ -1,9 +1,9 @@
 package io.test.synthetic;
 public interface SynPathItem extends Node {
 
-	public SynOperation getPut();
+	public SynOperation getGet();
 
-	public void setPut(SynOperation value);
+	public void setGet(SynOperation value);
 
 	public SynOperation createOperation();
 
@@ -11,11 +11,11 @@ public interface SynPathItem extends Node {
 
 	public void setPost(SynOperation value);
 
+	public SynOperation getPut();
+
+	public void setPut(SynOperation value);
+
 	public String getSummary();
 
 	public void setSummary(String value);
-
-	public SynOperation getGet();
-
-	public void setGet(SynOperation value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPaths.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynPaths.java
@@ -1,0 +1,5 @@
+package io.test.synthetic;
+public interface SynPaths extends Node, MappedNode<SynPathItem> {
+
+	public SynPathItem createPathItem();
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynReferenceable.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynReferenceable.java
@@ -1,0 +1,7 @@
+package io.test.synthetic;
+public interface SynReferenceable {
+
+	public String get$ref();
+
+	public void set$ref(String value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
@@ -1,0 +1,62 @@
+package io.test.synthetic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import java.util.List;
+import java.util.Map;
+
+public interface SynSchema extends Node, BooleanSchemaUnion, BooleanSchemaSchemaListUnion {
+
+	public SynSchema createSchema();
+
+	public Map<String, BooleanSchemaUnion> getProperties();
+
+	public void addProperty(String name, BooleanSchemaUnion value);
+
+	public void clearProperties();
+
+	public void removeProperty(String name);
+
+	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex);
+
+	public List<JsonNode> getEnum();
+
+	public void setEnum(List<JsonNode> value);
+
+	public BooleanSchemaSchemaListUnion getItems();
+
+	public void setItems(BooleanSchemaSchemaListUnion value);
+
+	public Integer getMinLength();
+
+	public void setMinLength(Integer value);
+
+	public List<BooleanSchemaUnion> getAllOf();
+
+	public void addAllOf(BooleanSchemaUnion value);
+
+	public void clearAllOf();
+
+	public void removeAllOf(BooleanSchemaUnion value);
+
+	public void insertAllOf(BooleanSchemaUnion value, int atIndex);
+
+	public String getType();
+
+	public void setType(String value);
+
+	public Map<String, BooleanSchemaUnion> getDefinitions();
+
+	public void addDefinition(String name, BooleanSchemaUnion value);
+
+	public void clearDefinitions();
+
+	public void removeDefinition(String name);
+
+	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex);
+
+	public Integer getMaxLength();
+
+	public void setMaxLength(Integer value);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
@@ -10,28 +10,6 @@ public interface SynSchema extends Node, BooleanSchemaUnion, BooleanSchemaSchema
 
 	public SynSchema createSchema();
 
-	public Map<String, BooleanSchemaUnion> getProperties();
-
-	public void addProperty(String name, BooleanSchemaUnion value);
-
-	public void clearProperties();
-
-	public void removeProperty(String name);
-
-	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex);
-
-	public List<JsonNode> getEnum();
-
-	public void setEnum(List<JsonNode> value);
-
-	public BooleanSchemaSchemaListUnion getItems();
-
-	public void setItems(BooleanSchemaSchemaListUnion value);
-
-	public Integer getMinLength();
-
-	public void setMinLength(Integer value);
-
 	public List<BooleanSchemaUnion> getAllOf();
 
 	public void addAllOf(BooleanSchemaUnion value);
@@ -41,10 +19,6 @@ public interface SynSchema extends Node, BooleanSchemaUnion, BooleanSchemaSchema
 	public void removeAllOf(BooleanSchemaUnion value);
 
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex);
-
-	public String getType();
-
-	public void setType(String value);
 
 	public Map<String, BooleanSchemaUnion> getDefinitions();
 
@@ -56,7 +30,33 @@ public interface SynSchema extends Node, BooleanSchemaUnion, BooleanSchemaSchema
 
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex);
 
+	public List<JsonNode> getEnum();
+
+	public void setEnum(List<JsonNode> value);
+
+	public BooleanSchemaSchemaListUnion getItems();
+
+	public void setItems(BooleanSchemaSchemaListUnion value);
+
 	public Integer getMaxLength();
 
 	public void setMaxLength(Integer value);
+
+	public Integer getMinLength();
+
+	public void setMinLength(Integer value);
+
+	public Map<String, BooleanSchemaUnion> getProperties();
+
+	public void addProperty(String name, BooleanSchemaUnion value);
+
+	public void clearProperties();
+
+	public void removeProperty(String name);
+
+	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex);
+
+	public String getType();
+
+	public void setType(String value);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Visitable.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Visitable.java
@@ -1,0 +1,9 @@
+package io.test.synthetic;
+
+import io.test.synthetic.visitors.Visitor;
+
+public interface Visitable {
+
+	public void accept(Visitor visitor);
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReader.java
@@ -1,0 +1,10 @@
+package io.test.synthetic.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+
+public interface ModelReader {
+
+	public RootNode readRoot(ObjectNode json);
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReaderFactory.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReaderFactory.java
@@ -1,0 +1,39 @@
+package io.test.synthetic.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.ModelType;
+import io.test.synthetic.v1.io.Syn1ModelReader;
+import io.test.synthetic.v1.io.Syn1ModelReaderDispatcher;
+import io.test.synthetic.v2.io.Syn2ModelReader;
+import io.test.synthetic.v2.io.Syn2ModelReaderDispatcher;
+import io.test.synthetic.visitors.Visitor;
+
+public class ModelReaderFactory {
+
+	public static ModelReader createModelReader(ModelType modelType) {
+		ModelReader reader = null;
+		switch (modelType) {
+			case SYN2 :
+				reader = new Syn2ModelReader();
+				break;
+			case SYN1 :
+				reader = new Syn1ModelReader();
+				break;
+		}
+		return reader;
+	}
+
+	public static Visitor createModelReaderDispatcher(ModelType modelType, ObjectNode json) {
+		ModelReader reader = ModelReaderFactory.createModelReader(modelType);
+		Visitor visitor = null;
+		switch (modelType) {
+			case SYN2 :
+				visitor = new Syn2ModelReaderDispatcher(json, (Syn2ModelReader) reader);
+				break;
+			case SYN1 :
+				visitor = new Syn1ModelReaderDispatcher(json, (Syn1ModelReader) reader);
+				break;
+		}
+		return visitor;
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriter.java
@@ -1,0 +1,10 @@
+package io.test.synthetic.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+
+public interface ModelWriter {
+
+	public ObjectNode writeRoot(RootNode node);
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriterFactory.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriterFactory.java
@@ -1,0 +1,39 @@
+package io.test.synthetic.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.ModelType;
+import io.test.synthetic.v1.io.Syn1ModelWriter;
+import io.test.synthetic.v1.io.Syn1ModelWriterDispatcher;
+import io.test.synthetic.v2.io.Syn2ModelWriter;
+import io.test.synthetic.v2.io.Syn2ModelWriterDispatcher;
+import io.test.synthetic.visitors.Visitor;
+
+public class ModelWriterFactory {
+
+	public static ModelWriter createModelWriter(ModelType modelType) {
+		ModelWriter writer = null;
+		switch (modelType) {
+			case SYN2 :
+				writer = new Syn2ModelWriter();
+				break;
+			case SYN1 :
+				writer = new Syn1ModelWriter();
+				break;
+		}
+		return writer;
+	}
+
+	public static Visitor createModelWriterDispatcher(ModelType modelType, ObjectNode json) {
+		ModelWriter writer = ModelWriterFactory.createModelWriter(modelType);
+		Visitor visitor = null;
+		switch (modelType) {
+			case SYN2 :
+				visitor = new Syn2ModelWriterDispatcher(json, (Syn2ModelWriter) writer);
+				break;
+			case SYN1 :
+				visitor = new Syn1ModelWriterDispatcher(json, (Syn1ModelWriter) writer);
+				break;
+		}
+		return visitor;
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/AnyUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/AnyUnionValue.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.union;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface AnyUnionValue extends PrimitiveUnionValue<JsonNode> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/AnyUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/AnyUnionValueImpl.java
@@ -1,0 +1,15 @@
+package io.test.synthetic.union;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class AnyUnionValueImpl extends PrimitiveUnionValueImpl<JsonNode> implements AnyUnionValue {
+
+	public AnyUnionValueImpl() {
+		super();
+	}
+
+	public AnyUnionValueImpl(JsonNode value) {
+		super(value);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanSchemaSchemaListUnion.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanSchemaSchemaListUnion.java
@@ -1,0 +1,19 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+import java.util.List;
+
+public interface BooleanSchemaSchemaListUnion extends Union {
+
+	public boolean isBoolean();
+
+	public Boolean asBoolean();
+
+	public boolean isSchema();
+
+	public SynSchema asSchema();
+
+	public boolean isSchemaList();
+
+	public List<SynSchema> asSchemaList();
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanSchemaUnion.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanSchemaUnion.java
@@ -1,0 +1,14 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+
+public interface BooleanSchemaUnion extends Union {
+
+	public boolean isBoolean();
+
+	public Boolean asBoolean();
+
+	public boolean isSchema();
+
+	public SynSchema asSchema();
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValue.java
@@ -1,0 +1,9 @@
+package io.test.synthetic.union;
+
+public interface BooleanUnionValue
+		extends
+			PrimitiveUnionValue<Boolean>,
+			BooleanSchemaUnion,
+			BooleanSchemaSchemaListUnion {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValueImpl.java
@@ -1,0 +1,42 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+import java.util.List;
+
+public class BooleanUnionValueImpl extends PrimitiveUnionValueImpl<Boolean> implements BooleanUnionValue {
+
+	public BooleanUnionValueImpl(Boolean value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isBoolean() {
+		return true;
+	}
+
+	@Override
+	public Boolean asBoolean() {
+		return getValue();
+	}
+
+	@Override
+	public boolean isSchema() {
+		return false;
+	}
+
+	@Override
+	public SynSchema asSchema() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public boolean isSchemaList() {
+		return false;
+	}
+
+	@Override
+	public List<SynSchema> asSchemaList() {
+		throw new ClassCastException();
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityListUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityListUnionValue.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.Node;
+
+public interface EntityListUnionValue<T extends Node> extends ListUnionValue<T> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityListUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityListUnionValueImpl.java
@@ -1,0 +1,21 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.Node;
+import java.util.List;
+
+public class EntityListUnionValueImpl<T extends Node> extends ListUnionValueImpl<T> implements EntityListUnionValue<T> {
+
+	public EntityListUnionValueImpl() {
+		super();
+	}
+
+	public EntityListUnionValueImpl(List<T> value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isEntityList() {
+		return true;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityMapUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityMapUnionValue.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.Node;
+
+public interface EntityMapUnionValue<T extends Node> extends MapUnionValue<T> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityMapUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/EntityMapUnionValueImpl.java
@@ -1,0 +1,21 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.Node;
+import java.util.Map;
+
+public class EntityMapUnionValueImpl<T extends Node> extends MapUnionValueImpl<T> implements EntityMapUnionValue<T> {
+
+	public EntityMapUnionValueImpl() {
+		super();
+	}
+
+	public EntityMapUnionValueImpl(Map<String, T> value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isEntityMap() {
+		return true;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ListUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ListUnionValue.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.union;
+
+import java.util.List;
+
+public interface ListUnionValue<T> extends UnionValue<List<T>> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ListUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ListUnionValueImpl.java
@@ -1,0 +1,21 @@
+package io.test.synthetic.union;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ListUnionValueImpl<T> extends UnionValueImpl<List<T>> implements ListUnionValue<T> {
+
+	public ListUnionValueImpl() {
+		super(new ArrayList<>());
+	}
+
+	public ListUnionValueImpl(List<T> value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isList() {
+		return true;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/MapUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/MapUnionValue.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.union;
+
+import java.util.Map;
+
+public interface MapUnionValue<T> extends UnionValue<Map<String, T>> {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/MapUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/MapUnionValueImpl.java
@@ -1,0 +1,21 @@
+package io.test.synthetic.union;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class MapUnionValueImpl<T> extends UnionValueImpl<Map<String, T>> implements MapUnionValue<T> {
+
+	public MapUnionValueImpl() {
+		super(new LinkedHashMap<String, T>());
+	}
+
+	public MapUnionValueImpl(Map<String, T> value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isMap() {
+		return true;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ObjectUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ObjectUnionValue.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.union;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public interface ObjectUnionValue extends PrimitiveUnionValue<ObjectNode> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ObjectUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/ObjectUnionValueImpl.java
@@ -1,0 +1,15 @@
+package io.test.synthetic.union;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class ObjectUnionValueImpl extends PrimitiveUnionValueImpl<ObjectNode> implements ObjectUnionValue {
+
+	public ObjectUnionValueImpl() {
+		super();
+	}
+
+	public ObjectUnionValueImpl(Object value) {
+		super((ObjectNode) value);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/PrimitiveUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/PrimitiveUnionValue.java
@@ -1,0 +1,5 @@
+package io.test.synthetic.union;
+
+public interface PrimitiveUnionValue<T> extends UnionValue<T> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/PrimitiveUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/PrimitiveUnionValueImpl.java
@@ -1,0 +1,12 @@
+package io.test.synthetic.union;
+
+public abstract class PrimitiveUnionValueImpl<T> extends UnionValueImpl<T> implements PrimitiveUnionValue<T> {
+
+	public PrimitiveUnionValueImpl() {
+	}
+
+	public PrimitiveUnionValueImpl(T value) {
+		super(value);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaListUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaListUnionValue.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+
+public interface SchemaListUnionValue extends EntityListUnionValue<SynSchema>, BooleanSchemaSchemaListUnion {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaListUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaListUnionValueImpl.java
@@ -1,0 +1,45 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+import java.util.List;
+
+public class SchemaListUnionValueImpl extends EntityListUnionValueImpl<SynSchema> implements SchemaListUnionValue {
+
+	public SchemaListUnionValueImpl() {
+		super();
+	}
+
+	public SchemaListUnionValueImpl(List<SynSchema> value) {
+		super(value);
+	}
+
+	@Override
+	public boolean isBoolean() {
+		return false;
+	}
+
+	@Override
+	public Boolean asBoolean() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public boolean isSchema() {
+		return false;
+	}
+
+	@Override
+	public SynSchema asSchema() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public boolean isSchemaList() {
+		return true;
+	}
+
+	@Override
+	public List<SynSchema> asSchemaList() {
+		return getValue();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringListUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringListUnionValue.java
@@ -1,0 +1,5 @@
+package io.test.synthetic.union;
+
+public interface StringListUnionValue extends ListUnionValue<String> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringListUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringListUnionValueImpl.java
@@ -1,0 +1,15 @@
+package io.test.synthetic.union;
+
+import java.util.List;
+
+public class StringListUnionValueImpl extends ListUnionValueImpl<String> implements StringListUnionValue {
+
+	public StringListUnionValueImpl() {
+		super();
+	}
+
+	public StringListUnionValueImpl(List<String> value) {
+		super(value);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringUnionValue.java
@@ -1,0 +1,5 @@
+package io.test.synthetic.union;
+
+public interface StringUnionValue extends PrimitiveUnionValue<String> {
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringUnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/StringUnionValueImpl.java
@@ -1,0 +1,13 @@
+package io.test.synthetic.union;
+
+public class StringUnionValueImpl extends PrimitiveUnionValueImpl<String> implements StringUnionValue {
+
+	public StringUnionValueImpl() {
+		super();
+	}
+
+	public StringUnionValueImpl(String value) {
+		super(value);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/Union.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/Union.java
@@ -1,0 +1,15 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.Visitable;
+
+public interface Union extends Visitable {
+
+	public Object unionValue();
+
+	public boolean isEntity();
+
+	public boolean isEntityList();
+
+	public boolean isEntityMap();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValue.java
@@ -1,0 +1,13 @@
+package io.test.synthetic.union;
+
+public interface UnionValue<T> {
+
+	T getValue();
+
+	void setValue(T value);
+
+	boolean isList();
+
+	boolean isMap();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValueImpl.java
@@ -1,0 +1,65 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.visitors.Visitor;
+
+/**
+ * Base class for all union value implementations.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
+
+	private T value;
+
+	public UnionValueImpl() {
+	}
+
+	public UnionValueImpl(T value) {
+		this.value = value;
+	}
+
+	@Override
+	public Object unionValue() {
+		return value;
+	}
+
+	@Override
+	public T getValue() {
+		return value;
+	}
+
+	@Override
+	public void setValue(T value) {
+		this.value = value;
+	}
+
+	@Override
+	public boolean isList() {
+		return false;
+	}
+
+	@Override
+	public boolean isMap() {
+		return false;
+	}
+
+	@Override
+	public boolean isEntity() {
+		return false;
+	}
+
+	@Override
+	public boolean isEntityList() {
+		return false;
+	}
+
+	@Override
+	public boolean isEntityMap() {
+		return false;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
@@ -1,0 +1,48 @@
+package io.test.synthetic.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DataModelUtil {
+
+	public static <V> Map<String, V> insertMapEntry(Map<String, V> map, String key, V value, int atIndex) {
+		// If the new key is present, then return without modification.
+		if (map.containsKey(key)) {
+			return map;
+		}
+		// If the map isn't an LHM then ordering can't be maintained anyway
+		// If the atIndex is null then we're trying to undo a command that was persisted
+		// prior to this functionality being added
+		// If the atIndex is >= the map size it has to go at the end anyway
+		if (!(map instanceof LinkedHashMap) || atIndex >= map.size()) {
+			map.put(key, value);
+			return map;
+		}
+
+		final LinkedHashMap<String, V> newMap = new LinkedHashMap<>();
+		// In order to maintain ordering of the elements when replacing a key in a
+		// LinkedHashMap,
+		// create a new instance and populate it in insertion order
+		int index = 0;
+		for (Map.Entry<String, V> entry : map.entrySet()) {
+			if (index++ == atIndex) {
+				newMap.put(key, value);
+			}
+			newMap.put(entry.getKey(), entry.getValue());
+		}
+		return newMap;
+	}
+
+	public static <V> List<V> insertListEntry(List<V> list, V value, int atIndex) {
+		if (atIndex >= list.size()) {
+			list.add(value);
+		} else if (atIndex < 0) {
+			list.add(0, value);
+		} else {
+			list.add(atIndex, value);
+		}
+		return list;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -1,0 +1,941 @@
+package io.test.synthetic.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class JsonUtil {
+
+	private static final JsonNodeFactory factory = JsonNodeFactory.instance;
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	public static List<String> keys(ObjectNode json) {
+		List<String> rval = new ArrayList<>();
+		if (json != null) {
+			Iterator<String> fieldNames = json.fieldNames();
+			while (fieldNames.hasNext()) {
+				String fieldName = fieldNames.next();
+				rval.add(fieldName);
+			}
+		}
+		return rval;
+	}
+
+	public static List<String> matchingKeys(String regex, ObjectNode json) {
+		return keys(json).stream().filter(key -> Pattern.matches(regex, key)).collect(Collectors.toList());
+	}
+
+	public static JsonNode getProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			return json.get(propertyName);
+		}
+		return null;
+	}
+
+	public static void setProperty(ObjectNode json, String propertyName, JsonNode value) {
+		if (value != null) {
+			json.set(propertyName, value);
+		}
+	}
+
+	/* Get/Consume a JSON (Object) property. */
+	public static ObjectNode getObjectProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode objectNode = json.get(propertyName);
+			if (objectNode.isObject()) {
+				return (ObjectNode) objectNode;
+			}
+		}
+		return null;
+	}
+	public static ObjectNode consumeObjectProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			ObjectNode rval = getObjectProperty(json, propertyName);
+			if (rval != null) {
+				json.remove(propertyName);
+				return rval;
+			}
+		}
+		return null;
+	}
+
+	/* Get/Consume a JSON (Any) property. */
+	public static JsonNode getAnyProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode jsonNode = json.get(propertyName);
+			if (!jsonNode.isNull()) {
+				return jsonNode;
+			}
+		}
+		return null;
+	}
+	public static JsonNode consumeAnyProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode rval = getAnyProperty(json, propertyName);
+			json.remove(propertyName);
+			return rval;
+		}
+		return null;
+	}
+
+	/* Get/consume an array of anys property. */
+	public static List<JsonNode> getAnyArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<JsonNode> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				rval.add(item);
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<JsonNode> consumeAnyArrayProperty(ObjectNode json, String propertyName) {
+		List<JsonNode> rval = getAnyArrayProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume an array of objects property. */
+	public static List<ObjectNode> getObjectArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<ObjectNode> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				if (item.isObject()) {
+					rval.add((ObjectNode) item);
+				}
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<ObjectNode> consumeObjectArrayProperty(ObjectNode json, String propertyName) {
+		List<ObjectNode> rval = getObjectArrayProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume an array of strings property. */
+	public static List<String> getStringArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<String> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				rval.add(item.isNull() ? null : item.asText());
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<String> consumeStringArrayProperty(ObjectNode json, String propertyName) {
+		ObjectNode node = json;
+		if (node.has(propertyName)) {
+			List<String> rval = getStringArrayProperty(json, propertyName);
+			node.remove(propertyName);
+			return rval;
+		}
+		return null;
+	}
+
+	/* Get/consume an array of integers property. */
+	public static List<Integer> getIntegerArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<Integer> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				if (item.isInt()) {
+					rval.add(item.asInt());
+				}
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<Integer> consumeIntegerArrayProperty(ObjectNode json, String propertyName) {
+		ObjectNode node = json;
+		if (node.has(propertyName)) {
+			List<Integer> rval = getIntegerArrayProperty(json, propertyName);
+			node.remove(propertyName);
+			return rval;
+		}
+		return null;
+	}
+
+	/* Get/consume an array of numbers property. */
+	public static List<Number> getNumberArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<Number> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				if (item.isInt()) {
+					rval.add(item.asInt());
+				}
+				if (item.isLong()) {
+					rval.add(item.asLong());
+				}
+				if (item.isFloat() || item.isDouble() || item.isBigDecimal() || item.isBigInteger()) {
+					rval.add(item.asDouble());
+				}
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<Number> consumeNumberArrayProperty(ObjectNode json, String propertyName) {
+		ObjectNode node = json;
+		if (node.has(propertyName)) {
+			List<Number> rval = getNumberArrayProperty(json, propertyName);
+			node.remove(propertyName);
+			return rval;
+		}
+		return null;
+	}
+
+	/* Get/consume an array of booleans property. */
+	public static List<Boolean> getBooleanArrayProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isArray()) {
+			ArrayNode array = (ArrayNode) node;
+			List<Boolean> rval = new ArrayList<>();
+			for (JsonNode item : array) {
+				if (item.isBoolean()) {
+					rval.add(item.asBoolean());
+				}
+			}
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static List<Boolean> consumeBooleanArrayProperty(ObjectNode json, String propertyName) {
+		ObjectNode node = json;
+		if (node.has(propertyName)) {
+			List<Boolean> rval = getBooleanArrayProperty(json, propertyName);
+			node.remove(propertyName);
+			return rval;
+		}
+		return null;
+	}
+
+	/* Get/Consume a string property. */
+	public static String getStringProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode textNode = json.get(propertyName);
+			if (textNode.isTextual()) {
+				return textNode.asText();
+			}
+		}
+		return null;
+	}
+	public static String consumeStringProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			String rval = getStringProperty(json, propertyName);
+			if (rval != null) {
+				json.remove(propertyName);
+				return rval;
+			}
+		}
+		return null;
+	}
+
+	/* Get/Consume an Integer property. */
+	public static Integer getIntegerProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode textNode = json.get(propertyName);
+			if (textNode.isInt()) {
+				return textNode.asInt();
+			}
+		}
+		return null;
+	}
+	public static Integer consumeIntegerProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			Integer rval = getIntegerProperty(json, propertyName);
+			if (rval != null) {
+				json.remove(propertyName);
+				return rval;
+			}
+		}
+		return null;
+	}
+
+	/* Get/Consume a Number property. */
+	public static Number getNumberProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode node = json.get(propertyName);
+			if (node.isInt()) {
+				return node.asInt();
+			}
+			if (node.isLong()) {
+				return node.asLong();
+			}
+			if (node.isFloat() || node.isDouble()) {
+				return node.asDouble();
+			}
+		}
+		return null;
+	}
+	public static Number consumeNumberProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			Number rval = getNumberProperty(json, propertyName);
+			if (rval != null) {
+				json.remove(propertyName);
+				return rval;
+			}
+		}
+		return null;
+	}
+
+	/* Get/Consume a Boolean property. */
+	public static Boolean getBooleanProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			JsonNode textNode = json.get(propertyName);
+			if (textNode.isBoolean()) {
+				return textNode.asBoolean();
+			}
+		}
+		return null;
+	}
+	public static Boolean consumeBooleanProperty(ObjectNode json, String propertyName) {
+		if (json.has(propertyName)) {
+			Boolean rval = getBooleanProperty(json, propertyName);
+			if (rval != null) {
+				json.remove(propertyName);
+				return rval;
+			}
+		}
+		return null;
+	}
+
+	/* Get/consume a map of anys property. */
+	public static Map<String, JsonNode> getAnyMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, JsonNode> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getAnyProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, JsonNode> consumeAnyMapProperty(ObjectNode json, String propertyName) {
+		Map<String, JsonNode> rval = getAnyMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume a map of objects property. */
+	public static Map<String, ObjectNode> getObjectMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, ObjectNode> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getObjectProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, ObjectNode> consumeObjectMapProperty(ObjectNode json, String propertyName) {
+		Map<String, ObjectNode> rval = getObjectMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume a map of strings property. */
+	public static Map<String, String> getStringMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, String> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getStringProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, String> consumeStringMapProperty(ObjectNode json, String propertyName) {
+		Map<String, String> rval = getStringMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume a map of integers property. */
+	public static Map<String, Integer> getIntegerMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, Integer> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getIntegerProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, Integer> consumeIntegerMapProperty(ObjectNode json, String propertyName) {
+		Map<String, Integer> rval = getIntegerMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume a map of numbers property. */
+	public static Map<String, Number> getNumberMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, Number> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getNumberProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, Number> consumeNumberMapProperty(ObjectNode json, String propertyName) {
+		Map<String, Number> rval = getNumberMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Get/consume a map of numbers property. */
+	public static Map<String, Boolean> getBooleanMapProperty(ObjectNode json, String propertyName) {
+		if (!json.has(propertyName)) {
+			return null;
+		}
+		JsonNode node = json.get(propertyName);
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			Map<String, Boolean> rval = new LinkedHashMap<>();
+			List<String> keys = keys(object);
+			keys.forEach(key -> {
+				rval.put(key, getBooleanProperty(object, key));
+			});
+			return rval;
+		} else {
+			return null;
+		}
+	}
+	public static Map<String, Boolean> consumeBooleanMapProperty(ObjectNode json, String propertyName) {
+		Map<String, Boolean> rval = getBooleanMapProperty(json, propertyName);
+		if (rval != null) {
+			json.remove(propertyName);
+		}
+		return rval;
+	}
+
+	/* Set a JSON (Object) property. */
+	public static void setObjectProperty(ObjectNode json, String propertyName, ObjectNode value) {
+		if (value != null) {
+			json.set(propertyName, value);
+		}
+	}
+	/* Set a JSON (Any) property. */
+	public static void setAnyProperty(ObjectNode json, String propertyName, JsonNode value) {
+		if (value != null) {
+			json.set(propertyName, value);
+		}
+	}
+	/* Set an array of anys property. */
+	public static void setAnyArrayProperty(ObjectNode json, String propertyName, List<JsonNode> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set an array of objects property. */
+	public static void setObjectArrayProperty(ObjectNode json, String propertyName, List<ObjectNode> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set an array of strings property. */
+	public static void setStringArrayProperty(ObjectNode json, String propertyName, List<String> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set an array of integers property. */
+	public static void setIntegerArrayProperty(ObjectNode json, String propertyName, List<Integer> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set an array of numbers property. */
+	public static void setNumberArrayProperty(ObjectNode json, String propertyName, List<Number> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v != null ? v.doubleValue() : null));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set an array of booleans property. */
+	public static void setBooleanArrayProperty(ObjectNode json, String propertyName, List<Boolean> value) {
+		if (value != null) {
+			ArrayNode array = json.arrayNode(value.size());
+			value.forEach(v -> array.add(v));
+			json.set(propertyName, array);
+		}
+	}
+	/* Set a string property. */
+	public static void setStringProperty(ObjectNode json, String propertyName, String value) {
+		if (value != null) {
+			json.set(propertyName, factory.textNode(value));
+		}
+	}
+	/* Set an Integer property. */
+	public static void setIntegerProperty(ObjectNode json, String propertyName, Integer value) {
+		if (value != null) {
+			json.set(propertyName, factory.numberNode(value));
+		}
+	}
+	/* Set a Number property. */
+	public static void setNumberProperty(ObjectNode json, String propertyName, Number value) {
+		if (value != null) {
+			json.set(propertyName, factory.numberNode(value.doubleValue()));
+		}
+	}
+	/* Set a Boolean property. */
+	public static void setBooleanProperty(ObjectNode json, String propertyName, Boolean value) {
+		if (value != null) {
+			json.set(propertyName, factory.booleanNode(value));
+		}
+	}
+	/* Set a map of anys property. */
+	public static void setAnyMapProperty(ObjectNode json, String propertyName, Map<String, JsonNode> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				object.set(entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+	/* Set a map of objects property. */
+	public static void setObjectMapProperty(ObjectNode json, String propertyName, Map<String, ObjectNode> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				object.set(entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+	/* Set a map of strings property. */
+	public static void setStringMapProperty(ObjectNode json, String propertyName, Map<String, String> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				setStringProperty(object, entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+	/* Set a map of integers property. */
+	public static void setIntegerMapProperty(ObjectNode json, String propertyName, Map<String, Integer> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				setIntegerProperty(object, entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+	/* Set a map of numbers property. */
+	public static void setNumberMapProperty(ObjectNode json, String propertyName, Map<String, Number> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				setNumberProperty(object, entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+	/* Set a map of numbers property. */
+	public static void setBooleanMapProperty(ObjectNode json, String propertyName, Map<String, Boolean> value) {
+		if (value != null) {
+			ObjectNode object = objectNode();
+			value.entrySet().forEach(entry -> {
+				setBooleanProperty(object, entry.getKey(), entry.getValue());
+			});
+			setProperty(json, propertyName, object);
+		}
+	}
+
+	public static String stringify(JsonNode json) {
+		try {
+			PrettyPrinter pp = new PrettyPrinter();
+			return mapper.writer(pp).writeValueAsString(json);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static JsonNode parseJSON(String jsonString) {
+		try {
+			return mapper.readTree(jsonString);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static JsonNode clone(JsonNode json) {
+		try {
+			TokenBuffer tb = new TokenBuffer(mapper, false);
+			mapper.writeTree(tb, json);
+			return mapper.readTree(tb.asParser());
+		} catch (IOException e) {
+			throw new RuntimeException("Error cloning JSON node.", e);
+		}
+	}
+
+	public static Collection<?> cloneCollection(Collection<?> collection) {
+		if (collection == null) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(collection);
+	}
+
+	public static ObjectNode objectNode() {
+		return factory.objectNode();
+	}
+
+	public static ArrayNode arrayNode() {
+		return factory.arrayNode();
+	}
+
+	public static TextNode textNode(String value) {
+		return factory.textNode(value);
+	}
+
+	public static void addToArray(ArrayNode array, JsonNode value) {
+		array.add(value);
+	}
+
+	public static boolean isPropertyDefined(JsonNode json, String propertyName) {
+		if (json.isObject()) {
+			ObjectNode node = (ObjectNode) json;
+			return node.has(propertyName) && !node.get(propertyName).isNull();
+		} else {
+			return false;
+		}
+	}
+
+	public static boolean isString(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isTextual();
+	}
+
+	public static boolean isJsonNode(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return true;
+	}
+
+	public static boolean isObjectNode(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isObject();
+	}
+
+	public static String toString(JsonNode value) {
+		return value.asText();
+	}
+
+	public static JsonNode toJsonNode(JsonNode value) {
+		return value;
+	}
+
+	public static ObjectNode toObjectNode(JsonNode value) {
+		return (ObjectNode) value;
+	}
+
+	public static boolean isBoolean(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isBoolean();
+	}
+
+	public static Boolean toBoolean(JsonNode value) {
+		return value.asBoolean();
+	}
+
+	public static boolean isNumber(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isNumber();
+	}
+
+	public static Number toNumber(JsonNode value) {
+		if (value.isInt()) {
+			return value.asInt();
+		}
+		if (value.isLong()) {
+			return value.asLong();
+		}
+		return value.asDouble();
+	}
+
+	public static boolean isObject(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isObject();
+	}
+
+	public static boolean isObjectWithProperty(JsonNode value, String propertyName) {
+		if (value == null) {
+			return false;
+		}
+		if (value.isObject()) {
+			ObjectNode object = (ObjectNode) value;
+			return object.has(propertyName);
+		}
+		return false;
+	}
+
+	public static boolean isObjectWithPropertyValue(JsonNode value, String propertyName, String propertyValue) {
+		if (value == null) {
+			return false;
+		}
+		if (value.isObject()) {
+			ObjectNode object = (ObjectNode) value;
+			if (object.has(propertyName)) {
+				JsonNode pvalue = object.get(propertyName);
+				if (!pvalue.isNull() && pvalue.isTextual()) {
+					String val = pvalue.asText();
+					return propertyValue.equals(val);
+				}
+			}
+		}
+		return false;
+	}
+
+	public static ObjectNode toObject(JsonNode value) {
+		return (ObjectNode) value;
+	}
+
+	public static boolean isArray(JsonNode value) {
+		if (value == null) {
+			return false;
+		}
+		return value.isArray();
+	}
+
+	public static ArrayNode toArray(JsonNode value) {
+		return (ArrayNode) value;
+	}
+
+	public static List<JsonNode> toList(JsonNode value) {
+		List<JsonNode> rval = new LinkedList<>();
+		ArrayNode array = (ArrayNode) value;
+		for (int idx = 0; idx < array.size(); idx++) {
+			JsonNode node = array.get(idx);
+			rval.add(node);
+		}
+		return rval;
+	}
+
+	private static class PrettyPrinter extends MinimalPrettyPrinter {
+		private static final long serialVersionUID = -4446121026177697380L;
+
+		private int indentLevel = 0;
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeStartObject(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void writeStartObject(JsonGenerator g) throws IOException {
+			super.writeStartObject(g);
+			indentLevel++;
+			g.writeRaw("\n");
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeEndObject(com.fasterxml.jackson.core.JsonGenerator,
+		 *      int)
+		 */
+		@Override
+		public void writeEndObject(JsonGenerator g, int nrOfEntries) throws IOException {
+			indentLevel--;
+			g.writeRaw("\n");
+			writeIndent(g);
+			super.writeEndObject(g, nrOfEntries);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeStartArray(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void writeStartArray(JsonGenerator g) throws IOException {
+			super.writeStartArray(g);
+			indentLevel++;
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeEndArray(com.fasterxml.jackson.core.JsonGenerator,
+		 *      int)
+		 */
+		@Override
+		public void writeEndArray(JsonGenerator g, int nrOfValues) throws IOException {
+			g.writeRaw("\n");
+			indentLevel--;
+			writeIndent(g);
+			super.writeEndArray(g, nrOfValues);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#beforeObjectEntries(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void beforeObjectEntries(JsonGenerator g) throws IOException {
+			writeIndent(g);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#beforeArrayValues(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void beforeArrayValues(JsonGenerator g) throws IOException {
+			g.writeRaw("\n");
+			writeIndent(g);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeArrayValueSeparator(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void writeArrayValueSeparator(JsonGenerator g) throws IOException {
+			super.writeArrayValueSeparator(g);
+			g.writeRaw("\n");
+			writeIndent(g);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeObjectEntrySeparator(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void writeObjectEntrySeparator(JsonGenerator g) throws IOException {
+			super.writeObjectEntrySeparator(g);
+			g.writeRaw("\n");
+			writeIndent(g);
+		}
+
+		/**
+		 * @see com.fasterxml.jackson.core.util.MinimalPrettyPrinter#writeObjectFieldValueSeparator(com.fasterxml.jackson.core.JsonGenerator)
+		 */
+		@Override
+		public void writeObjectFieldValueSeparator(JsonGenerator g) throws IOException {
+			super.writeObjectFieldValueSeparator(g);
+			g.writeRaw(" ");
+		}
+
+		private void writeIndent(JsonGenerator g) throws IOException {
+			for (int idx = 0; idx < this.indentLevel; idx++) {
+				g.writeRaw("    ");
+			}
+		}
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.Node;
+
+public class ReaderUtil {
+
+	public static final void readExtraProperties(ObjectNode json, Node node) {
+		if (json != null) {
+			JsonUtil.keys(json).forEach(key -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, key);
+				node.addExtraProperty(key, value);
+			});
+		}
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/WriterUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/WriterUtil.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.Node;
+
+public class WriterUtil {
+
+	public static final void writeExtraProperties(Node node, ObjectNode json) {
+		if (node.hasExtraProperties()) {
+			node.getExtraPropertyNames().forEach(name -> {
+				JsonNode value = node.getExtraProperty(name);
+				JsonUtil.setProperty(json, name, value);
+			});
+		}
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Contact.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Contact.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v1;
+
+import io.test.synthetic.SynContact;
+
+public interface Syn1Contact extends SynContact {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ContactImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ContactImpl.java
@@ -1,0 +1,54 @@
+package io.test.synthetic.v1;
+
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+
+public class Syn1ContactImpl extends NodeImpl implements Syn1Contact {
+
+	private String name;
+	private String email;
+	private String url;
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String value) {
+		this.name = value;
+	}
+
+	@Override
+	public String getEmail() {
+		return email;
+	}
+
+	@Override
+	public void setEmail(String value) {
+		this.email = value;
+	}
+
+	@Override
+	public String getUrl() {
+		return url;
+	}
+
+	@Override
+	public void setUrl(String value) {
+		this.url = value;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitContact(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1ContactImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Document.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Document.java
@@ -1,0 +1,19 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.SynDocument;
+import java.util.Map;
+
+public interface Syn1Document extends RootNode, SynDocument, Syn1Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -1,0 +1,182 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.ModelType;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.RootNodeImpl;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1DocumentImpl extends RootNodeImpl implements Syn1Document {
+
+	private String version;
+	private SynInfo info;
+	private List<SynItem> items;
+	private List<String> tags;
+	private Map<String, String> metadata;
+	private Map<String, JsonNode> extensions;
+
+	public Syn1DocumentImpl() {
+		super(ModelType.SYN1);
+	}
+
+	@Override
+	public String getVersion() {
+		return version;
+	}
+
+	@Override
+	public void setVersion(String value) {
+		this.version = value;
+	}
+
+	@Override
+	public SynInfo getInfo() {
+		return info;
+	}
+
+	@Override
+	public void setInfo(SynInfo value) {
+		this.info = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("info");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn1Info createInfo() {
+		Syn1InfoImpl node = new Syn1InfoImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Syn1Item createItem() {
+		Syn1ItemImpl node = new Syn1ItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<SynItem> getItems() {
+		return items;
+	}
+
+	@Override
+	public void addItem(SynItem value) {
+		if (this.items == null) {
+			this.items = new ArrayList<>();
+		}
+		this.items.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("items");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearItems() {
+		if (this.items != null) {
+			this.items.clear();
+		}
+	}
+
+	@Override
+	public void removeItem(SynItem value) {
+		if (this.items != null) {
+			this.items.remove(value);
+		}
+	}
+
+	@Override
+	public void insertItem(SynItem value, int atIndex) {
+		if (this.items == null) {
+			this.items = new ArrayList<>();
+			this.items.add(value);
+		} else {
+			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("items");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public void setTags(List<String> value) {
+		this.tags = value;
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	@Override
+	public void setMetadata(Map<String, String> value) {
+		this.metadata = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitDocument(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1DocumentImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Extensible.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Extensible.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v1;
+
+import io.test.synthetic.SynExtensible;
+
+public interface Syn1Extensible extends SynExtensible {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Info.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Info.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynInfo;
+import java.util.Map;
+
+public interface Syn1Info extends SynInfo, Syn1Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -1,0 +1,109 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
+
+	private String name;
+	private SynContact contact;
+	private String version;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String value) {
+		this.name = value;
+	}
+
+	@Override
+	public SynContact getContact() {
+		return contact;
+	}
+
+	@Override
+	public void setContact(SynContact value) {
+		this.contact = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("contact");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn1Contact createContact() {
+		Syn1ContactImpl node = new Syn1ContactImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public String getVersion() {
+		return version;
+	}
+
+	@Override
+	public void setVersion(String value) {
+		this.version = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitInfo(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1InfoImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Item.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Item.java
@@ -1,0 +1,22 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynItem;
+import java.util.Map;
+
+public interface Syn1Item extends SynItem, Syn1Extensible, Syn1Referenceable {
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -1,0 +1,227 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
+
+	private String $ref;
+	private String description;
+	private Boolean required;
+	private Integer order;
+	private Number weight;
+	private JsonNode extra;
+	private ObjectNode raw;
+	private SynSchema schema;
+	private List<JsonNode> examples;
+	private BooleanSchemaUnion defaultValue;
+	private String title;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public void setDescription(String value) {
+		this.description = value;
+	}
+
+	@Override
+	public Boolean isRequired() {
+		return required;
+	}
+
+	@Override
+	public void setRequired(Boolean value) {
+		this.required = value;
+	}
+
+	@Override
+	public Integer getOrder() {
+		return order;
+	}
+
+	@Override
+	public void setOrder(Integer value) {
+		this.order = value;
+	}
+
+	@Override
+	public Number getWeight() {
+		return weight;
+	}
+
+	@Override
+	public void setWeight(Number value) {
+		this.weight = value;
+	}
+
+	@Override
+	public JsonNode getExtra() {
+		return extra;
+	}
+
+	@Override
+	public void setExtra(JsonNode value) {
+		this.extra = value;
+	}
+
+	@Override
+	public ObjectNode getRaw() {
+		return raw;
+	}
+
+	@Override
+	public void setRaw(ObjectNode value) {
+		this.raw = value;
+	}
+
+	@Override
+	public SynSchema getSchema() {
+		return schema;
+	}
+
+	@Override
+	public void setSchema(SynSchema value) {
+		this.schema = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("schema");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn1Schema createSchema() {
+		Syn1SchemaImpl node = new Syn1SchemaImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<JsonNode> getExamples() {
+		return examples;
+	}
+
+	@Override
+	public void setExamples(List<JsonNode> value) {
+		this.examples = value;
+	}
+
+	@Override
+	public BooleanSchemaUnion getDefaultValue() {
+		return defaultValue;
+	}
+
+	@Override
+	public void setDefaultValue(BooleanSchemaUnion value) {
+		this.defaultValue = value;
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParentPropertyName("defaultValue");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParentPropertyName("defaultValue");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParentPropertyName("defaultValue");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public String getTitle() {
+		return title;
+	}
+
+	@Override
+	public void setTitle(String value) {
+		this.title = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitItem(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1ItemImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Operation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Operation.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynOperation;
+import java.util.Map;
+
+public interface Syn1Operation extends SynOperation, Syn1Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -1,0 +1,153 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
+
+	private String operationId;
+	private String summary;
+	private List<String> tags;
+	private List<SynItem> parameters;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String getOperationId() {
+		return operationId;
+	}
+
+	@Override
+	public void setOperationId(String value) {
+		this.operationId = value;
+	}
+
+	@Override
+	public String getSummary() {
+		return summary;
+	}
+
+	@Override
+	public void setSummary(String value) {
+		this.summary = value;
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public void setTags(List<String> value) {
+		this.tags = value;
+	}
+
+	@Override
+	public Syn1Item createItem() {
+		Syn1ItemImpl node = new Syn1ItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<SynItem> getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public void addParameter(SynItem value) {
+		if (this.parameters == null) {
+			this.parameters = new ArrayList<>();
+		}
+		this.parameters.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("parameters");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearParameters() {
+		if (this.parameters != null) {
+			this.parameters.clear();
+		}
+	}
+
+	@Override
+	public void removeParameter(SynItem value) {
+		if (this.parameters != null) {
+			this.parameters.remove(value);
+		}
+	}
+
+	@Override
+	public void insertParameter(SynItem value, int atIndex) {
+		if (this.parameters == null) {
+			this.parameters = new ArrayList<>();
+			this.parameters.add(value);
+		} else {
+			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("parameters");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitOperation(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1OperationImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItem.java
@@ -1,0 +1,22 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynPathItem;
+import java.util.Map;
+
+public interface Syn1PathItem extends SynPathItem, Syn1Extensible, Syn1Referenceable {
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -1,0 +1,139 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
+
+	private String $ref;
+	private String summary;
+	private SynOperation get;
+	private SynOperation put;
+	private SynOperation post;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getSummary() {
+		return summary;
+	}
+
+	@Override
+	public void setSummary(String value) {
+		this.summary = value;
+	}
+
+	@Override
+	public SynOperation getGet() {
+		return get;
+	}
+
+	@Override
+	public void setGet(SynOperation value) {
+		this.get = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("get");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn1Operation createOperation() {
+		Syn1OperationImpl node = new Syn1OperationImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public SynOperation getPut() {
+		return put;
+	}
+
+	@Override
+	public void setPut(SynOperation value) {
+		this.put = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("put");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public SynOperation getPost() {
+		return post;
+	}
+
+	@Override
+	public void setPost(SynOperation value) {
+		this.post = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("post");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitPathItem(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1PathItemImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Paths.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Paths.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynPaths;
+import java.util.Map;
+
+public interface Syn1Paths extends SynPaths, Syn1Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -1,0 +1,124 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
+
+	private Map<String, SynPathItem> _items = new LinkedHashMap<>();
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public SynPathItem getItem(String name) {
+		return this._items.get(name);
+	}
+
+	@Override
+	public List<SynPathItem> getItems() {
+		List<SynPathItem> rval = new ArrayList<>();
+		rval.addAll(this._items.values());
+		return rval;
+	}
+
+	@Override
+	public List<String> getItemNames() {
+		List<String> rval = new ArrayList<>();
+		rval.addAll(this._items.keySet());
+		return rval;
+	}
+
+	@Override
+	public void addItem(String name, SynPathItem item) {
+		this._items.put(name, item);
+		if (item != null) {
+			((NodeImpl) item)._setParentPropertyName(null);
+			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) item)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void insertItem(String name, SynPathItem item, int atIndex) {
+		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
+		if (item != null) {
+			((NodeImpl) item)._setParentPropertyName(null);
+			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) item)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public SynPathItem removeItem(String name) {
+		return this._items.remove(name);
+	}
+
+	@Override
+	public void clearItems() {
+		this._items.clear();
+	}
+
+	@Override
+	public Syn1PathItem createPathItem() {
+		Syn1PathItemImpl node = new Syn1PathItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitPaths(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1PathsImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Referenceable.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Referenceable.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v1;
+
+import io.test.synthetic.SynReferenceable;
+
+public interface Syn1Referenceable extends SynReferenceable {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Schema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Schema.java
@@ -1,0 +1,22 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynSchema;
+import java.util.Map;
+
+public interface Syn1Schema extends SynSchema, Syn1Extensible, Syn1Referenceable {
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -1,0 +1,346 @@
+package io.test.synthetic.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1SchemaImpl extends NodeImpl implements Syn1Schema {
+
+	private String $ref;
+	private String type;
+	private BooleanSchemaSchemaListUnion items;
+	private Map<String, BooleanSchemaUnion> properties;
+	private List<BooleanSchemaUnion> allOf;
+	private Map<String, BooleanSchemaUnion> definitions;
+	private Integer minLength;
+	private Integer maxLength;
+	private List<JsonNode> _enum;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public void setType(String value) {
+		this.type = value;
+	}
+
+	@Override
+	public BooleanSchemaSchemaListUnion getItems() {
+		return items;
+	}
+
+	@Override
+	public void setItems(BooleanSchemaSchemaListUnion value) {
+		this.items = value;
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParentPropertyName("items");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParentPropertyName("items");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParentPropertyName("items");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public Syn1Schema createSchema() {
+		Syn1SchemaImpl node = new Syn1SchemaImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Map<String, BooleanSchemaUnion> getProperties() {
+		return properties;
+	}
+
+	@Override
+	public void addProperty(String name, BooleanSchemaUnion value) {
+		if (this.properties == null) {
+			this.properties = new LinkedHashMap<>();
+		}
+		this.properties.put(name, value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("properties");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearProperties() {
+		if (this.properties != null) {
+			this.properties.clear();
+		}
+	}
+
+	@Override
+	public void removeProperty(String name) {
+		if (this.properties != null) {
+			this.properties.remove(name);
+		}
+	}
+
+	@Override
+	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
+		if (this.properties == null) {
+			this.properties = new LinkedHashMap<>();
+			this.properties.put(name, value);
+		} else {
+			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("properties");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public List<BooleanSchemaUnion> getAllOf() {
+		return allOf;
+	}
+
+	@Override
+	public void addAllOf(BooleanSchemaUnion value) {
+		if (this.allOf == null) {
+			this.allOf = new ArrayList<>();
+		}
+		this.allOf.add(value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("allOf");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearAllOf() {
+		if (this.allOf != null) {
+			this.allOf.clear();
+		}
+	}
+
+	@Override
+	public void removeAllOf(BooleanSchemaUnion value) {
+		if (this.allOf != null) {
+			this.allOf.remove(value);
+		}
+	}
+
+	@Override
+	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
+		if (this.allOf == null) {
+			this.allOf = new ArrayList<>();
+			this.allOf.add(value);
+		} else {
+			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("allOf");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public Map<String, BooleanSchemaUnion> getDefinitions() {
+		return definitions;
+	}
+
+	@Override
+	public void addDefinition(String name, BooleanSchemaUnion value) {
+		if (this.definitions == null) {
+			this.definitions = new LinkedHashMap<>();
+		}
+		this.definitions.put(name, value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("definitions");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearDefinitions() {
+		if (this.definitions != null) {
+			this.definitions.clear();
+		}
+	}
+
+	@Override
+	public void removeDefinition(String name) {
+		if (this.definitions != null) {
+			this.definitions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
+		if (this.definitions == null) {
+			this.definitions = new LinkedHashMap<>();
+			this.definitions.put(name, value);
+		} else {
+			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("definitions");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public Integer getMinLength() {
+		return minLength;
+	}
+
+	@Override
+	public void setMinLength(Integer value) {
+		this.minLength = value;
+	}
+
+	@Override
+	public Integer getMaxLength() {
+		return maxLength;
+	}
+
+	@Override
+	public void setMaxLength(Integer value) {
+		this.maxLength = value;
+	}
+
+	@Override
+	public List<JsonNode> getEnum() {
+		return _enum;
+	}
+
+	@Override
+	public void setEnum(List<JsonNode> value) {
+		this._enum = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public boolean isBoolean() {
+		return false;
+	}
+
+	@Override
+	public Boolean asBoolean() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public boolean isSchema() {
+		return true;
+	}
+
+	@Override
+	public SynSchema asSchema() {
+		return this;
+	}
+
+	@Override
+	public Object unionValue() {
+		return this;
+	}
+
+	@Override
+	public boolean isSchemaList() {
+		return false;
+	}
+
+	@Override
+	public List<SynSchema> asSchemaList() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn1Visitor viz = (Syn1Visitor) visitor;
+		viz.visitSchema(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn1SchemaImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -1,0 +1,400 @@
+package io.test.synthetic.v1.io;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.io.ModelReader;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.BooleanUnionValue;
+import io.test.synthetic.union.BooleanUnionValueImpl;
+import io.test.synthetic.union.SchemaListUnionValue;
+import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.util.JsonUtil;
+import io.test.synthetic.util.ReaderUtil;
+import io.test.synthetic.v1.Syn1Contact;
+import io.test.synthetic.v1.Syn1Document;
+import io.test.synthetic.v1.Syn1DocumentImpl;
+import io.test.synthetic.v1.Syn1Info;
+import io.test.synthetic.v1.Syn1Item;
+import io.test.synthetic.v1.Syn1Operation;
+import io.test.synthetic.v1.Syn1PathItem;
+import io.test.synthetic.v1.Syn1Paths;
+import io.test.synthetic.v1.Syn1Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1ModelReader implements ModelReader {
+
+	public void readDocument(ObjectNode json, Syn1Document node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "version");
+			node.setVersion(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "info");
+			if (object != null) {
+				node.setInfo(node.createInfo());
+				readInfo(object, (Syn1Info) node.getInfo());
+			}
+		}
+		{
+			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "items");
+			if (objects != null) {
+				objects.forEach(object -> {
+					Syn1Item model = (Syn1Item) node.createItem();
+					this.readItem(object, model);
+					node.addItem(model);
+				});
+			}
+		}
+		{
+			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
+			node.setTags(value);
+		}
+		{
+			Map<String, String> value = JsonUtil.consumeStringMapProperty(json, "metadata");
+			node.setMetadata(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	@Override
+	public RootNode readRoot(ObjectNode json) {
+		Syn1Document rootModel = new Syn1DocumentImpl();
+		this.readDocument(json, rootModel);
+		return rootModel;
+	}
+
+	public void readInfo(ObjectNode json, Syn1Info node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "name");
+			node.setName(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "contact");
+			if (object != null) {
+				node.setContact(node.createContact());
+				readContact(object, (Syn1Contact) node.getContact());
+			}
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "version");
+			node.setVersion(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readContact(ObjectNode json, Syn1Contact node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "name");
+			node.setName(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "email");
+			node.setEmail(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "url");
+			node.setUrl(value);
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readItem(ObjectNode json, Syn1Item node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "description");
+			node.setDescription(value);
+		}
+		{
+			Boolean value = JsonUtil.consumeBooleanProperty(json, "required");
+			node.setRequired(value);
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "order");
+			node.setOrder(value);
+		}
+		{
+			Number value = JsonUtil.consumeNumberProperty(json, "weight");
+			node.setWeight(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "extra");
+			node.setExtra(value);
+		}
+		{
+			ObjectNode value = JsonUtil.consumeObjectProperty(json, "raw");
+			node.setRaw(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "schema");
+			if (object != null) {
+				node.setSchema(node.createSchema());
+				readSchema(object, (Syn1Schema) node.getSchema());
+			}
+		}
+		{
+			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "examples");
+			node.setExamples(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
+			if (value != null) {
+				if (JsonUtil.isObjectWithProperty(value, "type")) {
+					ObjectNode object = JsonUtil.toObject(value);
+					node.setDefaultValue(node.createSchema());
+					readSchema(object, (Syn1Schema) node.getDefaultValue());
+				} else if (JsonUtil.isBoolean(value)) {
+					Boolean pValue = JsonUtil.toBoolean(value);
+					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+					node.setDefaultValue(unionValue);
+				} else {
+					node.addExtraProperty("defaultValue", value);
+				}
+			}
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "title");
+			node.setTitle(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readSchema(ObjectNode json, Syn1Schema node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "type");
+			node.setType(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
+			if (value != null) {
+				if (JsonUtil.isObjectWithProperty(value, "type")) {
+					ObjectNode object = JsonUtil.toObject(value);
+					node.setItems(node.createSchema());
+					readSchema(object, (Syn1Schema) node.getItems());
+				} else if (JsonUtil.isArray(value)) {
+					List<JsonNode> array = JsonUtil.toList(value);
+					List<Syn1Schema> models = new ArrayList<>();
+					array.forEach(item -> {
+						ObjectNode object = JsonUtil.toObject(item);
+						Syn1Schema model = (Syn1Schema) node.createSchema();
+						this.readSchema(object, model);
+						models.add(model);
+					});
+					@SuppressWarnings({"unchecked", "rawtypes"})
+					SchemaListUnionValue unionValue = new SchemaListUnionValueImpl((List) models);
+					node.setItems(unionValue);
+				} else if (JsonUtil.isBoolean(value)) {
+					Boolean pValue = JsonUtil.toBoolean(value);
+					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+					node.setItems(unionValue);
+				} else {
+					node.addExtraProperty("items", value);
+				}
+			}
+		}
+		{
+			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "properties");
+			if (mapObject != null) {
+				List<String> keys = JsonUtil.keys(mapObject);
+				keys.forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+					if (value != null) {
+						if (JsonUtil.isObject(value)) {
+							ObjectNode object = JsonUtil.toObject(value);
+							Syn1Schema model = (Syn1Schema) node.createSchema();
+							readSchema(object, model);
+							node.addProperty(key, model);
+						} else if (JsonUtil.isBoolean(value)) {
+							Boolean pValue = JsonUtil.toBoolean(value);
+							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+							node.addProperty(key, unionValue);
+						}
+					}
+				});
+			}
+		}
+		{
+			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
+			if (array != null) {
+				array.forEach(value -> {
+					if (JsonUtil.isObject(value)) {
+						ObjectNode object = JsonUtil.toObject(value);
+						Syn1Schema model = (Syn1Schema) node.createSchema();
+						readSchema(object, model);
+						node.addAllOf(model);
+					} else if (JsonUtil.isBoolean(value)) {
+						Boolean pValue = JsonUtil.toBoolean(value);
+						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+						node.addAllOf(unionValue);
+					}
+				});
+			}
+		}
+		{
+			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "definitions");
+			if (mapObject != null) {
+				List<String> keys = JsonUtil.keys(mapObject);
+				keys.forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+					if (value != null) {
+						if (JsonUtil.isObject(value)) {
+							ObjectNode object = JsonUtil.toObject(value);
+							Syn1Schema model = (Syn1Schema) node.createSchema();
+							readSchema(object, model);
+							node.addDefinition(key, model);
+						} else if (JsonUtil.isBoolean(value)) {
+							Boolean pValue = JsonUtil.toBoolean(value);
+							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+							node.addDefinition(key, unionValue);
+						}
+					}
+				});
+			}
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
+			node.setMinLength(value);
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "maxLength");
+			node.setMaxLength(value);
+		}
+		{
+			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "enum");
+			node.setEnum(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readPaths(ObjectNode json, Syn1Paths node) {
+		{
+			List<String> propertyNames = JsonUtil.keys(json);
+			propertyNames.forEach(name -> {
+				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
+				if (object != null) {
+					Syn1PathItem model = (Syn1PathItem) node.createPathItem();
+					this.readPathItem(object, model);
+					node.addItem(name, model);
+				}
+			});
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readPathItem(ObjectNode json, Syn1PathItem node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "summary");
+			node.setSummary(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "get");
+			if (object != null) {
+				node.setGet(node.createOperation());
+				readOperation(object, (Syn1Operation) node.getGet());
+			}
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "put");
+			if (object != null) {
+				node.setPut(node.createOperation());
+				readOperation(object, (Syn1Operation) node.getPut());
+			}
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "post");
+			if (object != null) {
+				node.setPost(node.createOperation());
+				readOperation(object, (Syn1Operation) node.getPost());
+			}
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readOperation(ObjectNode json, Syn1Operation node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "operationId");
+			node.setOperationId(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "summary");
+			node.setSummary(value);
+		}
+		{
+			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
+			node.setTags(value);
+		}
+		{
+			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "parameters");
+			if (objects != null) {
+				objects.forEach(object -> {
+					Syn1Item model = (Syn1Item) node.createItem();
+					this.readItem(object, model);
+					node.addParameter(model);
+				});
+			}
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
@@ -1,0 +1,71 @@
+package io.test.synthetic.v1.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v1.Syn1Contact;
+import io.test.synthetic.v1.Syn1Document;
+import io.test.synthetic.v1.Syn1Info;
+import io.test.synthetic.v1.Syn1Item;
+import io.test.synthetic.v1.Syn1Operation;
+import io.test.synthetic.v1.Syn1PathItem;
+import io.test.synthetic.v1.Syn1Paths;
+import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+
+public class Syn1ModelReaderDispatcher implements Syn1Visitor {
+
+	private final ObjectNode json;
+	private final Syn1ModelReader reader;
+
+	public Syn1ModelReaderDispatcher(ObjectNode json, Syn1ModelReader reader) {
+		this.json = json;
+		this.reader = reader;
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		this.reader.readPaths(this.json, (Syn1Paths) node);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		this.reader.readOperation(this.json, (Syn1Operation) node);
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		this.reader.readSchema(this.json, (Syn1Schema) node);
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		this.reader.readInfo(this.json, (Syn1Info) node);
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		this.reader.readPathItem(this.json, (Syn1PathItem) node);
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		this.reader.readDocument(this.json, (Syn1Document) node);
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		this.reader.readContact(this.json, (Syn1Contact) node);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		this.reader.readItem(this.json, (Syn1Item) node);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -1,0 +1,342 @@
+package io.test.synthetic.v1.io;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.io.ModelWriter;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.util.JsonUtil;
+import io.test.synthetic.util.WriterUtil;
+import io.test.synthetic.v1.Syn1Contact;
+import io.test.synthetic.v1.Syn1Document;
+import io.test.synthetic.v1.Syn1Info;
+import io.test.synthetic.v1.Syn1Item;
+import io.test.synthetic.v1.Syn1Operation;
+import io.test.synthetic.v1.Syn1PathItem;
+import io.test.synthetic.v1.Syn1Paths;
+import io.test.synthetic.v1.Syn1Schema;
+import java.util.List;
+import java.util.Map;
+
+public class Syn1ModelWriter implements ModelWriter {
+
+	public void writeDocument(Syn1Document node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		{
+			if (node.getInfo() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeInfo((Syn1Info) node.getInfo(), object);
+				JsonUtil.setObjectProperty(json, "info", object);
+			}
+		}
+		{
+			List<? extends SynItem> models = node.getItems();
+			if (models != null && !models.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				models.forEach(model -> {
+					ObjectNode object = JsonUtil.objectNode();
+					this.writeItem((Syn1Item) model, object);
+					JsonUtil.addToArray(array, object);
+				});
+				JsonUtil.setAnyProperty(json, "items", array);
+			}
+		}
+		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		JsonUtil.setStringMapProperty(json, "metadata", node.getMetadata());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	@Override
+	public ObjectNode writeRoot(RootNode node) {
+		ObjectNode json = JsonUtil.objectNode();
+		this.writeDocument((Syn1Document) node, json);
+		return json;
+	}
+
+	public void writeInfo(Syn1Info node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "name", node.getName());
+		{
+			if (node.getContact() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeContact((Syn1Contact) node.getContact(), object);
+				JsonUtil.setObjectProperty(json, "contact", object);
+			}
+		}
+		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeContact(Syn1Contact node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "name", node.getName());
+		JsonUtil.setStringProperty(json, "email", node.getEmail());
+		JsonUtil.setStringProperty(json, "url", node.getUrl());
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeItem(Syn1Item node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "description", node.getDescription());
+		JsonUtil.setBooleanProperty(json, "required", node.isRequired());
+		JsonUtil.setIntegerProperty(json, "order", node.getOrder());
+		JsonUtil.setNumberProperty(json, "weight", node.getWeight());
+		JsonUtil.setAnyProperty(json, "extra", node.getExtra());
+		JsonUtil.setObjectProperty(json, "raw", node.getRaw());
+		{
+			if (node.getSchema() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeSchema((Syn1Schema) node.getSchema(), object);
+				JsonUtil.setObjectProperty(json, "schema", object);
+			}
+		}
+		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
+		{
+			BooleanSchemaUnion union = node.getDefaultValue();
+			if (union != null) {
+				if (union.isBoolean()) {
+					JsonUtil.setBooleanProperty(json, "defaultValue", union.asBoolean());
+				}
+				if (union.isSchema()) {
+					ObjectNode jsonValue = JsonUtil.objectNode();
+					this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
+					JsonUtil.setObjectProperty(json, "defaultValue", jsonValue);
+				}
+			}
+		}
+		JsonUtil.setStringProperty(json, "title", node.getTitle());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeSchema(Syn1Schema node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "type", node.getType());
+		{
+			BooleanSchemaSchemaListUnion union = node.getItems();
+			if (union != null) {
+				if (union.isBoolean()) {
+					JsonUtil.setBooleanProperty(json, "items", union.asBoolean());
+				}
+				if (union.isSchema()) {
+					ObjectNode jsonValue = JsonUtil.objectNode();
+					this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
+					JsonUtil.setObjectProperty(json, "items", jsonValue);
+				}
+				if (union.isSchemaList()) {
+					List<? extends SynSchema> models = union.asSchemaList();
+					ArrayNode array = JsonUtil.arrayNode();
+					models.forEach(model -> {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn1Schema) model, object);
+						JsonUtil.addToArray(array, object);
+					});
+					JsonUtil.setAnyProperty(json, "items", array);
+				}
+			}
+		}
+		{
+			Map<String, BooleanSchemaUnion> unionMap = node.getProperties();
+			if (unionMap != null && !unionMap.isEmpty()) {
+				ObjectNode mapObject = JsonUtil.objectNode();
+				unionMap.keySet().forEach(key -> {
+					BooleanSchemaUnion union = unionMap.get(key);
+					if (union.isBoolean()) {
+						mapObject.put(key, union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn1Schema) union.asSchema(), object);
+						JsonUtil.setObjectProperty(mapObject, key, object);
+					}
+				});
+				JsonUtil.setObjectProperty(json, "properties", mapObject);
+			}
+		}
+		{
+			List<BooleanSchemaUnion> unionList = node.getAllOf();
+			if (unionList != null && !unionList.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				unionList.forEach(union -> {
+					if (union.isBoolean()) {
+						array.add(union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn1Schema) union.asSchema(), object);
+						JsonUtil.addToArray(array, object);
+					}
+				});
+				JsonUtil.setAnyProperty(json, "allOf", array);
+			}
+		}
+		{
+			Map<String, BooleanSchemaUnion> unionMap = node.getDefinitions();
+			if (unionMap != null && !unionMap.isEmpty()) {
+				ObjectNode mapObject = JsonUtil.objectNode();
+				unionMap.keySet().forEach(key -> {
+					BooleanSchemaUnion union = unionMap.get(key);
+					if (union.isBoolean()) {
+						mapObject.put(key, union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn1Schema) union.asSchema(), object);
+						JsonUtil.setObjectProperty(mapObject, key, object);
+					}
+				});
+				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+			}
+		}
+		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
+		JsonUtil.setIntegerProperty(json, "maxLength", node.getMaxLength());
+		JsonUtil.setAnyArrayProperty(json, "enum", node.getEnum());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writePaths(Syn1Paths node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		{
+			List<String> propertyNames = node.getItemNames();
+			propertyNames.forEach(propertyName -> {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writePathItem((Syn1PathItem) node.getItem(propertyName), object);
+				JsonUtil.setObjectProperty(json, propertyName, object);
+			});
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writePathItem(Syn1PathItem node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		{
+			if (node.getGet() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn1Operation) node.getGet(), object);
+				JsonUtil.setObjectProperty(json, "get", object);
+			}
+		}
+		{
+			if (node.getPut() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn1Operation) node.getPut(), object);
+				JsonUtil.setObjectProperty(json, "put", object);
+			}
+		}
+		{
+			if (node.getPost() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn1Operation) node.getPost(), object);
+				JsonUtil.setObjectProperty(json, "post", object);
+			}
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeOperation(Syn1Operation node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "operationId", node.getOperationId());
+		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		{
+			List<? extends SynItem> models = node.getParameters();
+			if (models != null && !models.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				models.forEach(model -> {
+					ObjectNode object = JsonUtil.objectNode();
+					this.writeItem((Syn1Item) model, object);
+					JsonUtil.addToArray(array, object);
+				});
+				JsonUtil.setAnyProperty(json, "parameters", array);
+			}
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
@@ -1,0 +1,71 @@
+package io.test.synthetic.v1.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v1.Syn1Contact;
+import io.test.synthetic.v1.Syn1Document;
+import io.test.synthetic.v1.Syn1Info;
+import io.test.synthetic.v1.Syn1Item;
+import io.test.synthetic.v1.Syn1Operation;
+import io.test.synthetic.v1.Syn1PathItem;
+import io.test.synthetic.v1.Syn1Paths;
+import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+
+public class Syn1ModelWriterDispatcher implements Syn1Visitor {
+
+	private final ObjectNode json;
+	private final Syn1ModelWriter writer;
+
+	public Syn1ModelWriterDispatcher(ObjectNode json, Syn1ModelWriter writer) {
+		this.json = json;
+		this.writer = writer;
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		this.writer.writePaths((Syn1Paths) node, this.json);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		this.writer.writeOperation((Syn1Operation) node, this.json);
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		this.writer.writeSchema((Syn1Schema) node, this.json);
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		this.writer.writeInfo((Syn1Info) node, this.json);
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		this.writer.writePathItem((Syn1PathItem) node, this.json);
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		this.writer.writeDocument((Syn1Document) node, this.json);
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		this.writer.writeContact((Syn1Contact) node, this.json);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		this.writer.writeItem((Syn1Item) node, this.json);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -1,0 +1,84 @@
+package io.test.synthetic.v1.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v1.Syn1Document;
+import io.test.synthetic.v1.Syn1Info;
+import io.test.synthetic.v1.Syn1Item;
+import io.test.synthetic.v1.Syn1Operation;
+import io.test.synthetic.v1.Syn1PathItem;
+import io.test.synthetic.v1.Syn1Paths;
+import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.visitors.AbstractTraverser;
+import io.test.synthetic.visitors.Visitor;
+
+public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
+
+	public Syn1Traverser(Visitor visitor) {
+		super(visitor);
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		node.accept(this.visitor);
+		Syn1Paths model = (Syn1Paths) node;
+		this.traverseMappedNode(model);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		node.accept(this.visitor);
+		Syn1Operation model = (Syn1Operation) node;
+		this.traverseList("parameters", model.getParameters());
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		node.accept(this.visitor);
+		Syn1Schema model = (Syn1Schema) node;
+		this.traverseUnion("items", model.getItems());
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		node.accept(this.visitor);
+		Syn1Info model = (Syn1Info) node;
+		this.traverseNode("contact", model.getContact());
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		node.accept(this.visitor);
+		Syn1PathItem model = (Syn1PathItem) node;
+		this.traverseNode("get", model.getGet());
+		this.traverseNode("put", model.getPut());
+		this.traverseNode("post", model.getPost());
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		node.accept(this.visitor);
+		Syn1Document model = (Syn1Document) node;
+		this.traverseNode("info", model.getInfo());
+		this.traverseList("items", model.getItems());
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		node.accept(this.visitor);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		node.accept(this.visitor);
+		Syn1Item model = (Syn1Item) node;
+		this.traverseNode("schema", model.getSchema());
+		this.traverseUnion("defaultValue", model.getDefaultValue());
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Visitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Visitor.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v1.visitors;
+
+import io.test.synthetic.visitors.Visitor;
+
+public interface Syn1Visitor extends Visitor {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
@@ -1,0 +1,45 @@
+package io.test.synthetic.v1.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+
+public class Syn1VisitorAdapter implements Syn1Visitor {
+
+	@Override
+	public void visitPaths(SynPaths node) {
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Contact.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Contact.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v2;
+
+import io.test.synthetic.SynContact;
+
+public interface Syn2Contact extends SynContact {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ContactImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ContactImpl.java
@@ -1,0 +1,54 @@
+package io.test.synthetic.v2;
+
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+
+public class Syn2ContactImpl extends NodeImpl implements Syn2Contact {
+
+	private String name;
+	private String email;
+	private String url;
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String value) {
+		this.name = value;
+	}
+
+	@Override
+	public String getEmail() {
+		return email;
+	}
+
+	@Override
+	public void setEmail(String value) {
+		this.email = value;
+	}
+
+	@Override
+	public String getUrl() {
+		return url;
+	}
+
+	@Override
+	public void setUrl(String value) {
+		this.url = value;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitContact(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2ContactImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Document.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Document.java
@@ -1,0 +1,31 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.SynDocument;
+import java.util.Map;
+
+public interface Syn2Document extends RootNode, SynDocument, Syn2Extensible {
+
+	public Syn2PathItem createPathItem();
+
+	public Map<String, Syn2PathItem> getWebhooks();
+
+	public void addWebhook(String name, Syn2PathItem value);
+
+	public void clearWebhooks();
+
+	public void removeWebhook(String name);
+
+	public void insertWebhook(String name, Syn2PathItem value, int atIndex);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -1,0 +1,237 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.ModelType;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.RootNodeImpl;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2DocumentImpl extends RootNodeImpl implements Syn2Document {
+
+	private String version;
+	private SynInfo info;
+	private List<SynItem> items;
+	private List<String> tags;
+	private Map<String, String> metadata;
+	private Map<String, Syn2PathItem> webhooks;
+	private Map<String, JsonNode> extensions;
+
+	public Syn2DocumentImpl() {
+		super(ModelType.SYN2);
+	}
+
+	@Override
+	public String getVersion() {
+		return version;
+	}
+
+	@Override
+	public void setVersion(String value) {
+		this.version = value;
+	}
+
+	@Override
+	public SynInfo getInfo() {
+		return info;
+	}
+
+	@Override
+	public void setInfo(SynInfo value) {
+		this.info = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("info");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn2Info createInfo() {
+		Syn2InfoImpl node = new Syn2InfoImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Syn2Item createItem() {
+		Syn2ItemImpl node = new Syn2ItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<SynItem> getItems() {
+		return items;
+	}
+
+	@Override
+	public void addItem(SynItem value) {
+		if (this.items == null) {
+			this.items = new ArrayList<>();
+		}
+		this.items.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("items");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearItems() {
+		if (this.items != null) {
+			this.items.clear();
+		}
+	}
+
+	@Override
+	public void removeItem(SynItem value) {
+		if (this.items != null) {
+			this.items.remove(value);
+		}
+	}
+
+	@Override
+	public void insertItem(SynItem value, int atIndex) {
+		if (this.items == null) {
+			this.items = new ArrayList<>();
+			this.items.add(value);
+		} else {
+			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("items");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public void setTags(List<String> value) {
+		this.tags = value;
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	@Override
+	public void setMetadata(Map<String, String> value) {
+		this.metadata = value;
+	}
+
+	@Override
+	public Syn2PathItem createPathItem() {
+		Syn2PathItemImpl node = new Syn2PathItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Map<String, Syn2PathItem> getWebhooks() {
+		return webhooks;
+	}
+
+	@Override
+	public void addWebhook(String name, Syn2PathItem value) {
+		if (this.webhooks == null) {
+			this.webhooks = new LinkedHashMap<>();
+		}
+		this.webhooks.put(name, value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("webhooks");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearWebhooks() {
+		if (this.webhooks != null) {
+			this.webhooks.clear();
+		}
+	}
+
+	@Override
+	public void removeWebhook(String name) {
+		if (this.webhooks != null) {
+			this.webhooks.remove(name);
+		}
+	}
+
+	@Override
+	public void insertWebhook(String name, Syn2PathItem value, int atIndex) {
+		if (this.webhooks == null) {
+			this.webhooks = new LinkedHashMap<>();
+			this.webhooks.put(name, value);
+		} else {
+			this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("webhooks");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitDocument(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2DocumentImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Extensible.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Extensible.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v2;
+
+import io.test.synthetic.SynExtensible;
+
+public interface Syn2Extensible extends SynExtensible {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Info.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Info.java
@@ -1,0 +1,22 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynInfo;
+import java.util.Map;
+
+public interface Syn2Info extends SynInfo, Syn2Extensible {
+
+	public String getLicense();
+
+	public void setLicense(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -1,0 +1,120 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
+
+	private String name;
+	private SynContact contact;
+	private String version;
+	private String license;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String value) {
+		this.name = value;
+	}
+
+	@Override
+	public SynContact getContact() {
+		return contact;
+	}
+
+	@Override
+	public void setContact(SynContact value) {
+		this.contact = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("contact");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn2Contact createContact() {
+		Syn2ContactImpl node = new Syn2ContactImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public String getVersion() {
+		return version;
+	}
+
+	@Override
+	public void setVersion(String value) {
+		this.version = value;
+	}
+
+	@Override
+	public String getLicense() {
+		return license;
+	}
+
+	@Override
+	public void setLicense(String value) {
+		this.license = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitInfo(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2InfoImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Item.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Item.java
@@ -1,0 +1,26 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynItem;
+import java.util.Map;
+
+public interface Syn2Item extends SynItem, Syn2Extensible, Syn2Referenceable {
+
+	public Boolean isDeprecated();
+
+	public void setDeprecated(Boolean value);
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -1,0 +1,238 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
+
+	private String $ref;
+	private String description;
+	private Boolean required;
+	private Integer order;
+	private Number weight;
+	private JsonNode extra;
+	private ObjectNode raw;
+	private SynSchema schema;
+	private List<JsonNode> examples;
+	private BooleanSchemaUnion defaultValue;
+	private String title;
+	private Boolean deprecated;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public void setDescription(String value) {
+		this.description = value;
+	}
+
+	@Override
+	public Boolean isRequired() {
+		return required;
+	}
+
+	@Override
+	public void setRequired(Boolean value) {
+		this.required = value;
+	}
+
+	@Override
+	public Integer getOrder() {
+		return order;
+	}
+
+	@Override
+	public void setOrder(Integer value) {
+		this.order = value;
+	}
+
+	@Override
+	public Number getWeight() {
+		return weight;
+	}
+
+	@Override
+	public void setWeight(Number value) {
+		this.weight = value;
+	}
+
+	@Override
+	public JsonNode getExtra() {
+		return extra;
+	}
+
+	@Override
+	public void setExtra(JsonNode value) {
+		this.extra = value;
+	}
+
+	@Override
+	public ObjectNode getRaw() {
+		return raw;
+	}
+
+	@Override
+	public void setRaw(ObjectNode value) {
+		this.raw = value;
+	}
+
+	@Override
+	public SynSchema getSchema() {
+		return schema;
+	}
+
+	@Override
+	public void setSchema(SynSchema value) {
+		this.schema = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("schema");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn2Schema createSchema() {
+		Syn2SchemaImpl node = new Syn2SchemaImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<JsonNode> getExamples() {
+		return examples;
+	}
+
+	@Override
+	public void setExamples(List<JsonNode> value) {
+		this.examples = value;
+	}
+
+	@Override
+	public BooleanSchemaUnion getDefaultValue() {
+		return defaultValue;
+	}
+
+	@Override
+	public void setDefaultValue(BooleanSchemaUnion value) {
+		this.defaultValue = value;
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParentPropertyName("defaultValue");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParentPropertyName("defaultValue");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParentPropertyName("defaultValue");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public String getTitle() {
+		return title;
+	}
+
+	@Override
+	public void setTitle(String value) {
+		this.title = value;
+	}
+
+	@Override
+	public Boolean isDeprecated() {
+		return deprecated;
+	}
+
+	@Override
+	public void setDeprecated(Boolean value) {
+		this.deprecated = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitItem(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2ItemImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Operation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Operation.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynOperation;
+import java.util.Map;
+
+public interface Syn2Operation extends SynOperation, Syn2Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -1,0 +1,153 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
+
+	private String operationId;
+	private String summary;
+	private List<String> tags;
+	private List<SynItem> parameters;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String getOperationId() {
+		return operationId;
+	}
+
+	@Override
+	public void setOperationId(String value) {
+		this.operationId = value;
+	}
+
+	@Override
+	public String getSummary() {
+		return summary;
+	}
+
+	@Override
+	public void setSummary(String value) {
+		this.summary = value;
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public void setTags(List<String> value) {
+		this.tags = value;
+	}
+
+	@Override
+	public Syn2Item createItem() {
+		Syn2ItemImpl node = new Syn2ItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public List<SynItem> getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public void addParameter(SynItem value) {
+		if (this.parameters == null) {
+			this.parameters = new ArrayList<>();
+		}
+		this.parameters.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("parameters");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearParameters() {
+		if (this.parameters != null) {
+			this.parameters.clear();
+		}
+	}
+
+	@Override
+	public void removeParameter(SynItem value) {
+		if (this.parameters != null) {
+			this.parameters.remove(value);
+		}
+	}
+
+	@Override
+	public void insertParameter(SynItem value, int atIndex) {
+		if (this.parameters == null) {
+			this.parameters = new ArrayList<>();
+			this.parameters.add(value);
+		} else {
+			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("parameters");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitOperation(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2OperationImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItem.java
@@ -1,0 +1,28 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynPathItem;
+import java.util.Map;
+
+public interface Syn2PathItem extends SynPathItem, Syn2Extensible, Syn2Referenceable {
+
+	public Syn2Operation getDelete();
+
+	public void setDelete(Syn2Operation value);
+
+	public Syn2Operation createOperation();
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -1,0 +1,154 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
+
+	private String $ref;
+	private String summary;
+	private SynOperation get;
+	private SynOperation put;
+	private SynOperation post;
+	private Syn2Operation delete;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getSummary() {
+		return summary;
+	}
+
+	@Override
+	public void setSummary(String value) {
+		this.summary = value;
+	}
+
+	@Override
+	public SynOperation getGet() {
+		return get;
+	}
+
+	@Override
+	public void setGet(SynOperation value) {
+		this.get = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("get");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn2Operation createOperation() {
+		Syn2OperationImpl node = new Syn2OperationImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public SynOperation getPut() {
+		return put;
+	}
+
+	@Override
+	public void setPut(SynOperation value) {
+		this.put = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("put");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public SynOperation getPost() {
+		return post;
+	}
+
+	@Override
+	public void setPost(SynOperation value) {
+		this.post = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("post");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Syn2Operation getDelete() {
+		return delete;
+	}
+
+	@Override
+	public void setDelete(Syn2Operation value) {
+		this.delete = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("delete");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitPathItem(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2PathItemImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Paths.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Paths.java
@@ -1,0 +1,18 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynPaths;
+import java.util.Map;
+
+public interface Syn2Paths extends SynPaths, Syn2Extensible {
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -1,0 +1,124 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
+
+	private Map<String, SynPathItem> _items = new LinkedHashMap<>();
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public SynPathItem getItem(String name) {
+		return this._items.get(name);
+	}
+
+	@Override
+	public List<SynPathItem> getItems() {
+		List<SynPathItem> rval = new ArrayList<>();
+		rval.addAll(this._items.values());
+		return rval;
+	}
+
+	@Override
+	public List<String> getItemNames() {
+		List<String> rval = new ArrayList<>();
+		rval.addAll(this._items.keySet());
+		return rval;
+	}
+
+	@Override
+	public void addItem(String name, SynPathItem item) {
+		this._items.put(name, item);
+		if (item != null) {
+			((NodeImpl) item)._setParentPropertyName(null);
+			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) item)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void insertItem(String name, SynPathItem item, int atIndex) {
+		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
+		if (item != null) {
+			((NodeImpl) item)._setParentPropertyName(null);
+			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) item)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public SynPathItem removeItem(String name) {
+		return this._items.remove(name);
+	}
+
+	@Override
+	public void clearItems() {
+		this._items.clear();
+	}
+
+	@Override
+	public Syn2PathItem createPathItem() {
+		Syn2PathItemImpl node = new Syn2PathItemImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitPaths(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2PathsImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Referenceable.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Referenceable.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v2;
+
+import io.test.synthetic.SynReferenceable;
+
+public interface Syn2Referenceable extends SynReferenceable {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Schema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Schema.java
@@ -1,0 +1,22 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.SynSchema;
+import java.util.Map;
+
+public interface Syn2Schema extends SynSchema, Syn2Extensible, Syn2Referenceable {
+
+	public String get$ref();
+
+	public void set$ref(String value);
+
+	public Map<String, JsonNode> getExtensions();
+
+	public void addExtension(String name, JsonNode value);
+
+	public void clearExtensions();
+
+	public void removeExtension(String name);
+
+	public void insertExtension(String name, JsonNode value, int atIndex);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -1,0 +1,346 @@
+package io.test.synthetic.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.util.DataModelUtil;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+import io.test.synthetic.visitors.Visitor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2SchemaImpl extends NodeImpl implements Syn2Schema {
+
+	private String $ref;
+	private String type;
+	private BooleanSchemaSchemaListUnion items;
+	private Map<String, BooleanSchemaUnion> properties;
+	private List<BooleanSchemaUnion> allOf;
+	private Map<String, BooleanSchemaUnion> definitions;
+	private Integer minLength;
+	private Integer maxLength;
+	private List<JsonNode> _enum;
+	private Map<String, JsonNode> extensions;
+
+	@Override
+	public String get$ref() {
+		return $ref;
+	}
+
+	@Override
+	public void set$ref(String value) {
+		this.$ref = value;
+	}
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public void setType(String value) {
+		this.type = value;
+	}
+
+	@Override
+	public BooleanSchemaSchemaListUnion getItems() {
+		return items;
+	}
+
+	@Override
+	public void setItems(BooleanSchemaSchemaListUnion value) {
+		this.items = value;
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParentPropertyName("items");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParentPropertyName("items");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParentPropertyName("items");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public Syn2Schema createSchema() {
+		Syn2SchemaImpl node = new Syn2SchemaImpl();
+		node.setParent(this);
+		return node;
+	}
+
+	@Override
+	public Map<String, BooleanSchemaUnion> getProperties() {
+		return properties;
+	}
+
+	@Override
+	public void addProperty(String name, BooleanSchemaUnion value) {
+		if (this.properties == null) {
+			this.properties = new LinkedHashMap<>();
+		}
+		this.properties.put(name, value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("properties");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearProperties() {
+		if (this.properties != null) {
+			this.properties.clear();
+		}
+	}
+
+	@Override
+	public void removeProperty(String name) {
+		if (this.properties != null) {
+			this.properties.remove(name);
+		}
+	}
+
+	@Override
+	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
+		if (this.properties == null) {
+			this.properties = new LinkedHashMap<>();
+			this.properties.put(name, value);
+		} else {
+			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("properties");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public List<BooleanSchemaUnion> getAllOf() {
+		return allOf;
+	}
+
+	@Override
+	public void addAllOf(BooleanSchemaUnion value) {
+		if (this.allOf == null) {
+			this.allOf = new ArrayList<>();
+		}
+		this.allOf.add(value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("allOf");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearAllOf() {
+		if (this.allOf != null) {
+			this.allOf.clear();
+		}
+	}
+
+	@Override
+	public void removeAllOf(BooleanSchemaUnion value) {
+		if (this.allOf != null) {
+			this.allOf.remove(value);
+		}
+	}
+
+	@Override
+	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
+		if (this.allOf == null) {
+			this.allOf = new ArrayList<>();
+			this.allOf.add(value);
+		} else {
+			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("allOf");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public Map<String, BooleanSchemaUnion> getDefinitions() {
+		return definitions;
+	}
+
+	@Override
+	public void addDefinition(String name, BooleanSchemaUnion value) {
+		if (this.definitions == null) {
+			this.definitions = new LinkedHashMap<>();
+		}
+		this.definitions.put(name, value);
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("definitions");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearDefinitions() {
+		if (this.definitions != null) {
+			this.definitions.clear();
+		}
+	}
+
+	@Override
+	public void removeDefinition(String name) {
+		if (this.definitions != null) {
+			this.definitions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
+		if (this.definitions == null) {
+			this.definitions = new LinkedHashMap<>();
+			this.definitions.put(name, value);
+		} else {
+			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
+		}
+		if (value != null && value.isEntity()) {
+			((NodeImpl) value)._setParentPropertyName("definitions");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public Integer getMinLength() {
+		return minLength;
+	}
+
+	@Override
+	public void setMinLength(Integer value) {
+		this.minLength = value;
+	}
+
+	@Override
+	public Integer getMaxLength() {
+		return maxLength;
+	}
+
+	@Override
+	public void setMaxLength(Integer value) {
+		this.maxLength = value;
+	}
+
+	@Override
+	public List<JsonNode> getEnum() {
+		return _enum;
+	}
+
+	@Override
+	public void setEnum(List<JsonNode> value) {
+		this._enum = value;
+	}
+
+	@Override
+	public Map<String, JsonNode> getExtensions() {
+		return extensions;
+	}
+
+	@Override
+	public void addExtension(String name, JsonNode value) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+		}
+		this.extensions.put(name, value);
+	}
+
+	@Override
+	public void clearExtensions() {
+		if (this.extensions != null) {
+			this.extensions.clear();
+		}
+	}
+
+	@Override
+	public void removeExtension(String name) {
+		if (this.extensions != null) {
+			this.extensions.remove(name);
+		}
+	}
+
+	@Override
+	public void insertExtension(String name, JsonNode value, int atIndex) {
+		if (this.extensions == null) {
+			this.extensions = new LinkedHashMap<>();
+			this.extensions.put(name, value);
+		} else {
+			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
+		}
+	}
+
+	@Override
+	public boolean isBoolean() {
+		return false;
+	}
+
+	@Override
+	public Boolean asBoolean() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public boolean isSchema() {
+		return true;
+	}
+
+	@Override
+	public SynSchema asSchema() {
+		return this;
+	}
+
+	@Override
+	public Object unionValue() {
+		return this;
+	}
+
+	@Override
+	public boolean isSchemaList() {
+		return false;
+	}
+
+	@Override
+	public List<SynSchema> asSchemaList() {
+		throw new ClassCastException();
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Syn2Visitor viz = (Syn2Visitor) visitor;
+		viz.visitSchema(this);
+	}
+
+	@Override
+	public Node emptyClone() {
+		return new Syn2SchemaImpl();
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -1,0 +1,426 @@
+package io.test.synthetic.v2.io;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.io.ModelReader;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.BooleanUnionValue;
+import io.test.synthetic.union.BooleanUnionValueImpl;
+import io.test.synthetic.union.SchemaListUnionValue;
+import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.util.JsonUtil;
+import io.test.synthetic.util.ReaderUtil;
+import io.test.synthetic.v2.Syn2Contact;
+import io.test.synthetic.v2.Syn2Document;
+import io.test.synthetic.v2.Syn2DocumentImpl;
+import io.test.synthetic.v2.Syn2Info;
+import io.test.synthetic.v2.Syn2Item;
+import io.test.synthetic.v2.Syn2Operation;
+import io.test.synthetic.v2.Syn2PathItem;
+import io.test.synthetic.v2.Syn2Paths;
+import io.test.synthetic.v2.Syn2Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2ModelReader implements ModelReader {
+
+	public void readDocument(ObjectNode json, Syn2Document node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "version");
+			node.setVersion(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "info");
+			if (object != null) {
+				node.setInfo(node.createInfo());
+				readInfo(object, (Syn2Info) node.getInfo());
+			}
+		}
+		{
+			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "items");
+			if (objects != null) {
+				objects.forEach(object -> {
+					Syn2Item model = (Syn2Item) node.createItem();
+					this.readItem(object, model);
+					node.addItem(model);
+				});
+			}
+		}
+		{
+			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
+			node.setTags(value);
+		}
+		{
+			Map<String, String> value = JsonUtil.consumeStringMapProperty(json, "metadata");
+			node.setMetadata(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "webhooks");
+			JsonUtil.keys(object).forEach(name -> {
+				ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);
+				if (mapValue != null) {
+					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
+					this.readPathItem(mapValue, model);
+					node.addWebhook(name, model);
+				}
+			});
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	@Override
+	public RootNode readRoot(ObjectNode json) {
+		Syn2Document rootModel = new Syn2DocumentImpl();
+		this.readDocument(json, rootModel);
+		return rootModel;
+	}
+
+	public void readInfo(ObjectNode json, Syn2Info node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "name");
+			node.setName(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "contact");
+			if (object != null) {
+				node.setContact(node.createContact());
+				readContact(object, (Syn2Contact) node.getContact());
+			}
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "version");
+			node.setVersion(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "license");
+			node.setLicense(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readContact(ObjectNode json, Syn2Contact node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "name");
+			node.setName(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "email");
+			node.setEmail(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "url");
+			node.setUrl(value);
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readItem(ObjectNode json, Syn2Item node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "description");
+			node.setDescription(value);
+		}
+		{
+			Boolean value = JsonUtil.consumeBooleanProperty(json, "required");
+			node.setRequired(value);
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "order");
+			node.setOrder(value);
+		}
+		{
+			Number value = JsonUtil.consumeNumberProperty(json, "weight");
+			node.setWeight(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "extra");
+			node.setExtra(value);
+		}
+		{
+			ObjectNode value = JsonUtil.consumeObjectProperty(json, "raw");
+			node.setRaw(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "schema");
+			if (object != null) {
+				node.setSchema(node.createSchema());
+				readSchema(object, (Syn2Schema) node.getSchema());
+			}
+		}
+		{
+			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "examples");
+			node.setExamples(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
+			if (value != null) {
+				if (JsonUtil.isObjectWithProperty(value, "type")) {
+					ObjectNode object = JsonUtil.toObject(value);
+					node.setDefaultValue(node.createSchema());
+					readSchema(object, (Syn2Schema) node.getDefaultValue());
+				} else if (JsonUtil.isBoolean(value)) {
+					Boolean pValue = JsonUtil.toBoolean(value);
+					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+					node.setDefaultValue(unionValue);
+				} else {
+					node.addExtraProperty("defaultValue", value);
+				}
+			}
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "title");
+			node.setTitle(value);
+		}
+		{
+			Boolean value = JsonUtil.consumeBooleanProperty(json, "deprecated");
+			node.setDeprecated(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readSchema(ObjectNode json, Syn2Schema node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "type");
+			node.setType(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
+			if (value != null) {
+				if (JsonUtil.isObjectWithProperty(value, "type")) {
+					ObjectNode object = JsonUtil.toObject(value);
+					node.setItems(node.createSchema());
+					readSchema(object, (Syn2Schema) node.getItems());
+				} else if (JsonUtil.isArray(value)) {
+					List<JsonNode> array = JsonUtil.toList(value);
+					List<Syn2Schema> models = new ArrayList<>();
+					array.forEach(item -> {
+						ObjectNode object = JsonUtil.toObject(item);
+						Syn2Schema model = (Syn2Schema) node.createSchema();
+						this.readSchema(object, model);
+						models.add(model);
+					});
+					@SuppressWarnings({"unchecked", "rawtypes"})
+					SchemaListUnionValue unionValue = new SchemaListUnionValueImpl((List) models);
+					node.setItems(unionValue);
+				} else if (JsonUtil.isBoolean(value)) {
+					Boolean pValue = JsonUtil.toBoolean(value);
+					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+					node.setItems(unionValue);
+				} else {
+					node.addExtraProperty("items", value);
+				}
+			}
+		}
+		{
+			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "properties");
+			if (mapObject != null) {
+				List<String> keys = JsonUtil.keys(mapObject);
+				keys.forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+					if (value != null) {
+						if (JsonUtil.isObject(value)) {
+							ObjectNode object = JsonUtil.toObject(value);
+							Syn2Schema model = (Syn2Schema) node.createSchema();
+							readSchema(object, model);
+							node.addProperty(key, model);
+						} else if (JsonUtil.isBoolean(value)) {
+							Boolean pValue = JsonUtil.toBoolean(value);
+							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+							node.addProperty(key, unionValue);
+						}
+					}
+				});
+			}
+		}
+		{
+			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
+			if (array != null) {
+				array.forEach(value -> {
+					if (JsonUtil.isObject(value)) {
+						ObjectNode object = JsonUtil.toObject(value);
+						Syn2Schema model = (Syn2Schema) node.createSchema();
+						readSchema(object, model);
+						node.addAllOf(model);
+					} else if (JsonUtil.isBoolean(value)) {
+						Boolean pValue = JsonUtil.toBoolean(value);
+						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+						node.addAllOf(unionValue);
+					}
+				});
+			}
+		}
+		{
+			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "definitions");
+			if (mapObject != null) {
+				List<String> keys = JsonUtil.keys(mapObject);
+				keys.forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+					if (value != null) {
+						if (JsonUtil.isObject(value)) {
+							ObjectNode object = JsonUtil.toObject(value);
+							Syn2Schema model = (Syn2Schema) node.createSchema();
+							readSchema(object, model);
+							node.addDefinition(key, model);
+						} else if (JsonUtil.isBoolean(value)) {
+							Boolean pValue = JsonUtil.toBoolean(value);
+							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
+							node.addDefinition(key, unionValue);
+						}
+					}
+				});
+			}
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
+			node.setMinLength(value);
+		}
+		{
+			Integer value = JsonUtil.consumeIntegerProperty(json, "maxLength");
+			node.setMaxLength(value);
+		}
+		{
+			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "enum");
+			node.setEnum(value);
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readPaths(ObjectNode json, Syn2Paths node) {
+		{
+			List<String> propertyNames = JsonUtil.keys(json);
+			propertyNames.forEach(name -> {
+				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
+				if (object != null) {
+					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
+					this.readPathItem(object, model);
+					node.addItem(name, model);
+				}
+			});
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readPathItem(ObjectNode json, Syn2PathItem node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "$ref");
+			node.set$ref(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "summary");
+			node.setSummary(value);
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "get");
+			if (object != null) {
+				node.setGet(node.createOperation());
+				readOperation(object, (Syn2Operation) node.getGet());
+			}
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "put");
+			if (object != null) {
+				node.setPut(node.createOperation());
+				readOperation(object, (Syn2Operation) node.getPut());
+			}
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "post");
+			if (object != null) {
+				node.setPost(node.createOperation());
+				readOperation(object, (Syn2Operation) node.getPost());
+			}
+		}
+		{
+			ObjectNode object = JsonUtil.consumeObjectProperty(json, "delete");
+			if (object != null) {
+				node.setDelete(node.createOperation());
+				readOperation(object, (Syn2Operation) node.getDelete());
+			}
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	public void readOperation(ObjectNode json, Syn2Operation node) {
+		{
+			String value = JsonUtil.consumeStringProperty(json, "operationId");
+			node.setOperationId(value);
+		}
+		{
+			String value = JsonUtil.consumeStringProperty(json, "summary");
+			node.setSummary(value);
+		}
+		{
+			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
+			node.setTags(value);
+		}
+		{
+			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "parameters");
+			if (objects != null) {
+				objects.forEach(object -> {
+					Syn2Item model = (Syn2Item) node.createItem();
+					this.readItem(object, model);
+					node.addParameter(model);
+				});
+			}
+		}
+		{
+			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
+			propertyNames.forEach(name -> {
+				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
+				node.addExtension(name, value);
+			});
+		}
+		ReaderUtil.readExtraProperties(json, node);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
@@ -1,0 +1,71 @@
+package io.test.synthetic.v2.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v2.Syn2Contact;
+import io.test.synthetic.v2.Syn2Document;
+import io.test.synthetic.v2.Syn2Info;
+import io.test.synthetic.v2.Syn2Item;
+import io.test.synthetic.v2.Syn2Operation;
+import io.test.synthetic.v2.Syn2PathItem;
+import io.test.synthetic.v2.Syn2Paths;
+import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+
+public class Syn2ModelReaderDispatcher implements Syn2Visitor {
+
+	private final ObjectNode json;
+	private final Syn2ModelReader reader;
+
+	public Syn2ModelReaderDispatcher(ObjectNode json, Syn2ModelReader reader) {
+		this.json = json;
+		this.reader = reader;
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		this.reader.readPaths(this.json, (Syn2Paths) node);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		this.reader.readOperation(this.json, (Syn2Operation) node);
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		this.reader.readSchema(this.json, (Syn2Schema) node);
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		this.reader.readInfo(this.json, (Syn2Info) node);
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		this.reader.readPathItem(this.json, (Syn2PathItem) node);
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		this.reader.readDocument(this.json, (Syn2Document) node);
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		this.reader.readContact(this.json, (Syn2Contact) node);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		this.reader.readItem(this.json, (Syn2Item) node);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -1,0 +1,364 @@
+package io.test.synthetic.v2.io;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.RootNode;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.io.ModelWriter;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
+import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.util.JsonUtil;
+import io.test.synthetic.util.WriterUtil;
+import io.test.synthetic.v2.Syn2Contact;
+import io.test.synthetic.v2.Syn2Document;
+import io.test.synthetic.v2.Syn2Info;
+import io.test.synthetic.v2.Syn2Item;
+import io.test.synthetic.v2.Syn2Operation;
+import io.test.synthetic.v2.Syn2PathItem;
+import io.test.synthetic.v2.Syn2Paths;
+import io.test.synthetic.v2.Syn2Schema;
+import java.util.List;
+import java.util.Map;
+
+public class Syn2ModelWriter implements ModelWriter {
+
+	public void writeDocument(Syn2Document node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		{
+			if (node.getInfo() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeInfo((Syn2Info) node.getInfo(), object);
+				JsonUtil.setObjectProperty(json, "info", object);
+			}
+		}
+		{
+			List<? extends SynItem> models = node.getItems();
+			if (models != null && !models.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				models.forEach(model -> {
+					ObjectNode object = JsonUtil.objectNode();
+					this.writeItem((Syn2Item) model, object);
+					JsonUtil.addToArray(array, object);
+				});
+				JsonUtil.setAnyProperty(json, "items", array);
+			}
+		}
+		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		JsonUtil.setStringMapProperty(json, "metadata", node.getMetadata());
+		{
+			Map<String, ? extends SynPathItem> models = node.getWebhooks();
+			if (models != null && !models.isEmpty()) {
+				ObjectNode object = JsonUtil.objectNode();
+				models.keySet().forEach(jsonName -> {
+					ObjectNode jsonValue = JsonUtil.objectNode();
+					this.writePathItem((Syn2PathItem) models.get(jsonName), jsonValue);
+					JsonUtil.setObjectProperty(object, jsonName, jsonValue);
+				});
+				JsonUtil.setObjectProperty(json, "webhooks", object);
+			}
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	@Override
+	public ObjectNode writeRoot(RootNode node) {
+		ObjectNode json = JsonUtil.objectNode();
+		this.writeDocument((Syn2Document) node, json);
+		return json;
+	}
+
+	public void writeInfo(Syn2Info node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "name", node.getName());
+		{
+			if (node.getContact() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeContact((Syn2Contact) node.getContact(), object);
+				JsonUtil.setObjectProperty(json, "contact", object);
+			}
+		}
+		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		JsonUtil.setStringProperty(json, "license", node.getLicense());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeContact(Syn2Contact node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "name", node.getName());
+		JsonUtil.setStringProperty(json, "email", node.getEmail());
+		JsonUtil.setStringProperty(json, "url", node.getUrl());
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeItem(Syn2Item node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "description", node.getDescription());
+		JsonUtil.setBooleanProperty(json, "required", node.isRequired());
+		JsonUtil.setIntegerProperty(json, "order", node.getOrder());
+		JsonUtil.setNumberProperty(json, "weight", node.getWeight());
+		JsonUtil.setAnyProperty(json, "extra", node.getExtra());
+		JsonUtil.setObjectProperty(json, "raw", node.getRaw());
+		{
+			if (node.getSchema() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeSchema((Syn2Schema) node.getSchema(), object);
+				JsonUtil.setObjectProperty(json, "schema", object);
+			}
+		}
+		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
+		{
+			BooleanSchemaUnion union = node.getDefaultValue();
+			if (union != null) {
+				if (union.isBoolean()) {
+					JsonUtil.setBooleanProperty(json, "defaultValue", union.asBoolean());
+				}
+				if (union.isSchema()) {
+					ObjectNode jsonValue = JsonUtil.objectNode();
+					this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
+					JsonUtil.setObjectProperty(json, "defaultValue", jsonValue);
+				}
+			}
+		}
+		JsonUtil.setStringProperty(json, "title", node.getTitle());
+		JsonUtil.setBooleanProperty(json, "deprecated", node.isDeprecated());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeSchema(Syn2Schema node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "type", node.getType());
+		{
+			BooleanSchemaSchemaListUnion union = node.getItems();
+			if (union != null) {
+				if (union.isBoolean()) {
+					JsonUtil.setBooleanProperty(json, "items", union.asBoolean());
+				}
+				if (union.isSchema()) {
+					ObjectNode jsonValue = JsonUtil.objectNode();
+					this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
+					JsonUtil.setObjectProperty(json, "items", jsonValue);
+				}
+				if (union.isSchemaList()) {
+					List<? extends SynSchema> models = union.asSchemaList();
+					ArrayNode array = JsonUtil.arrayNode();
+					models.forEach(model -> {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn2Schema) model, object);
+						JsonUtil.addToArray(array, object);
+					});
+					JsonUtil.setAnyProperty(json, "items", array);
+				}
+			}
+		}
+		{
+			Map<String, BooleanSchemaUnion> unionMap = node.getProperties();
+			if (unionMap != null && !unionMap.isEmpty()) {
+				ObjectNode mapObject = JsonUtil.objectNode();
+				unionMap.keySet().forEach(key -> {
+					BooleanSchemaUnion union = unionMap.get(key);
+					if (union.isBoolean()) {
+						mapObject.put(key, union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn2Schema) union.asSchema(), object);
+						JsonUtil.setObjectProperty(mapObject, key, object);
+					}
+				});
+				JsonUtil.setObjectProperty(json, "properties", mapObject);
+			}
+		}
+		{
+			List<BooleanSchemaUnion> unionList = node.getAllOf();
+			if (unionList != null && !unionList.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				unionList.forEach(union -> {
+					if (union.isBoolean()) {
+						array.add(union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn2Schema) union.asSchema(), object);
+						JsonUtil.addToArray(array, object);
+					}
+				});
+				JsonUtil.setAnyProperty(json, "allOf", array);
+			}
+		}
+		{
+			Map<String, BooleanSchemaUnion> unionMap = node.getDefinitions();
+			if (unionMap != null && !unionMap.isEmpty()) {
+				ObjectNode mapObject = JsonUtil.objectNode();
+				unionMap.keySet().forEach(key -> {
+					BooleanSchemaUnion union = unionMap.get(key);
+					if (union.isBoolean()) {
+						mapObject.put(key, union.asBoolean());
+					}
+					if (union.isSchema()) {
+						ObjectNode object = JsonUtil.objectNode();
+						this.writeSchema((Syn2Schema) union.asSchema(), object);
+						JsonUtil.setObjectProperty(mapObject, key, object);
+					}
+				});
+				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+			}
+		}
+		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
+		JsonUtil.setIntegerProperty(json, "maxLength", node.getMaxLength());
+		JsonUtil.setAnyArrayProperty(json, "enum", node.getEnum());
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writePaths(Syn2Paths node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		{
+			List<String> propertyNames = node.getItemNames();
+			propertyNames.forEach(propertyName -> {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writePathItem((Syn2PathItem) node.getItem(propertyName), object);
+				JsonUtil.setObjectProperty(json, propertyName, object);
+			});
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writePathItem(Syn2PathItem node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
+		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		{
+			if (node.getGet() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn2Operation) node.getGet(), object);
+				JsonUtil.setObjectProperty(json, "get", object);
+			}
+		}
+		{
+			if (node.getPut() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn2Operation) node.getPut(), object);
+				JsonUtil.setObjectProperty(json, "put", object);
+			}
+		}
+		{
+			if (node.getPost() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn2Operation) node.getPost(), object);
+				JsonUtil.setObjectProperty(json, "post", object);
+			}
+		}
+		{
+			if (node.getDelete() != null) {
+				ObjectNode object = JsonUtil.objectNode();
+				this.writeOperation((Syn2Operation) node.getDelete(), object);
+				JsonUtil.setObjectProperty(json, "delete", object);
+			}
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	public void writeOperation(Syn2Operation node, ObjectNode json) {
+		if (node == null) {
+			return;
+		}
+		JsonUtil.setStringProperty(json, "operationId", node.getOperationId());
+		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		{
+			List<? extends SynItem> models = node.getParameters();
+			if (models != null && !models.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				models.forEach(model -> {
+					ObjectNode object = JsonUtil.objectNode();
+					this.writeItem((Syn2Item) model, object);
+					JsonUtil.addToArray(array, object);
+				});
+				JsonUtil.setAnyProperty(json, "parameters", array);
+			}
+		}
+		{
+			Map<String, JsonNode> values = node.getExtensions();
+			if (values != null && !values.isEmpty()) {
+				values.keySet().forEach(propertyName -> {
+					JsonNode value = values.get(propertyName);
+					JsonUtil.setAnyProperty(json, propertyName, value);
+				});
+			}
+		}
+		WriterUtil.writeExtraProperties(node, json);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
@@ -1,0 +1,71 @@
+package io.test.synthetic.v2.io;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v2.Syn2Contact;
+import io.test.synthetic.v2.Syn2Document;
+import io.test.synthetic.v2.Syn2Info;
+import io.test.synthetic.v2.Syn2Item;
+import io.test.synthetic.v2.Syn2Operation;
+import io.test.synthetic.v2.Syn2PathItem;
+import io.test.synthetic.v2.Syn2Paths;
+import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+
+public class Syn2ModelWriterDispatcher implements Syn2Visitor {
+
+	private final ObjectNode json;
+	private final Syn2ModelWriter writer;
+
+	public Syn2ModelWriterDispatcher(ObjectNode json, Syn2ModelWriter writer) {
+		this.json = json;
+		this.writer = writer;
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		this.writer.writePaths((Syn2Paths) node, this.json);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		this.writer.writeOperation((Syn2Operation) node, this.json);
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		this.writer.writeSchema((Syn2Schema) node, this.json);
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		this.writer.writeInfo((Syn2Info) node, this.json);
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		this.writer.writePathItem((Syn2PathItem) node, this.json);
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		this.writer.writeDocument((Syn2Document) node, this.json);
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		this.writer.writeContact((Syn2Contact) node, this.json);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		this.writer.writeItem((Syn2Item) node, this.json);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -1,0 +1,86 @@
+package io.test.synthetic.v2.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v2.Syn2Document;
+import io.test.synthetic.v2.Syn2Info;
+import io.test.synthetic.v2.Syn2Item;
+import io.test.synthetic.v2.Syn2Operation;
+import io.test.synthetic.v2.Syn2PathItem;
+import io.test.synthetic.v2.Syn2Paths;
+import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.visitors.AbstractTraverser;
+import io.test.synthetic.visitors.Visitor;
+
+public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
+
+	public Syn2Traverser(Visitor visitor) {
+		super(visitor);
+	}
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		node.accept(this.visitor);
+		Syn2Paths model = (Syn2Paths) node;
+		this.traverseMappedNode(model);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		node.accept(this.visitor);
+		Syn2Operation model = (Syn2Operation) node;
+		this.traverseList("parameters", model.getParameters());
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		node.accept(this.visitor);
+		Syn2Schema model = (Syn2Schema) node;
+		this.traverseUnion("items", model.getItems());
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		node.accept(this.visitor);
+		Syn2Info model = (Syn2Info) node;
+		this.traverseNode("contact", model.getContact());
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		node.accept(this.visitor);
+		Syn2PathItem model = (Syn2PathItem) node;
+		this.traverseNode("get", model.getGet());
+		this.traverseNode("put", model.getPut());
+		this.traverseNode("post", model.getPost());
+		this.traverseNode("delete", model.getDelete());
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		node.accept(this.visitor);
+		Syn2Document model = (Syn2Document) node;
+		this.traverseNode("info", model.getInfo());
+		this.traverseList("items", model.getItems());
+		this.traverseMap("webhooks", model.getWebhooks());
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		node.accept(this.visitor);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		node.accept(this.visitor);
+		Syn2Item model = (Syn2Item) node;
+		this.traverseNode("schema", model.getSchema());
+		this.traverseUnion("defaultValue", model.getDefaultValue());
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Visitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Visitor.java
@@ -1,0 +1,6 @@
+package io.test.synthetic.v2.visitors;
+
+import io.test.synthetic.visitors.Visitor;
+
+public interface Syn2Visitor extends Visitor {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
@@ -1,0 +1,45 @@
+package io.test.synthetic.v2.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+
+public class Syn2VisitorAdapter implements Syn2Visitor {
+
+	@Override
+	public void visitPaths(SynPaths node) {
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -1,0 +1,156 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.MappedNode;
+import io.test.synthetic.Node;
+import io.test.synthetic.Visitable;
+import io.test.synthetic.union.EntityListUnionValue;
+import io.test.synthetic.union.EntityMapUnionValue;
+import io.test.synthetic.union.Union;
+import io.test.synthetic.util.JsonUtil;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Base class for all traversers.
+ */
+public abstract class AbstractTraverser implements Traverser, Visitor {
+
+	protected final Visitor visitor;
+	protected final TraversalContextImpl traversalContext = new TraversalContextImpl();
+
+	/**
+	 * C'tor.
+	 *
+	 * @param visitor
+	 */
+	public AbstractTraverser(Visitor visitor) {
+		this.visitor = visitor;
+		if (visitor instanceof TraversingVisitor) {
+			((TraversingVisitor) visitor).setTraversalContext(this.traversalContext);
+		}
+	}
+
+	/**
+	 * Traverse the given node. Guaranteed to not be null here.
+	 *
+	 * @param node
+	 */
+	protected void doTraverseNode(Visitable node) {
+		node.accept(this);
+	}
+
+	/**
+	 * Traverse into the given node, unless it's null.
+	 *
+	 * @param propertyName
+	 * @param node
+	 */
+	protected void traverseNode(String propertyName, Visitable node) {
+		if (node != null) {
+			traversalContext.pushProperty(propertyName);
+			doTraverseNode(node);
+			traversalContext.pop();
+		}
+	}
+
+	/**
+	 * Traverse the items of the given array.
+	 *
+	 * @param propertyName
+	 * @param items
+	 */
+	@SuppressWarnings("unchecked")
+	protected void traverseList(String propertyName, Collection<? extends Node> items) {
+		if (items != null) {
+			int index = 0;
+			traversalContext.pushProperty(propertyName);
+			Collection<? extends Node> clonedItems = (Collection<? extends Node>) JsonUtil.cloneCollection(items);
+			for (Node node : clonedItems) {
+				if (node != null) {
+					traversalContext.pushListIndex(index);
+					doTraverseNode(node);
+					traversalContext.pop();
+				}
+				index++;
+			}
+			traversalContext.pop();
+		}
+	}
+
+	/**
+	 * Traverse the items of the given map.
+	 *
+	 * @param propertyName
+	 * @param items
+	 */
+	@SuppressWarnings("unchecked")
+	protected void traverseMap(String propertyName, Map<String, ? extends Node> items) {
+		if (items != null) {
+			traversalContext.pushProperty(propertyName);
+			Collection<String> keys = (Collection<String>) JsonUtil.cloneCollection(items.keySet());
+			keys.forEach(key -> {
+				Node value = items.get(key);
+				if (value != null) {
+					this.traversalContext.pushMapIndex(key);
+					this.doTraverseNode(value);
+					this.traversalContext.pop();
+				}
+			});
+			this.traversalContext.pop();
+		}
+	}
+
+	/**
+	 * Traverse the items of the given mapped node.
+	 *
+	 * @param items
+	 */
+	@SuppressWarnings("unchecked")
+	protected void traverseMappedNode(MappedNode<? extends Node> mappedNode) {
+		if (mappedNode != null) {
+			Collection<String> names = (Collection<String>) JsonUtil.cloneCollection(mappedNode.getItemNames());
+			names.forEach(name -> {
+				Node value = mappedNode.getItem(name);
+				if (value != null) {
+					this.traversalContext.pushMapIndex(name);
+					this.doTraverseNode(value);
+					this.traversalContext.pop();
+				}
+			});
+		}
+	}
+
+	/**
+	 * Traverse a union property. Traversal of a union property only needs to happen
+	 * if the value of the union is an entity or an entity collection.
+	 * 
+	 * @param propertyName
+	 * @param union
+	 */
+	@SuppressWarnings("unchecked")
+	protected void traverseUnion(String propertyName, Union union) {
+		if (union != null) {
+			if (union.isEntity()) {
+				this.traverseNode(propertyName, union);
+			} else if (union.isEntityList()) {
+				EntityListUnionValue<? extends Node> value = (EntityListUnionValue<? extends Node>) union;
+				this.traverseList(propertyName, value.getValue());
+			} else if (union.isEntityMap()) {
+				EntityMapUnionValue<? extends Node> value = (EntityMapUnionValue<? extends Node>) union;
+				this.traverseMap(propertyName, value.getValue());
+			}
+		}
+	}
+
+	/**
+	 * Called to traverse the data model starting at the given node and traversing
+	 * down until this node and all child nodes have been visited.
+	 *
+	 * @param node
+	 */
+	@Override
+	public void traverse(Node node) {
+		node.accept(this);
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
@@ -1,0 +1,56 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.Node;
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+
+public abstract class AllNodeVisitor implements CombinedVisitor {
+
+	protected abstract void visitNode(Node node);
+
+	@Override
+	public void visitPaths(SynPaths node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+		this.visitNode(node);
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+		this.visitNode(node);
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitor.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+
+public interface CombinedVisitor extends Syn2Visitor, Syn1Visitor {
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
@@ -1,0 +1,47 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+import io.test.synthetic.v1.visitors.Syn1Visitor;
+import io.test.synthetic.v2.visitors.Syn2Visitor;
+
+public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
+
+	@Override
+	public void visitPaths(SynPaths node) {
+	}
+
+	@Override
+	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public void visitSchema(SynSchema node) {
+	}
+
+	@Override
+	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public void visitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public void visitContact(SynContact node) {
+	}
+
+	@Override
+	public void visitItem(SynItem node) {
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
@@ -1,0 +1,27 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.Node;
+
+public class ReverseTraverser extends AllNodeVisitor implements Traverser {
+
+	protected Visitor visitor;
+
+	public ReverseTraverser(Visitor visitor) {
+		this.visitor = visitor;
+	}
+
+	@Override
+	public void traverse(Node node) {
+		node.accept(this);
+	}
+
+	@Override
+	protected void visitNode(Node node) {
+		node.accept(this.visitor);
+
+		if (node.parent() != null) {
+			this.traverse(node.parent());
+		}
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContext.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContext.java
@@ -1,0 +1,21 @@
+package io.test.synthetic.visitors;
+
+import java.util.List;
+
+/**
+ * Context used during traversal of a model. This gives insight into where in
+ * the traversal of a model a visitor/traverser might be. The traverser
+ * maintains this context and optionally makes it available to the visitor (only
+ * if the visitor implements the TraversingVisitor interface.
+ */
+public interface TraversalContext {
+
+	public TraversalStep getMostRecentStep();
+
+	public List<TraversalStep> getAllSteps();
+
+	public boolean containsStep(TraversalStepType type, Object value);
+
+	public String getMostRecentPropertyStep();
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContextImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContextImpl.java
@@ -1,0 +1,70 @@
+package io.test.synthetic.visitors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * Context used during traversal of a model. This gives insight into where in
+ * the traversal of a model a visitor/traverser might be. The traverser
+ * maintains this context and optionally makes it available to the visitor (only
+ * if the visitor implements the TraversingVisitor interface.
+ *
+ * @author eric.wittmann@gmail.com
+ */
+public class TraversalContextImpl implements TraversalContext {
+
+	private final Stack<TraversalStep> stack = new Stack<>();
+
+	public void pushProperty(String propertyName) {
+		this.stack.push(TraversalStep.fromNodeProperty(propertyName));
+	}
+	public void pushListIndex(int index) {
+		this.stack.push(TraversalStep.fromListIndex(index));
+	}
+	public void pushMapIndex(String key) {
+		this.stack.push(TraversalStep.fromMapIndex(key));
+	}
+
+	public void pop() {
+		this.stack.pop();
+	}
+
+	public TraversalStep peek() {
+		return this.stack.peek();
+	}
+
+	@Override
+	public TraversalStep getMostRecentStep() {
+		return this.stack.peek();
+	}
+
+	@Override
+	public List<TraversalStep> getAllSteps() {
+		TraversalStep[] steps = this.stack.toArray(new TraversalStep[this.stack.size()]);
+		return Collections.unmodifiableList(Arrays.asList(steps));
+	}
+
+	@Override
+	public String getMostRecentPropertyStep() {
+		for (int idx = stack.size() - 1; idx >= 0; idx--) {
+			TraversalStep step = stack.get(idx);
+			if (step.getType() == TraversalStepType.property) {
+				return (String) step.getValue();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean containsStep(TraversalStepType type, Object value) {
+		for (TraversalStep step : stack) {
+			if (step.getType() == type && value.equals(step.getValue())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalStep.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalStep.java
@@ -1,0 +1,33 @@
+package io.test.synthetic.visitors;
+
+public class TraversalStep {
+
+	private final TraversalStepType type;
+	private final Object value;
+
+	public static TraversalStep fromNodeProperty(String propertyName) {
+		return new TraversalStep(TraversalStepType.property, propertyName);
+	}
+
+	public static TraversalStep fromListIndex(int index) {
+		return new TraversalStep(TraversalStepType.arrayIndex, index);
+	}
+
+	public static TraversalStep fromMapIndex(String key) {
+		return new TraversalStep(TraversalStepType.mapIndex, key);
+	}
+
+	private TraversalStep(TraversalStepType type, Object value) {
+		this.type = type;
+		this.value = value;
+	}
+
+	public TraversalStepType getType() {
+		return type;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalStepType.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalStepType.java
@@ -1,0 +1,7 @@
+package io.test.synthetic.visitors;
+
+public enum TraversalStepType {
+
+	property, arrayIndex, mapIndex
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Traverser.java
@@ -1,0 +1,17 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.Node;
+
+/**
+ * All data model traversers must implement this interface.
+ */
+public interface Traverser {
+
+	/**
+	 * Traverse a single node in a data model.
+	 * 
+	 * @param node
+	 */
+	public void traverse(Node node);
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversingVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversingVisitor.java
@@ -1,0 +1,14 @@
+package io.test.synthetic.visitors;
+
+/**
+ * Any visitor that cares about traversal context can implement this interface
+ * (in addition to the standard Visitor interface). When this interface is
+ * implemented, the standard traverser will share the traverser context with the
+ * visitor. This will allow the visitor to have some context about where it is
+ * in the traversal of the model.
+ */
+public interface TraversingVisitor {
+
+	public void setTraversalContext(TraversalContext context);
+
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
@@ -1,0 +1,29 @@
+package io.test.synthetic.visitors;
+
+import io.test.synthetic.SynContact;
+import io.test.synthetic.SynDocument;
+import io.test.synthetic.SynInfo;
+import io.test.synthetic.SynItem;
+import io.test.synthetic.SynOperation;
+import io.test.synthetic.SynPathItem;
+import io.test.synthetic.SynPaths;
+import io.test.synthetic.SynSchema;
+
+public interface Visitor {
+
+	public void visitPaths(SynPaths node);
+
+	public void visitOperation(SynOperation node);
+
+	public void visitSchema(SynSchema node);
+
+	public void visitInfo(SynInfo node);
+
+	public void visitPathItem(SynPathItem node);
+
+	public void visitDocument(SynDocument node);
+
+	public void visitContact(SynContact node);
+
+	public void visitItem(SynItem node);
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
@@ -1,0 +1,211 @@
+# Synthetic spec version 1 — exercises all generator features.
+# Version 2 adds properties/entities for normalization testing.
+
+name: Synthetic v1
+version: "1"
+versions:
+  - version: "1.0"
+    url: https://example.com/synthetic/1.0
+prefix: Syn1
+namespace: io.test.synthetic.v1
+majorVersionPrefix: Syn1x
+majorVersionNamespace: io.test.synthetic.v1x
+
+traits:
+  # Feature 9: Basic trait with properties
+  - name: Extensible
+    properties:
+      # Feature 7: Regex property with collection
+      - name: '/^x-.+$/'
+        type: any
+        collection: extensions
+
+  # Feature 9: Trait with entity property
+  - name: Referenceable
+    properties:
+      - name: '$ref'
+        type: string
+
+  # Feature 10: Transparent trait (inlined into entity, no interface generated)
+  - name: CommonMetadata
+    transparent: true
+    properties:
+      - name: title
+        type: string
+      - name: description
+        type: string
+
+entities:
+  # Feature 8: Root entity
+  - name: Document
+    root: true
+    # Feature 11: Entity with traits
+    traits:
+      - Extensible
+    properties:
+      # Feature 1: Primitive property types
+      - name: version
+        type: string
+      - name: info
+        # Feature 2: Entity property type
+        type: Info
+      - name: items
+        # Feature 3: List of entities
+        type: '[Item]'
+      - name: tags
+        # Feature 3: List of primitives
+        type: '[string]'
+      - name: metadata
+        # Feature 4: Map of primitives
+        type: '{string}'
+    # Feature 12: Property ordering
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: Info
+    traits:
+      - Extensible
+    properties:
+      - name: name
+        type: string
+      - name: contact
+        type: Contact
+      - name: version
+        type: string
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: Contact
+    properties:
+      - name: name
+        type: string
+      - name: email
+        type: string
+      - name: url
+        type: string
+    propertyOrder:
+      - $this
+
+  - name: Item
+    traits:
+      - Extensible
+      - Referenceable
+      # Feature 10: Transparent trait on entity
+      - CommonMetadata
+    properties:
+      # Feature 1: Various primitive types
+      - name: required
+        type: boolean
+      - name: order
+        type: integer
+      - name: weight
+        type: number
+      - name: extra
+        type: any
+      - name: raw
+        type: object
+      # Feature 2: Entity type
+      - name: schema
+        type: Schema
+      # Feature 3: List of entities
+      - name: examples
+        type: '[any]'
+      # Feature 5: Union of entity and primitive
+      - name: defaultValue
+        type: 'boolean|Schema'
+        # Feature 14: Union rules
+        unionRules:
+          - unionType: Schema
+            ruleType: propertyExists
+            propertyName: type
+      # Feature 16: Shaded property (also defined in CommonMetadata trait)
+      - name: title
+        type: string
+    propertyOrder:
+      - $Referenceable
+      - $CommonMetadata
+      - $this
+      - $Extensible
+
+  - name: Schema
+    traits:
+      - Extensible
+      - Referenceable
+    properties:
+      - name: type
+        type: string
+      # Feature 5: Union of primitives and entity
+      - name: items
+        type: 'boolean|Schema|[Schema]'
+        # Feature 18: Complex multi-way union with list
+        unionRules:
+          - unionType: Schema
+            ruleType: propertyExists
+            propertyName: type
+      # Feature 4: Map of entities
+      - name: properties
+        type: '{boolean|Schema}'
+      # Feature 20: List of unions
+      - name: allOf
+        type: '[boolean|Schema]'
+      # Feature 19: Map of unions
+      - name: definitions
+        type: '{boolean|Schema}'
+      - name: minLength
+        type: integer
+      - name: maxLength
+        type: integer
+      - name: enum
+        type: '[any]'
+    propertyOrder:
+      - $Referenceable
+      - $this
+      - $Extensible
+
+  # Feature 6: Star property (MappedNode)
+  - name: Paths
+    traits:
+      - Extensible
+    properties:
+      - name: '*'
+        type: PathItem
+        collection: items
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: PathItem
+    traits:
+      - Extensible
+      - Referenceable
+    properties:
+      - name: summary
+        type: string
+      - name: get
+        type: Operation
+      - name: put
+        type: Operation
+      - name: post
+        type: Operation
+    propertyOrder:
+      - $Referenceable
+      - $this
+      - $Extensible
+
+  - name: Operation
+    traits:
+      - Extensible
+    properties:
+      - name: operationId
+        type: string
+      - name: summary
+        type: string
+      - name: tags
+        type: '[string]'
+      - name: parameters
+        type: '[Item]'
+    propertyOrder:
+      - $this
+      - $Extensible

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
@@ -1,0 +1,199 @@
+# Synthetic spec version 2 — adds/removes properties for normalization testing.
+# Some entities are shared with v1 (testing entity/trait/property normalization),
+# some are v2-only.
+
+name: Synthetic v2
+version: "2"
+versions:
+  - version: "2.0"
+    url: https://example.com/synthetic/2.0
+prefix: Syn2
+namespace: io.test.synthetic.v2
+majorVersionPrefix: Syn2x
+majorVersionNamespace: io.test.synthetic.v2x
+
+traits:
+  - name: Extensible
+    properties:
+      - name: '/^x-.+$/'
+        type: any
+        collection: extensions
+
+  - name: Referenceable
+    properties:
+      - name: '$ref'
+        type: string
+
+  - name: CommonMetadata
+    transparent: true
+    properties:
+      - name: title
+        type: string
+      - name: description
+        type: string
+
+entities:
+  - name: Document
+    root: true
+    traits:
+      - Extensible
+    properties:
+      - name: version
+        type: string
+      - name: info
+        type: Info
+      - name: items
+        type: '[Item]'
+      - name: tags
+        type: '[string]'
+      - name: metadata
+        type: '{string}'
+      # Feature 13: v2 adds a new property (normalization test)
+      - name: webhooks
+        type: '{PathItem}'
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: Info
+    traits:
+      - Extensible
+    properties:
+      - name: name
+        type: string
+      - name: contact
+        type: Contact
+      - name: version
+        type: string
+      # Feature 13: v2 adds a new property
+      - name: license
+        type: string
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: Contact
+    properties:
+      - name: name
+        type: string
+      - name: email
+        type: string
+      - name: url
+        type: string
+    propertyOrder:
+      - $this
+
+  - name: Item
+    traits:
+      - Extensible
+      - Referenceable
+      - CommonMetadata
+    properties:
+      - name: required
+        type: boolean
+      - name: order
+        type: integer
+      - name: weight
+        type: number
+      - name: extra
+        type: any
+      - name: raw
+        type: object
+      - name: schema
+        type: Schema
+      - name: examples
+        type: '[any]'
+      - name: defaultValue
+        type: 'boolean|Schema'
+        unionRules:
+          - unionType: Schema
+            ruleType: propertyExists
+            propertyName: type
+      - name: title
+        type: string
+      # Feature 13: v2 adds a new property
+      - name: deprecated
+        type: boolean
+    propertyOrder:
+      - $Referenceable
+      - $CommonMetadata
+      - $this
+      - $Extensible
+
+  - name: Schema
+    traits:
+      - Extensible
+      - Referenceable
+    properties:
+      - name: type
+        type: string
+      - name: items
+        type: 'boolean|Schema|[Schema]'
+        unionRules:
+          - unionType: Schema
+            ruleType: propertyExists
+            propertyName: type
+      - name: properties
+        type: '{boolean|Schema}'
+      - name: allOf
+        type: '[boolean|Schema]'
+      - name: definitions
+        type: '{boolean|Schema}'
+      - name: minLength
+        type: integer
+      - name: maxLength
+        type: integer
+      - name: enum
+        type: '[any]'
+    propertyOrder:
+      - $Referenceable
+      - $this
+      - $Extensible
+
+  - name: Paths
+    traits:
+      - Extensible
+    properties:
+      - name: '*'
+        type: PathItem
+        collection: items
+    propertyOrder:
+      - $this
+      - $Extensible
+
+  - name: PathItem
+    traits:
+      - Extensible
+      - Referenceable
+    properties:
+      - name: summary
+        type: string
+      - name: get
+        type: Operation
+      - name: put
+        type: Operation
+      - name: post
+        type: Operation
+      # Feature 13: v2 adds delete
+      - name: delete
+        type: Operation
+    propertyOrder:
+      - $Referenceable
+      - $this
+      - $Extensible
+
+  - name: Operation
+    traits:
+      - Extensible
+    properties:
+      - name: operationId
+        type: string
+      - name: summary
+        type: string
+      - name: tags
+        type: '[string]'
+      - name: parameters
+        type: '[Item]'
+    propertyOrder:
+      - $this
+      - $Extensible

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic.yaml
@@ -1,0 +1,8 @@
+name: Synthetic
+url: https://example.com/synthetic
+description: Synthetic spec exercising every generator feature for snapshot testing.
+prefix: Syn
+namespace: io.test.synthetic
+versions:
+  - $ref: ./synthetic-v1.yaml
+  - $ref: ./synthetic-v2.yaml


### PR DESCRIPTION
## Summary

- Add a synthetic spec exercising all 20 generator features for snapshot testing
- Fix non-deterministic property ordering that caused test flakiness

## Synthetic snapshot test

A "kitchen sink" spec with 2 versions, ~8 entities, ~3 traits, covering:
primitives, entities, lists, maps, unions, MappedNode, regex properties,
traits, transparent traits, normalization, union rules, property ordering,
shaded properties, and multi-way unions.

115 generated files are committed as expected output. The test compares
generated output byte-for-byte against these files, catching any regression.

To update after intentional changes: delete `expected/` and re-run.

## Deterministic ordering fix

Two sources of non-determinism:

1. `PropertyType.nested` used `HashSet` — union type variants iterated in
   unpredictable order. Fixed: `LinkedHashSet` preserves parser insertion order.

2. `ConceptIndex.getAllEntityProperties()` used `HashSet` as fallback when no
   `propertyOrder` was declared. Fixed: `TreeSet` with alphabetical ordering.

## Test plan

- [x] All 5 generator tests pass together (`mvn clean test -pl generator`)
- [x] Full build produces identical output (`mvn clean install`, 901 data-models tests pass)

## Related

- Epic: Apitomy/apitomy-data-models#1041