### PR TITLE
feat(generator): Type hierarchy and Java type layer (G6.1 + G7.1)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/UnifiedModelGenerator.java
+++ b/generator/src/main/java/io/apitomy/umg/UnifiedModelGenerator.java
@@ -24,7 +24,7 @@ import io.apitomy.umg.pipe.concept.CreateEntityModelsStage;
 import io.apitomy.umg.pipe.concept.CreateImplicitUnionRulesStage;
 import io.apitomy.umg.pipe.concept.CreateNamespaceModelsStage;
 import io.apitomy.umg.pipe.concept.CreatePropertyComparatorStage;
-import io.apitomy.umg.pipe.concept.CreatePropertyModelsStage;
+import io.apitomy.umg.pipe.concept.CreatePropertyAndTypeModelsStage;
 import io.apitomy.umg.pipe.concept.CreateTraitModelsStage;
 import io.apitomy.umg.pipe.concept.CreateVisitorsStage;
 import io.apitomy.umg.pipe.concept.ExpandPropertyOrderStage;
@@ -111,7 +111,7 @@ public class UnifiedModelGenerator {
         pipe.addStage(new CreateTraitModelsStage());
         pipe.addStage(new CreateEntityModelsStage());
 //        pipe.addStage(new CreateParentTraitsStage());
-        pipe.addStage(new CreatePropertyModelsStage());
+        pipe.addStage(new CreatePropertyAndTypeModelsStage());
         pipe.addStage(new CreateVisitorsStage());
         pipe.addStage(new RemoveShadedPropertyModelsStage());
 

--- a/generator/src/main/java/io/apitomy/umg/index/concept/ConceptIndex.java
+++ b/generator/src/main/java/io/apitomy/umg/index/concept/ConceptIndex.java
@@ -35,6 +35,7 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyModelWithOriginComparator;
 import io.apitomy.umg.models.concept.TraitModel;
 import io.apitomy.umg.models.concept.VisitorModel;
+import io.apitomy.umg.models.concept.type.Type;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -46,6 +47,8 @@ public class ConceptIndex {
     private Trie<String, EntityModel> entityIndex = new PatriciaTrie<>();
     private Trie<String, VisitorModel> visitorIndex = new PatriciaTrie<>();
     private Map<String, PropertyModelWithOriginComparator> propertyComparatorIndex = new HashMap<>();
+    // Named types (type aliases) indexed by fully-qualified name (namespace.typeName)
+    private Trie<String, Type> typeIndex = new PatriciaTrie<>();
 
 
     public void remove(TraitModel traitModel) {
@@ -100,6 +103,26 @@ public class ConceptIndex {
 
     public void index(EntityModel model, PropertyModelWithOriginComparator comparator) {
         propertyComparatorIndex.put(model.fullyQualifiedName(), comparator);
+    }
+
+    public void indexType(String fullyQualifiedName, Type type) {
+        typeIndex.put(fullyQualifiedName, type);
+    }
+
+    public Type lookupType(String fullyQualifiedName) {
+        return typeIndex.get(fullyQualifiedName);
+    }
+
+    public Type lookupType(String namespace, String typeName) {
+        return lookupType(namespace + "." + typeName);
+    }
+
+    public Collection<Type> findTypes(String prefix) {
+        return typeIndex.prefixMap(prefix).values();
+    }
+
+    public boolean hasType(String fullyQualifiedName) {
+        return typeIndex.containsKey(fullyQualifiedName);
     }
 
     public NamespaceModel lookupNamespace(String namespace) {

--- a/generator/src/main/java/io/apitomy/umg/index/concept/SpecificationIndex.java
+++ b/generator/src/main/java/io/apitomy/umg/index/concept/SpecificationIndex.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import io.apitomy.umg.beans.Entity;
@@ -43,7 +44,7 @@ public class SpecificationIndex {
     //  alongside the type system refactoring (G6).
     private Collection<SpecificationModel> specifications = new HashSet<>();
 
-    private Collection<SpecificationVersion> specificationVersions = new HashSet<>();
+    private Collection<SpecificationVersion> specificationVersions = new LinkedHashSet<>();
 
     @Getter
     private Map<SpecificationVersionId, SpecificationModel> specIndex = new HashMap<>();

--- a/generator/src/main/java/io/apitomy/umg/models/concept/PropertyModel.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/PropertyModel.java
@@ -3,6 +3,7 @@ package io.apitomy.umg.models.concept;
 import java.util.List;
 
 import io.apitomy.umg.beans.UnionRule;
+import io.apitomy.umg.models.concept.type.Type;
 import lombok.Builder;
 import lombok.Data;
 
@@ -23,7 +24,17 @@ public class PropertyModel {
 
     private List<UnionRule> unionRules;
 
+    /**
+     * @deprecated Use {@link #resolvedType} instead. Will be removed once all stages are migrated.
+     */
+    @Deprecated
     private PropertyType type;
+
+    /**
+     * The resolved type — references actual EntityModel objects, carries union rules,
+     * and supports the visitor pattern. Set by CreatePropertyAndTypeModelsStage.
+     */
+    private Type resolvedType;
 
     private boolean shaded;
 

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/AbstractType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/AbstractType.java
@@ -1,0 +1,29 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString
+public abstract class AbstractType implements Type {
+
+    @EqualsAndHashCode.Include
+    protected String namespace;
+
+    @EqualsAndHashCode.Include
+    protected String name;
+
+    protected RawType rawType;
+
+    protected Type parent;
+
+    protected boolean leaf;
+
+    protected boolean root;
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/CollectionType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/CollectionType.java
@@ -1,0 +1,23 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Base class for list and map types.
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@ToString(callSuper = true)
+public abstract class CollectionType extends AbstractType {
+
+    protected Type valueType;
+
+    @Override
+    public boolean isCollectionType() { return true; }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/EntityType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/EntityType.java
@@ -1,0 +1,52 @@
+package io.apitomy.umg.models.concept.type;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Represents a reference to an entity type.
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class EntityType extends AbstractType {
+
+    @ToString.Exclude
+    private EntityModel entity;
+
+    public static EntityType fromEntity(EntityModel entity) {
+        return EntityType.builder()
+                .namespace(entity.getNamespace().fullName())
+                .name(entity.getName())
+                .rawType(RawType.parse(entity.getName()))
+                .entity(entity)
+                .build();
+    }
+
+    @Override
+    public EntityType copy() {
+        return EntityType.builder()
+                .namespace(namespace)
+                .name(name)
+                .rawType(rawType)
+                .entity(entity)
+                .parent(parent)
+                .leaf(leaf)
+                .root(root)
+                .build();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isEntityType() { return true; }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/ListType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/ListType.java
@@ -1,0 +1,46 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Represents a list type (e.g., {@code [Widget]}, {@code [string]}).
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@ToString(callSuper = true)
+public class ListType extends CollectionType {
+
+    @Override
+    public ListType copy() {
+        return ListType.builder()
+                .namespace(namespace)
+                .name(name)
+                .rawType(rawType)
+                .valueType(valueType)
+                .parent(parent)
+                .leaf(leaf)
+                .root(root)
+                .build();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        valueType.accept(visitor);
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isListType() { return true; }
+
+    @Override
+    public boolean isPrimitiveListType() { return valueType.isPrimitiveType(); }
+
+    @Override
+    public boolean isEntityListType() { return valueType.isEntityType(); }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/MapType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/MapType.java
@@ -1,0 +1,47 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Represents a map type (e.g., {@code {Widget}}, {@code {string}}).
+ * Keys are always strings.
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@ToString(callSuper = true)
+public class MapType extends CollectionType {
+
+    @Override
+    public MapType copy() {
+        return MapType.builder()
+                .namespace(namespace)
+                .name(name)
+                .rawType(rawType)
+                .valueType(valueType)
+                .parent(parent)
+                .leaf(leaf)
+                .root(root)
+                .build();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        valueType.accept(visitor);
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isMapType() { return true; }
+
+    @Override
+    public boolean isPrimitiveMapType() { return valueType.isPrimitiveType(); }
+
+    @Override
+    public boolean isEntityMapType() { return valueType.isEntityType(); }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/PrimitiveType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/PrimitiveType.java
@@ -1,0 +1,104 @@
+package io.apitomy.umg.models.concept.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a primitive (built-in) type: string, boolean, number, integer, object, any.
+ */
+public enum PrimitiveType implements Type {
+
+    STRING("string", String.class),
+    BOOLEAN("boolean", Boolean.class),
+    NUMBER("number", Number.class),
+    INTEGER("integer", Integer.class),
+    OBJECT("object", ObjectNode.class),
+    ANY("any", JsonNode.class);
+
+    public static final String NAMESPACE = "<primitive>";
+
+    private static final Map<String, PrimitiveType> BY_NAME = new HashMap<>();
+
+    static {
+        for (var type : PrimitiveType.values()) {
+            BY_NAME.put(type.name, type);
+        }
+    }
+
+    public static PrimitiveType getByName(String name) {
+        return BY_NAME.get(name);
+    }
+
+    public static boolean isPrimitive(String name) {
+        return BY_NAME.containsKey(name);
+    }
+
+    private final String name;
+    private final Class<?> javaClass;
+    private final RawType rawType;
+
+    PrimitiveType(String name, Class<?> javaClass) {
+        this.name = name;
+        this.javaClass = javaClass;
+        this.rawType = RawType.parse(name);
+    }
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public RawType getRawType() {
+        return rawType;
+    }
+
+    public Class<?> getJavaClass() {
+        return javaClass;
+    }
+
+    @Override
+    public boolean isRoot() { return false; }
+
+    @Override
+    public void setRoot(boolean root) {
+        throw new UnsupportedOperationException("Primitive type cannot be root");
+    }
+
+    @Override
+    public Type getParent() { return null; }
+
+    @Override
+    public void setParent(Type parent) {
+        throw new UnsupportedOperationException("Primitive type cannot have a parent");
+    }
+
+    @Override
+    public boolean isLeaf() { return false; }
+
+    @Override
+    public void setLeaf(boolean leaf) {
+        throw new UnsupportedOperationException("Primitive type cannot be leaf");
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public PrimitiveType copy() {
+        return this;
+    }
+
+    @Override
+    public boolean isPrimitiveType() { return true; }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/PrimitiveUnionVariantType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/PrimitiveUnionVariantType.java
@@ -1,0 +1,44 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Wraps a {@link PrimitiveType} when it appears as a variant in a union.
+ * This distinction exists because primitives in unions need different
+ * code generation (wrapper classes like {@code BooleanUnionValueImpl}).
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@ToString(callSuper = true)
+public class PrimitiveUnionVariantType extends AbstractType {
+
+    private PrimitiveType type;
+
+    @Override
+    public PrimitiveUnionVariantType copy() {
+        return PrimitiveUnionVariantType.builder()
+                .namespace(namespace)
+                .name(name)
+                .rawType(rawType)
+                .type(type)
+                .parent(parent)
+                .leaf(leaf)
+                .root(root)
+                .build();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        type.accept(visitor);
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isPrimitiveUnionVariantType() { return true; }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/RawType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/RawType.java
@@ -1,0 +1,158 @@
+package io.apitomy.umg.models.concept.type;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Parses and represents a raw type string from the spec YAML (e.g., "{@code [Widget]}", "{@code Foo|Bar}").
+ * <p>
+ * Unlike {@link Type}, this is a pure parse tree with no semantic resolution —
+ * entity names are just strings, not references to {@link io.apitomy.umg.models.concept.EntityModel}.
+ * <p>
+ * Compared to {@link io.apitomy.umg.models.concept.PropertyType}, this uses ordered {@code List}
+ * instead of unordered {@code Set} for nested types, and sorts union variants alphabetically
+ * for deterministic output.
+ */
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class RawType {
+
+    public static RawType parse(String type) {
+        Deque<RawType> stack = new ArrayDeque<>();
+        RawType last = null;
+        var charArray = type.toCharArray();
+        readNextChar:
+        for (var i = 0; i < charArray.length; i++) {
+            var c = charArray[i];
+            var current = stack.peek();
+            switch (c) {
+                case '{', '[' -> {
+                    if (current != null && current.simple) {
+                        throw new ParserException(type, i, "Unexpected token '" + c + "'");
+                    }
+                    var nested = c == '{' ? RawType.builder().map(true).build()
+                            : RawType.builder().list(true).build();
+                    stack.push(nested);
+                }
+                case '}', ']' -> {
+                    while (!stack.isEmpty()) {
+                        current = stack.pop();
+                        if (current.union) {
+                            current.nested.add(last);
+                        }
+                        if ((c == '}' && current.map) || (c == ']' && current.list)) {
+                            current.nested.add(last);
+                            last = current;
+                            continue readNextChar;
+                        }
+                        last = current;
+                    }
+                    throw new ParserException(type, i, "Unexpected token '" + c + "'");
+                }
+                case '|' -> {
+                    if (current == null || current.map || current.list) {
+                        var union = RawType.builder().union(true).build();
+                        union.nested.add(last);
+                        stack.push(union);
+                    } else if (current.union) {
+                        current.nested.add(last);
+                    } else if (current.simple) {
+                        current = stack.pop();
+                        last = current;
+                        var after = stack.peek();
+                        if (after != null && after.union) {
+                            after.nested.add(current);
+                        } else {
+                            var union = RawType.builder().union(true).build();
+                            union.nested.add(current);
+                            stack.push(union);
+                        }
+                    }
+                }
+                default -> {
+                    if (current == null || current.union || current.map || current.list) {
+                        var simple = RawType.builder().simple(true).build();
+                        simple.simpleType = "" + c;
+                        stack.push(simple);
+                    } else if (current.simple) {
+                        current.simpleType += c;
+                    }
+                }
+            }
+        }
+        while (!stack.isEmpty()) {
+            var current = stack.pop();
+            if (current.union) {
+                current.nested.add(last);
+            } else if (!current.simple) {
+                throw new ParserException(type, type.length(), "Unexpected end of string");
+            }
+            last = current;
+        }
+        sort(last);
+        return last;
+    }
+
+    private static void sort(RawType type) {
+        type.getNested().forEach(RawType::sort);
+        type.getNested().sort(Comparator.comparing(RawType::asRawType));
+    }
+
+    @Builder.Default
+    @Getter
+    private final List<RawType> nested = new ArrayList<>();
+
+    @Builder.Default
+    @Getter
+    private String simpleType = "";
+
+    @Getter
+    private boolean list;
+
+    @Getter
+    private boolean map;
+
+    @Getter
+    private boolean union;
+
+    private boolean simple;
+
+    public boolean isSimple() { return simple; }
+
+    public boolean isPrimitiveType() {
+        return simple && PrimitiveType.isPrimitive(simpleType);
+    }
+
+    public boolean isEntityType() {
+        return simple && !isPrimitiveType();
+    }
+
+    @EqualsAndHashCode.Include
+    public String asRawType() {
+        if (simple) return simpleType;
+        if (list) return "[" + nested.get(0).asRawType() + "]";
+        if (map) return "{" + nested.get(0).asRawType() + "}";
+        if (union) return nested.stream().map(RawType::asRawType).collect(Collectors.joining("|"));
+        throw new IllegalStateException("Unknown raw type structure");
+    }
+
+    @Override
+    public String toString() {
+        return asRawType();
+    }
+
+    public static class ParserException extends RuntimeException {
+
+        public ParserException(String type, int position, String message) {
+            super("Parser error at:\n" + type + "\n" + " ".repeat(position) + "^\n" + message);
+        }
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/Type.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/Type.java
@@ -1,0 +1,71 @@
+package io.apitomy.umg.models.concept.type;
+
+/**
+ * Represents a resolved type in the generator's concept model.
+ * <p>
+ * Types form a tree: a {@link UnionType} contains multiple variant {@code Type}s,
+ * a {@link ListType} or {@link MapType} wraps a value {@code Type}.
+ * <p>
+ * Unlike {@link io.apitomy.umg.models.concept.PropertyType} (which is a raw parser output),
+ * {@code Type} instances are resolved against the concept index — entity types reference
+ * actual {@link io.apitomy.umg.models.concept.EntityModel} objects.
+ *
+ * @see EntityType
+ * @see UnionType
+ * @see PrimitiveType
+ * @see ListType
+ * @see MapType
+ */
+public interface Type {
+
+    String getNamespace();
+
+    String getName();
+
+    /**
+     * The raw type string this type was parsed from (e.g., "string", "[Widget]", "Foo|Bar").
+     */
+    RawType getRawType();
+
+    boolean isRoot();
+
+    void setRoot(boolean root);
+
+    /**
+     * Parent type in the normalization hierarchy — a type with the same name
+     * in a parent namespace. Used for cross-version type lifting.
+     */
+    Type getParent();
+
+    void setParent(Type parent);
+
+    boolean isLeaf();
+
+    void setLeaf(boolean leaf);
+
+    void accept(TypeVisitor visitor);
+
+    Type copy();
+
+    default boolean isEntityType() { return false; }
+
+    default boolean isPrimitiveType() { return false; }
+
+    default boolean isUnionType() { return false; }
+
+    default boolean isListType() { return false; }
+
+    default boolean isMapType() { return false; }
+
+    default boolean isCollectionType() { return false; }
+
+    default boolean isPrimitiveUnionVariantType() { return false; }
+
+    default boolean isPrimitiveListType() { return false; }
+
+    default boolean isPrimitiveMapType() { return false; }
+
+    default boolean isEntityListType() { return false; }
+
+    default boolean isEntityMapType() { return false; }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/TypeVisitor.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/TypeVisitor.java
@@ -1,0 +1,22 @@
+package io.apitomy.umg.models.concept.type;
+
+/**
+ * Visitor for the {@link Type} hierarchy.
+ * All methods have default no-op implementations — override only the types you care about.
+ */
+public interface TypeVisitor {
+
+    default void visit(PrimitiveType type) {}
+
+    default boolean shouldVisit(UnionType type) { return true; }
+
+    default void visit(UnionType type) {}
+
+    default void visit(ListType type) {}
+
+    default void visit(MapType type) {}
+
+    default void visit(EntityType type) {}
+
+    default void visit(PrimitiveUnionVariantType type) {}
+}

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/UnionType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/UnionType.java
@@ -1,0 +1,70 @@
+package io.apitomy.umg.models.concept.type;
+
+import io.apitomy.umg.beans.UnionRule;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a union of multiple types (e.g., {@code Foo|Bar|boolean}).
+ * <p>
+ * Union types can be:
+ * <ul>
+ *   <li>Named — created from a type alias in the spec YAML</li>
+ *   <li>Anonymous — created inline from a property's type string</li>
+ * </ul>
+ * Named unions are stored in the type index and can be referenced by name.
+ */
+@SuperBuilder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@ToString(callSuper = true)
+public class UnionType extends AbstractType {
+
+    @lombok.Builder.Default
+    private List<Type> types = new ArrayList<>();
+
+    @lombok.Builder.Default
+    private List<UnionRule> unionRules = new ArrayList<>();
+
+    @Override
+    public UnionType copy() {
+        return UnionType.builder()
+                .namespace(namespace)
+                .name(name)
+                .rawType(rawType)
+                .types(new ArrayList<>(types))
+                .unionRules(new ArrayList<>(unionRules))
+                .parent(parent)
+                .leaf(leaf)
+                .root(root)
+                .build();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        if (visitor.shouldVisit(this)) {
+            types.forEach(t -> t.accept(visitor));
+        }
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isUnionType() { return true; }
+
+    public UnionRule getRuleFor(String rawUnionSubtype) {
+        if (unionRules != null) {
+            return unionRules.stream()
+                    .filter(rule -> rule.getUnionType().equals(rawUnionSubtype))
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/EntityJavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/EntityJavaType.java
@@ -1,0 +1,44 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.Type;
+import org.jboss.forge.roaster.model.source.Importer;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+
+/**
+ * Java type for entity references. Resolves to the entity's Java interface.
+ */
+public class EntityJavaType implements JavaType {
+
+    private final EntityType entityType;
+    private final JavaInterfaceSource interfaceSource;
+
+    public EntityJavaType(EntityType entityType, JavaInterfaceSource interfaceSource) {
+        this.entityType = entityType;
+        this.interfaceSource = interfaceSource;
+    }
+
+    @Override
+    public Type getConceptType() {
+        return entityType;
+    }
+
+    @Override
+    public String toJavaTypeString() {
+        return interfaceSource.getName();
+    }
+
+    @Override
+    public void addImportsTo(Importer<?> importer) {
+        importer.addImport(interfaceSource);
+    }
+
+    @Override
+    public String getSimpleName() {
+        return interfaceSource.getName();
+    }
+
+    public JavaInterfaceSource getInterfaceSource() {
+        return interfaceSource;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/JavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/JavaType.java
@@ -1,0 +1,37 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.Type;
+import org.jboss.forge.roaster.model.source.Importer;
+
+/**
+ * Represents a resolved Java type for code generation.
+ * <p>
+ * Each implementation wraps a concept {@link Type} and provides Java-specific
+ * operations: type string generation, import management, and entity resolution.
+ * <p>
+ * Created by {@link JavaTypeFactory} from concept Types.
+ */
+public interface JavaType {
+
+    /**
+     * The underlying concept type.
+     */
+    Type getConceptType();
+
+    /**
+     * The Java type string for use in generated code (e.g., "String", "List&lt;Widget&gt;",
+     * "BooleanWidgetUnion").
+     */
+    String toJavaTypeString();
+
+    /**
+     * Add necessary imports to the given Java source.
+     */
+    void addImportsTo(Importer<?> importer);
+
+    /**
+     * The simple name of this type (for method names, field names, etc.).
+     * For entities: "Widget". For primitives: "String". For lists: "WidgetList".
+     */
+    String getSimpleName();
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/JavaTypeFactory.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/JavaTypeFactory.java
@@ -1,0 +1,161 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.index.java.JavaIndex;
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.concept.SpecificationIndex;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+/**
+ * Creates {@link JavaType} instances from concept {@link Type} objects by resolving
+ * entity references against the Java index.
+ * <p>
+ * This replaces the inner {@code JavaType} class in {@code AbstractJavaStage} with
+ * a proper factory that uses the resolved Type hierarchy.
+ */
+public class JavaTypeFactory {
+
+    private final ConceptIndex conceptIndex;
+    private final SpecificationIndex specIndex;
+    private final JavaIndex javaIndex;
+    private final String unionTypesPackage;
+
+    public JavaTypeFactory(ConceptIndex conceptIndex, SpecificationIndex specIndex,
+                           JavaIndex javaIndex, String unionTypesPackage) {
+        this.conceptIndex = conceptIndex;
+        this.specIndex = specIndex;
+        this.javaIndex = javaIndex;
+        this.unionTypesPackage = unionTypesPackage;
+    }
+
+    /**
+     * Create a JavaType from a concept Type, resolving entity references
+     * using the namespace context's prefix to construct the Java FQN.
+     * This matches the old behavior where the origin entity's namespace
+     * determines the prefix used.
+     */
+    public JavaType createJavaType(Type type, NamespaceModel namespaceContext) {
+        return createJavaType(type, namespaceContext, false);
+    }
+
+    /**
+     * Create a JavaType from a concept Type.
+     *
+     * @param useCommonResolution if true, resolve entities to their most-parent
+     *                            common entity (used for union type stages).
+     */
+    public JavaType createJavaType(Type type, NamespaceModel namespaceContext, boolean useCommonResolution) {
+        if (type instanceof PrimitiveType primitive) {
+            return new PrimitiveJavaType(primitive);
+        }
+
+        if (type instanceof EntityType entityType) {
+            var interfaceSource = resolveEntityInterface(entityType, namespaceContext, useCommonResolution);
+            return new EntityJavaType(entityType, interfaceSource);
+        }
+
+        if (type instanceof ListType listType) {
+            var valueJavaType = createJavaType(listType.getValueType(), namespaceContext, useCommonResolution);
+            return new ListJavaType(listType, valueJavaType);
+        }
+
+        if (type instanceof MapType mapType) {
+            var valueJavaType = createJavaType(mapType.getValueType(), namespaceContext, useCommonResolution);
+            return new MapJavaType(mapType, valueJavaType);
+        }
+
+        if (type instanceof UnionType unionType) {
+            return createUnionJavaType(unionType, namespaceContext, useCommonResolution);
+        }
+
+        if (type instanceof PrimitiveUnionVariantType variant) {
+            return new PrimitiveJavaType(variant.getType());
+        }
+
+        throw new IllegalArgumentException("Unsupported type: " + type.getClass().getSimpleName());
+    }
+
+    private UnionJavaType createUnionJavaType(UnionType unionType, NamespaceModel namespaceContext,
+                                               boolean useCommonResolution) {
+        var variantJavaTypes = unionType.getTypes().stream()
+                .map(t -> createJavaType(t, namespaceContext, useCommonResolution))
+                .collect(Collectors.toList());
+
+        var sortedTypes = new ArrayList<>(unionType.getTypes());
+        sortedTypes.sort(Comparator.comparing(t -> getUnionComponentName(t).toLowerCase()));
+
+        var unionName = sortedTypes.stream()
+                .map(JavaTypeFactory::getUnionComponentName)
+                .collect(Collectors.joining()) + "Union";
+        var unionFQN = unionTypesPackage + "." + unionName;
+
+        return new UnionJavaType(unionType, unionName, unionFQN, variantJavaTypes);
+    }
+
+    public static String getUnionComponentName(Type type) {
+        if (type instanceof EntityType entityType) {
+            return entityType.getName();
+        } else if (type instanceof PrimitiveType primitiveType) {
+            return StringUtils.capitalize(primitiveType.name().toLowerCase());
+        } else if (type instanceof PrimitiveUnionVariantType variant) {
+            return StringUtils.capitalize(variant.getType().name().toLowerCase());
+        } else if (type instanceof ListType listType) {
+            return getUnionComponentName(listType.getValueType()) + "List";
+        } else if (type instanceof MapType mapType) {
+            return getUnionComponentName(mapType.getValueType()) + "Map";
+        } else if (type instanceof UnionType unionType) {
+            return unionType.getTypes().stream()
+                    .map(JavaTypeFactory::getUnionComponentName)
+                    .collect(Collectors.joining()) + "Union";
+        }
+        throw new IllegalArgumentException("Unsupported type for union naming: " + type);
+    }
+
+    private JavaInterfaceSource resolveEntityInterface(EntityType entityType, NamespaceModel namespaceContext,
+                                                        boolean useCommonResolution) {
+        var entityName = entityType.getName();
+        if (useCommonResolution) {
+            var commonEntity = conceptIndex.lookupCommonEntity(namespaceContext.fullName(), entityName);
+            if (commonEntity != null) {
+                return lookupJavaEntityInterface(commonEntity);
+            }
+        }
+        // Default: resolve using the namespace context's prefix, matching old behavior
+        // where the origin entity's namespace determines the Java type prefix
+        return lookupJavaEntityInterfaceByNamespace(namespaceContext.fullName(), entityName);
+    }
+
+    private JavaInterfaceSource lookupJavaEntityInterfaceByNamespace(String namespace, String entityName) {
+        var prefix = specIndex.prefixForNS(namespace);
+        var fqn = namespace + "." + (prefix == null ? "" : prefix) + entityName;
+        var result = javaIndex.lookupInterface(fqn);
+        if (result == null) {
+            throw new RuntimeException("Java interface not found: " + fqn);
+        }
+        return result;
+    }
+
+    private JavaInterfaceSource lookupJavaEntityInterface(EntityModel entity) {
+        var namespace = entity.getNamespace().fullName();
+        var prefix = specIndex.prefixForNS(namespace);
+        var fqn = namespace + "." + (prefix == null ? "" : prefix) + entity.getName();
+        var result = javaIndex.lookupInterface(fqn);
+        if (result == null) {
+            throw new RuntimeException("Java interface not found for entity: " + fqn);
+        }
+        return result;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/ListJavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/ListJavaType.java
@@ -1,0 +1,46 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.Type;
+import org.jboss.forge.roaster.model.source.Importer;
+
+import java.util.List;
+
+/**
+ * Java type for list types: [Widget] → List&lt;Widget&gt;, [string] → List&lt;String&gt;.
+ */
+public class ListJavaType implements JavaType {
+
+    private final ListType listType;
+    private final JavaType valueJavaType;
+
+    public ListJavaType(ListType listType, JavaType valueJavaType) {
+        this.listType = listType;
+        this.valueJavaType = valueJavaType;
+    }
+
+    @Override
+    public Type getConceptType() {
+        return listType;
+    }
+
+    @Override
+    public String toJavaTypeString() {
+        return "List<" + valueJavaType.toJavaTypeString() + ">";
+    }
+
+    @Override
+    public void addImportsTo(Importer<?> importer) {
+        importer.addImport(List.class);
+        valueJavaType.addImportsTo(importer);
+    }
+
+    @Override
+    public String getSimpleName() {
+        return valueJavaType.getSimpleName() + "List";
+    }
+
+    public JavaType getValueJavaType() {
+        return valueJavaType;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/MapJavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/MapJavaType.java
@@ -1,0 +1,47 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.concept.type.Type;
+import org.jboss.forge.roaster.model.source.Importer;
+
+import java.util.Map;
+
+/**
+ * Java type for map types: {Widget} → Map&lt;String, Widget&gt;, {string} → Map&lt;String, String&gt;.
+ * Keys are always String.
+ */
+public class MapJavaType implements JavaType {
+
+    private final MapType mapType;
+    private final JavaType valueJavaType;
+
+    public MapJavaType(MapType mapType, JavaType valueJavaType) {
+        this.mapType = mapType;
+        this.valueJavaType = valueJavaType;
+    }
+
+    @Override
+    public Type getConceptType() {
+        return mapType;
+    }
+
+    @Override
+    public String toJavaTypeString() {
+        return "Map<String, " + valueJavaType.toJavaTypeString() + ">";
+    }
+
+    @Override
+    public void addImportsTo(Importer<?> importer) {
+        importer.addImport(Map.class);
+        valueJavaType.addImportsTo(importer);
+    }
+
+    @Override
+    public String getSimpleName() {
+        return valueJavaType.getSimpleName() + "Map";
+    }
+
+    public JavaType getValueJavaType() {
+        return valueJavaType;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/PrimitiveJavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/PrimitiveJavaType.java
@@ -1,0 +1,44 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.Type;
+import org.jboss.forge.roaster.model.source.Importer;
+
+/**
+ * Java type for primitives: string → String, boolean → Boolean, number → Number, etc.
+ */
+public class PrimitiveJavaType implements JavaType {
+
+    private final PrimitiveType primitiveType;
+
+    public PrimitiveJavaType(PrimitiveType primitiveType) {
+        this.primitiveType = primitiveType;
+    }
+
+    @Override
+    public Type getConceptType() {
+        return primitiveType;
+    }
+
+    @Override
+    public String toJavaTypeString() {
+        return primitiveType.getJavaClass().getSimpleName();
+    }
+
+    @Override
+    public void addImportsTo(Importer<?> importer) {
+        var javaClass = primitiveType.getJavaClass();
+        if (!javaClass.getPackageName().equals("java.lang")) {
+            importer.addImport(javaClass);
+        }
+    }
+
+    @Override
+    public String getSimpleName() {
+        return primitiveType.getJavaClass().getSimpleName();
+    }
+
+    public Class<?> getJavaClass() {
+        return primitiveType.getJavaClass();
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/UnionJavaType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/UnionJavaType.java
@@ -1,0 +1,55 @@
+package io.apitomy.umg.models.java.type;
+
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+import org.jboss.forge.roaster.model.source.Importer;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+
+import java.util.List;
+
+/**
+ * Java type for union types: boolean|Widget → BooleanWidgetUnion.
+ */
+public class UnionJavaType implements JavaType {
+
+    private final UnionType unionType;
+    private final String unionName;
+    private final String unionFQN;
+    private final List<JavaType> variantJavaTypes;
+
+    public UnionJavaType(UnionType unionType, String unionName, String unionFQN,
+                         List<JavaType> variantJavaTypes) {
+        this.unionType = unionType;
+        this.unionName = unionName;
+        this.unionFQN = unionFQN;
+        this.variantJavaTypes = variantJavaTypes;
+    }
+
+    @Override
+    public Type getConceptType() {
+        return unionType;
+    }
+
+    @Override
+    public String toJavaTypeString() {
+        return unionName;
+    }
+
+    @Override
+    public void addImportsTo(Importer<?> importer) {
+        importer.addImport(unionFQN);
+    }
+
+    @Override
+    public String getSimpleName() {
+        return unionName;
+    }
+
+    public String getUnionFQN() {
+        return unionFQN;
+    }
+
+    public List<JavaType> getVariantJavaTypes() {
+        return variantJavaTypes;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/CreateImplicitUnionRulesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/CreateImplicitUnionRulesStage.java
@@ -11,7 +11,8 @@ import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.pipe.AbstractStage;
 
 /**
@@ -36,7 +37,7 @@ public class CreateImplicitUnionRulesStage extends AbstractStage {
         getState().getConceptIndex().findEntities("").forEach(entity -> {
             entity.getProperties().values().stream()
             // Only care about properties with union types.
-            .filter(property -> property.getType().isUnion())
+            .filter(property -> property.getResolvedType() instanceof UnionType)
             // Only if the property doesn't already have union rules defined.
             .filter(property -> property.getUnionRules() == null || property.getUnionRules().isEmpty())
             // Only if the union type has ambiguity
@@ -48,13 +49,14 @@ public class CreateImplicitUnionRulesStage extends AbstractStage {
     }
 
     private boolean isUnionAmbiguous(PropertyModel property) {
+        var unionType = (UnionType) property.getResolvedType();
         int entityCount = 0;
         int arrayCount = 0;
         int mapCount = 0;
-        for (PropertyType nestedType : property.getType().getNested()) {
-            if (nestedType.isMap()) {
+        for (var nestedType : unionType.getTypes()) {
+            if (nestedType.isMapType()) {
                 mapCount++;
-            } else if (nestedType.isList()) {
+            } else if (nestedType.isListType()) {
                 arrayCount++;
             } else if (nestedType.isEntityType()) {
                 entityCount++;
@@ -76,10 +78,11 @@ public class CreateImplicitUnionRulesStage extends AbstractStage {
      * @param property
      */
     private void createImplicitUnionRules(EntityModel entity, PropertyModel property) {
-        final int minimumRulesRequired = property.getType().getNested().size() - 1;
+        var unionType = (UnionType) property.getResolvedType();
+        final int minimumRulesRequired = unionType.getTypes().size() - 1;
         int rulesCreated = 0;
-        for (PropertyType nestedType : property.getType().getNested()) {
-            UnionRule rule = createImplicitRuleForEntity(entity.getNamespace(), nestedType.getSimpleType());
+        for (var nestedType : unionType.getTypes()) {
+            UnionRule rule = createImplicitRuleForEntity(entity.getNamespace(), nestedType.getName());
             if (rule != null) {
                 List<UnionRule> unionRules = property.getUnionRules();
                 if (unionRules == null) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
@@ -1,0 +1,180 @@
+package io.apitomy.umg.pipe.concept;
+
+import io.apitomy.umg.beans.Property;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.TraitModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
+import io.apitomy.umg.models.concept.type.RawType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.pipe.AbstractStage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Creates property models AND resolves their types into the new Type hierarchy.
+ * <p>
+ * This stage replaces {@link CreatePropertyModelsStage} with an extended version that:
+ * <ol>
+ *   <li>Creates {@link PropertyModel} with parsed {@link PropertyType} (legacy, for backward compat)</li>
+ *   <li>Also resolves each property's type into a {@link Type} object and sets {@link PropertyModel#setResolvedType}</li>
+ *   <li>Indexes named types (type aliases) in the concept index for later reference</li>
+ * </ol>
+ * <p>
+ * Type resolution means entity type names are looked up in the concept index to get actual
+ * {@link EntityModel} references, and union/list/map types build a proper type tree.
+ */
+public class CreatePropertyAndTypeModelsStage extends AbstractStage {
+
+    @Override
+    protected void doProcess() {
+        info("-- Creating Property and Type Models --");
+        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
+            var namespace = specVersion.getNamespace();
+
+            // Process trait properties
+            specVersion.getTraits().forEach(trait -> {
+                var fqTraitName = namespace + "." + trait.getName();
+                var traitModel = getState().getConceptIndex().lookupTrait(fqTraitName);
+                trait.getProperties().forEach(property -> {
+                    var propertyModel = createPropertyModel(property, namespace, false, null);
+                    traitModel.getProperties().put(property.getName(), propertyModel);
+                });
+            });
+
+            // Process entity properties
+            specVersion.getEntities().forEach(entity -> {
+                var fqEntityName = namespace + "." + entity.getName();
+                var entityModel = getState().getConceptIndex().lookupEntity(fqEntityName);
+                entity.getProperties().forEach(property -> {
+                    var propertyModel = createPropertyModel(property, namespace, true, entityModel);
+                    entityModel.getProperties().put(property.getName(), propertyModel);
+                });
+            });
+        });
+    }
+
+    private PropertyModel createPropertyModel(Property property, String namespace,
+                                               boolean checkShading, EntityModel entityModel) {
+        var propertyType = PropertyType.parse(property.getType());
+        var rawType = RawType.parse(property.getType());
+        var resolvedType = resolveType(rawType, namespace);
+
+        var builder = PropertyModel.builder()
+                .name(property.getName())
+                .collection(property.getCollection())
+                .discriminator(property.getDiscriminator())
+                .unionRules(property.getUnionRules())
+                .rawType(property.getType())
+                .type(propertyType)
+                .resolvedType(resolvedType);
+
+        if (checkShading && entityModel != null) {
+            builder.shaded(isPropertyShaded(property, entityModel));
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Resolve a parsed {@link RawType} into a semantic {@link Type} by looking up
+     * entity names in the concept index.
+     */
+    private Type resolveType(RawType rawType, String namespace) {
+        if (rawType.isSimple()) {
+            if (rawType.isPrimitiveType()) {
+                return PrimitiveType.getByName(rawType.getSimpleType());
+            }
+            // Entity type — look up in concept index
+            var entityName = rawType.getSimpleType();
+            var entity = getState().getConceptIndex().lookupEntity(namespace, entityName);
+            if (entity == null) {
+                // Try looking up as a type alias (will be used in Step 2)
+                var type = getState().getConceptIndex().lookupType(namespace, entityName);
+                if (type != null) {
+                    return type;
+                }
+                warn("Entity not found for type '%s' in namespace '%s'", entityName, namespace);
+                // Fall back to creating an unresolved entity type
+                return EntityType.builder()
+                        .namespace(namespace)
+                        .name(entityName)
+                        .rawType(rawType)
+                        .build();
+            }
+            return EntityType.fromEntity(entity);
+        }
+
+        if (rawType.isList()) {
+            var valueRawType = rawType.getNested().get(0);
+            var valueType = resolveType(valueRawType, namespace);
+            return ListType.builder()
+                    .namespace(namespace)
+                    .name("[" + valueType.getName() + "]")
+                    .rawType(rawType)
+                    .valueType(valueType)
+                    .build();
+        }
+
+        if (rawType.isMap()) {
+            var valueRawType = rawType.getNested().get(0);
+            var valueType = resolveType(valueRawType, namespace);
+            return MapType.builder()
+                    .namespace(namespace)
+                    .name("{" + valueType.getName() + "}")
+                    .rawType(rawType)
+                    .valueType(valueType)
+                    .build();
+        }
+
+        if (rawType.isUnion()) {
+            var types = new ArrayList<Type>();
+            for (var nestedRawType : rawType.getNested()) {
+                var nestedType = resolveType(nestedRawType, namespace);
+                // Wrap primitives in PrimitiveUnionVariantType when they appear in unions
+                if (nestedType instanceof PrimitiveType primitive) {
+                    types.add(PrimitiveUnionVariantType.builder()
+                            .namespace(PrimitiveType.NAMESPACE)
+                            .name(primitive.getName())
+                            .rawType(nestedRawType)
+                            .type(primitive)
+                            .build());
+                } else {
+                    types.add(nestedType);
+                }
+            }
+            return UnionType.builder()
+                    .namespace(namespace)
+                    .name(rawType.asRawType())
+                    .rawType(rawType)
+                    .types(types)
+                    .build();
+        }
+
+        throw new IllegalStateException("Unknown raw type structure: " + rawType);
+    }
+
+    private boolean isPropertyShaded(Property property, EntityModel entityModel) {
+        var type = PropertyType.parse(property.getType());
+        if (type != null && type.isPrimitiveType()) {
+            return false;
+        }
+        var traits = entityModel.getTraits();
+        if (traits != null) {
+            for (var trait : traits) {
+                if (trait.getProperties().containsKey(property.getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
@@ -99,6 +99,6 @@ public class NormalizePropertiesStage extends AbstractStage {
      */
     private boolean hasProperty(Map<String, PropertyModel> properties, PropertyModel property) {
         PropertyModel otherProperty = properties.get(property.getName());
-        return otherProperty != null && otherProperty.getType().equals(property.getType());
+        return otherProperty != null && otherProperty.getRawType().equals(property.getRawType());
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
@@ -10,6 +10,8 @@ import org.jboss.forge.roaster.model.source.MethodSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
 
 /**
  * Base class for the stages that create methods for entity interfaces and impl classes both.  The
@@ -100,28 +102,28 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName(getterMethodName(property)).setPublic();
         addAnnotations(method);
 
-        if (isUnion(property)) {
+        if (property.getResolvedType() != null) {
+            var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
+            jt.addImportsTo(javaEntity);
+            method.setReturnType(jt.toJavaTypeString());
+        } else if (isUnion(property)) {
             UnionPropertyType ut = new UnionPropertyType(property.getType());
             ut.addImportsTo(javaEntity);
             method.setReturnType(ut.toJavaTypeString());
         } else if (isUnionList(property)) {
-            // Handle [Union] -> List<UnionType>
             PropertyType unionType = property.getType().getNested().iterator().next();
             UnionPropertyType ut = new UnionPropertyType(unionType);
             ut.addImportsTo(javaEntity);
             javaEntity.addImport(java.util.List.class);
             method.setReturnType("List<" + ut.toJavaTypeString() + ">");
         } else if (isUnionMap(property)) {
-            // Handle {Union} -> Map<String, UnionType>
             PropertyType unionType = property.getType().getNested().iterator().next();
             UnionPropertyType ut = new UnionPropertyType(unionType);
             ut.addImportsTo(javaEntity);
             javaEntity.addImport(java.util.Map.class);
             method.setReturnType("Map<String, " + ut.toJavaTypeString() + ">");
         } else {
-            String propertyOriginNS = propertyWithOrigin.getOrigin().getNamespace().fullName();
-
-            JavaType jt = new JavaType(property.getType(), propertyOriginNS);
+            JavaType jt = new JavaType(property.getType(), propertyWithOrigin.getOrigin().getNamespace().fullName());
             jt.addImportsTo(javaEntity);
             method.setReturnType(jt.toJavaTypeString());
         }
@@ -137,31 +139,32 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
      */
     protected void createSetter(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        String propertyOriginNS = propertyWithOrigin.getOrigin().getNamespace().fullName();
 
         MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName(setterMethodName(property)).setReturnTypeVoid().setPublic();
         addAnnotations(method);
 
-        if (isUnion(property)) {
+        if (property.getResolvedType() != null) {
+            var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
+            jt.addImportsTo(javaEntity);
+            method.addParameter(jt.toJavaTypeString(), "value");
+        } else if (isUnion(property)) {
             UnionPropertyType ut = new UnionPropertyType(property.getType());
             ut.addImportsTo(javaEntity);
             method.addParameter(ut.toJavaTypeString(), "value");
         } else if (isUnionList(property)) {
-            // Handle [Union] -> List<UnionType>
             PropertyType unionType = property.getType().getNested().iterator().next();
             UnionPropertyType ut = new UnionPropertyType(unionType);
             ut.addImportsTo(javaEntity);
             javaEntity.addImport(java.util.List.class);
             method.addParameter("List<" + ut.toJavaTypeString() + ">", "value");
         } else if (isUnionMap(property)) {
-            // Handle {Union} -> Map<String, UnionType>
             PropertyType unionType = property.getType().getNested().iterator().next();
             UnionPropertyType ut = new UnionPropertyType(unionType);
             ut.addImportsTo(javaEntity);
             javaEntity.addImport(java.util.Map.class);
             method.addParameter("Map<String, " + ut.toJavaTypeString() + ">", "value");
         } else {
-            JavaType jt = new JavaType(property.getType(), propertyOriginNS);
+            JavaType jt = new JavaType(property.getType(), propertyWithOrigin.getOrigin().getNamespace().fullName());
             jt.addImportsTo(javaEntity);
             method.addParameter(jt.toJavaTypeString(), "value");
         }
@@ -219,6 +222,22 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         PropertyType type = property.getType().getNested().iterator().next();
         String methodName = addMethodName(singularize(property.getName()));
         MethodSource<?> method;
+
+        if (property.getResolvedType() != null) {
+            var resolvedValueType = extractValueType(property.getResolvedType());
+            if (resolvedValueType != null) {
+                var jt = getJavaTypeFactory().createJavaType(resolvedValueType, propertyWithOrigin.getOrigin().getNamespace());
+                jt.addImportsTo(javaEntity);
+                method = ((MethodHolderSource<?>) javaEntity).addMethod().setPublic().setName(methodName).setReturnTypeVoid();
+                addAnnotations(method);
+                if (property.getType().isMap()) {
+                    method.addParameter("String", "name");
+                }
+                method.addParameter(jt.toJavaTypeString(), "value");
+                createAddMethodBody(javaEntity, property, method);
+                return;
+            }
+        }
 
         if (type.isEntityType()) {
             JavaInterfaceSource entityType = resolveJavaEntityType(_package, type);
@@ -298,6 +317,16 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         addAnnotations(method);
 
         if (property.getType().isList()) {
+            if (property.getResolvedType() != null) {
+                var resolvedValueType = extractValueType(property.getResolvedType());
+                if (resolvedValueType != null) {
+                    var jt = getJavaTypeFactory().createJavaType(resolvedValueType, propertyWithOrigin.getOrigin().getNamespace());
+                    jt.addImportsTo(javaEntity);
+                    method.addParameter(jt.toJavaTypeString(), "value");
+                    createRemoveMethodBody(property, method);
+                    return;
+                }
+            }
             PropertyType type = property.getType().getNested().iterator().next();
             if (type.isEntityType()) {
                 JavaInterfaceSource entityType = resolveJavaEntityType(_package, type);
@@ -338,6 +367,23 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         PropertyType type = property.getType().getNested().iterator().next();
         String methodName = insertMethodName(singularize(property.getName()));
         MethodSource<?> method;
+
+        if (property.getResolvedType() != null) {
+            var resolvedValueType = extractValueType(property.getResolvedType());
+            if (resolvedValueType != null) {
+                var jt = getJavaTypeFactory().createJavaType(resolvedValueType, propertyWithOrigin.getOrigin().getNamespace());
+                jt.addImportsTo(javaEntity);
+                method = ((MethodHolderSource<?>) javaEntity).addMethod().setPublic().setName(methodName).setReturnTypeVoid();
+                addAnnotations(method);
+                if (property.getType().isMap()) {
+                    method.addParameter("String", "name");
+                }
+                method.addParameter(jt.toJavaTypeString(), "value");
+                method.addParameter("int", "atIndex");
+                createInsertMethodBody(javaEntity, property, method);
+                return;
+            }
+        }
 
         if (type.isEntityType()) {
             JavaInterfaceSource entityType = resolveJavaEntityType(_package, type);
@@ -421,6 +467,13 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
      * @param method
      */
     protected void addAnnotations(MethodSource<?> method) {
+    }
+
+    private Type extractValueType(Type type) {
+        if (type instanceof CollectionType collectionType) {
+            return collectionType.getValueType();
+        }
+        return null;
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
@@ -20,9 +20,23 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
 import io.apitomy.umg.models.concept.TraitModel;
 import io.apitomy.umg.models.concept.VisitorModel;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
 import io.apitomy.umg.pipe.AbstractStage;
 
 public abstract class AbstractJavaStage extends AbstractStage {
+
+    private JavaTypeFactory javaTypeFactory;
+
+    protected JavaTypeFactory getJavaTypeFactory() {
+        if (javaTypeFactory == null) {
+            javaTypeFactory = new JavaTypeFactory(
+                    getState().getConceptIndex(),
+                    getState().getSpecIndex(),
+                    getState().getJavaIndex(),
+                    getUnionTypesPackageName());
+        }
+        return javaTypeFactory;
+    }
 
     protected String getReaderClassName(SpecificationVersion specVersion) {
         return specVersion.getPrefix() + "ModelReader";

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractUnionTypeJavaStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractUnionTypeJavaStage.java
@@ -1,7 +1,7 @@
 package io.apitomy.umg.pipe.java;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -11,12 +11,12 @@ public abstract class AbstractUnionTypeJavaStage extends AbstractJavaStage {
 
     @Override
     protected void doProcess() {
-        Set<PropertyModelWithOrigin> unionProperties = new HashSet<>();
+        Set<PropertyModelWithOrigin> unionProperties = new LinkedHashSet<>();
         getState().getConceptIndex().findEntities("").stream().filter(entity -> entity.isLeaf()).forEach(entity -> {
             Collection<PropertyModelWithOrigin> allProperties = getState().getConceptIndex().getAllEntityProperties(entity);
             unionProperties.addAll(allProperties.stream().filter(property ->
                 isUnion(property.getProperty()) || isUnionList(property.getProperty()) || isUnionMap(property.getProperty())
-            ).collect(Collectors.toSet()));
+            ).collect(Collectors.toCollection(LinkedHashSet::new)));
         });
 
         unionProperties.forEach(property -> {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplFieldsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplFieldsStage.java
@@ -67,7 +67,12 @@ public class CreateImplFieldsStage extends AbstractJavaStage {
             return;
         }
 
-        if (isUnion(property)) {
+        if (property.getResolvedType() != null) {
+            var jt = getJavaTypeFactory().createJavaType(
+                    property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
+            jt.addImportsTo(javaEntityImpl);
+            fieldType = jt.toJavaTypeString();
+        } else if (isUnion(property)) {
             UnionPropertyType upt = new UnionPropertyType(property.getType());
             upt.addImportsTo(javaEntityImpl);
             fieldType = upt.getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -64,7 +64,11 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
         javaEntity.addImport(List.class);
         javaEntity.addImport(ArrayList.class);
 
-        if (isPrimitiveList(property)) {
+        if (property.getResolvedType() != null) {
+            var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
+            jt.addImportsTo(javaEntity);
+            mappedNodeType = jt.toJavaTypeString();
+        } else if (isPrimitiveList(property)) {
             Class<?> listType = primitiveTypeToClass(property.getType().getNested().iterator().next());
             javaEntity.addImport(listType);
             mappedNodeType = "List<" + listType.getSimpleName() + ">";

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
@@ -81,12 +81,11 @@ public class CreateInterfaceMethodsStage extends AbstractCreateMethodsStage {
         javaEntity.addImport(mappedNodeInterface);
         String mappedNodeInterfaceWithType;
 
-        // TODO use the JavaType helper instead of the following if/then/else
-        //        JavaType jt = new JavaType(property.getType(), propertyWithOrigin.getOrigin().getNamespace().fullName());
-        //        jt.addImportsTo(javaEntity);
-        //        mappedNodeInterfaceWithType = jt.toJavaTypeString();
-
-        if (isPrimitiveList(property)) {
+        if (property.getResolvedType() != null) {
+            var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
+            jt.addImportsTo(javaEntity);
+            mappedNodeInterfaceWithType = mappedNodeInterface.getName() + "<" + jt.toJavaTypeString() + ">";
+        } else if (isPrimitiveList(property)) {
             Class<?> listType = primitiveTypeToClass(property.getType().getNested().iterator().next());
             javaEntity.addImport(List.class);
             javaEntity.addImport(listType);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypesStage.java
@@ -6,6 +6,9 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 
 /**
  * Creates the union type interface.  For example, if the union type is "boolean|[string]" then
@@ -52,7 +55,15 @@ public class CreateUnionTypesStage extends AbstractUnionTypeJavaStage {
         unionTypeInterface.addInterface(unionValueSource);
 
         // Now create the union methods.
-        createUnionMethods(unionType, unionTypeInterface, property.getOrigin().getNamespace());
+        Type resolvedType = property.getProperty().getResolvedType();
+        if (resolvedType instanceof CollectionType collectionType) {
+            resolvedType = collectionType.getValueType();
+        }
+        if (resolvedType instanceof UnionType resolvedUnionType) {
+            createUnionMethods(resolvedUnionType, unionTypeInterface, property.getOrigin().getNamespace());
+        } else {
+            createUnionMethods(unionType, unionTypeInterface, property.getOrigin().getNamespace());
+        }
 
         getState().getJavaIndex().index(unionTypeInterface);
     }
@@ -65,6 +76,23 @@ public class CreateUnionTypesStage extends AbstractUnionTypeJavaStage {
 
             JavaType jt = new JavaType(nestedType, nsContext.fullName()).useCommonEntityResolution();
 
+            String asMethodReturnType = jt.toJavaTypeString();
+
+            unionTypeInterface.addMethod().setName(isMethodName).setReturnType(boolean.class).setPublic();
+            unionTypeInterface.addMethod().setName(asMethodName).setReturnType(asMethodReturnType).setPublic();
+            jt.addImportsTo(unionTypeInterface);
+        });
+    }
+
+    private void createUnionMethods(UnionType resolvedUnionType, JavaInterfaceSource unionTypeInterface, NamespaceModel nsContext) {
+        var sortedTypes = new java.util.ArrayList<>(resolvedUnionType.getTypes());
+        sortedTypes.sort(java.util.Comparator.comparing(t -> io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(t).toLowerCase()));
+        sortedTypes.forEach(variantType -> {
+            String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+            String isMethodName = "is" + typeName;
+            String asMethodName = "as" + typeName;
+
+            var jt = getJavaTypeFactory().createJavaType(variantType, nsContext, true);
             String asMethodReturnType = jt.toJavaTypeString();
 
             unionTypeInterface.addMethod().setName(isMethodName).setReturnType(boolean.class).setPublic();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionValueMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionValueMethodsStage.java
@@ -12,6 +12,10 @@ import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 
 /**
@@ -54,6 +58,9 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
         }
         UnionPropertyType unionType = new UnionPropertyType(actualUnionType);
 
+        // Also extract the resolved union type if available
+        final UnionType resolvedUnionType = extractResolvedUnionType(property);
+
         debug("Creating union value methods for property '" + property.getName() + "' of type '"
                 + property.getRawType() +"' on entity: " + origin.fullyQualifiedName());
 
@@ -71,7 +78,7 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
                 if (unionValueImplSource == null) {
                     throw new RuntimeException("[CreateUnionValueMethodsStage] Union type value not supported: " + nestedType);
                 }
-                createUnionImplMethods(unionType, unionValueImplSource, unionValueTypeName, false, origin.getNamespace());
+                createUnionImplMethods(unionType, resolvedUnionType, unionValueImplSource, unionValueTypeName, false, origin.getNamespace());
             } else if (nestedJT.isEntity()) {
                 // The union interface may have been applied to a common parent entity interface
                 // (via ApplyUnionTypesStage after property normalization), which means ALL leaf
@@ -87,7 +94,7 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
                 for (EntityModel leafEntity : leafEntities) {
                     JavaClassSource implSource = resolveJavaEntityImpl(leafEntity);
                     if (implSource != null) {
-                        createUnionImplMethods(unionType, implSource, entityName, true, leafEntity.getNamespace());
+                        createUnionImplMethods(unionType, resolvedUnionType, implSource, entityName, true, leafEntity.getNamespace());
                     }
                 }
             } else if (nestedJT.isEntityList()) {
@@ -97,15 +104,73 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
                 if (unionValueImplSource == null) {
                     throw new RuntimeException("[CreateUnionValueMethodsStage] Union type value not supported: " + nestedType);
                 }
-                createUnionImplMethods(unionType, unionValueImplSource, unionValueTypeName, false, origin.getNamespace());
+                createUnionImplMethods(unionType, resolvedUnionType, unionValueImplSource, unionValueTypeName, false, origin.getNamespace());
             } else {
                 throw new RuntimeException("[CreateUnionValueMethodsStage] Union type value not supported: " + nestedType);
             }
         });
     }
 
-    private void createUnionImplMethods(UnionPropertyType unionType, JavaClassSource unionValueClass,
+    private void createUnionImplMethods(UnionPropertyType unionType, UnionType resolvedUnionType,
+            JavaClassSource unionValueClass,
             String unionValueTypeName, boolean unionValueIsEntity, NamespaceModel nsContext) {
+
+        if (resolvedUnionType != null) {
+            var sortedTypes = new java.util.ArrayList<>(resolvedUnionType.getTypes());
+            sortedTypes.sort(java.util.Comparator.comparing(t -> JavaTypeFactory.getUnionComponentName(t).toLowerCase()));
+            sortedTypes.forEach(variantType -> {
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                String isMethodName = "is" + typeName;
+                String asMethodName = "as" + typeName;
+
+                var jt = getJavaTypeFactory().createJavaType(variantType, nsContext, true);
+                String asMethodReturnType = jt.toJavaTypeString();
+
+                if (!unionValueClass.hasMethodSignature(isMethodName)) {
+                    MethodSource<JavaClassSource> isMethod = unionValueClass.addMethod().setName(isMethodName).setReturnType(boolean.class).setPublic();
+                    isMethod.addAnnotation(Override.class);
+                    BodyBuilder isMethodBody = new BodyBuilder();
+
+                    MethodSource<JavaClassSource> asMethod = unionValueClass.addMethod().setName(asMethodName).setReturnType(asMethodReturnType).setPublic();
+                    asMethod.addAnnotation(Override.class);
+                    BodyBuilder asMethodBody = new BodyBuilder();
+
+                    if (typeName.equals(unionValueTypeName)) {
+                        isMethodBody.append("return true;");
+                        isMethod.setBody(isMethodBody.toString());
+                        if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType) {
+                            asMethodBody.append("return this;");
+                        } else {
+                            asMethodBody.append("return getValue();");
+                        }
+                        asMethod.setBody(asMethodBody.toString());
+                    } else {
+                        isMethodBody.append("return false;");
+                        isMethod.setBody(isMethodBody.toString());
+                        asMethodBody.append("throw new ClassCastException();");
+                        asMethod.setBody(asMethodBody.toString());
+                    }
+
+                    jt.addImportsTo(unionValueClass);
+                }
+            });
+        } else {
+            createUnionImplMethodsLegacy(unionType, unionValueClass, unionValueTypeName, nsContext);
+        }
+
+        // If this is an entity, add the "unionValue" method.
+        if (unionValueIsEntity && !unionValueClass.hasMethodSignature("unionValue")) {
+            MethodSource<JavaClassSource> unionValueMethod = unionValueClass.addMethod().setName("unionValue").setReturnType("Object").setPublic();
+            unionValueMethod.addAnnotation(Override.class);
+            BodyBuilder unionValueMethodBody = new BodyBuilder();
+            unionValueMethodBody.append("return this;");
+            unionValueMethod.setBody(unionValueMethodBody.toString());
+        }
+
+    }
+
+    private void createUnionImplMethodsLegacy(UnionPropertyType unionType, JavaClassSource unionValueClass,
+            String unionValueTypeName, NamespaceModel nsContext) {
 
         unionType.getNestedTypes().forEach(nestedType -> {
             String typeName = getTypeName(nestedType);
@@ -146,15 +211,16 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
                 jt.addImportsTo(unionValueClass);
             }
         });
+    }
 
-        // If this is an entity, add the "unionValue" method.
-        if (unionValueIsEntity && !unionValueClass.hasMethodSignature("unionValue")) {
-            MethodSource<JavaClassSource> unionValueMethod = unionValueClass.addMethod().setName("unionValue").setReturnType("Object").setPublic();
-            unionValueMethod.addAnnotation(Override.class);
-            BodyBuilder unionValueMethodBody = new BodyBuilder();
-            unionValueMethodBody.append("return this;");
-            unionValueMethod.setBody(unionValueMethodBody.toString());
+    private UnionType extractResolvedUnionType(PropertyModel property) {
+        if (property.getResolvedType() == null) {
+            return null;
         }
-
+        Type resolved = property.getResolvedType();
+        if (resolved instanceof CollectionType collectionType) {
+            resolved = collectionType.getValueType();
+        }
+        return resolved instanceof UnionType ut ? ut : null;
     }
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReaderFactory.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelReaderFactory.java
@@ -13,11 +13,11 @@ public class ModelReaderFactory {
 	public static ModelReader createModelReader(ModelType modelType) {
 		ModelReader reader = null;
 		switch (modelType) {
-			case SYN2 :
-				reader = new Syn2ModelReader();
-				break;
 			case SYN1 :
 				reader = new Syn1ModelReader();
+				break;
+			case SYN2 :
+				reader = new Syn2ModelReader();
 				break;
 		}
 		return reader;
@@ -27,11 +27,11 @@ public class ModelReaderFactory {
 		ModelReader reader = ModelReaderFactory.createModelReader(modelType);
 		Visitor visitor = null;
 		switch (modelType) {
-			case SYN2 :
-				visitor = new Syn2ModelReaderDispatcher(json, (Syn2ModelReader) reader);
-				break;
 			case SYN1 :
 				visitor = new Syn1ModelReaderDispatcher(json, (Syn1ModelReader) reader);
+				break;
+			case SYN2 :
+				visitor = new Syn2ModelReaderDispatcher(json, (Syn2ModelReader) reader);
 				break;
 		}
 		return visitor;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriterFactory.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriterFactory.java
@@ -13,11 +13,11 @@ public class ModelWriterFactory {
 	public static ModelWriter createModelWriter(ModelType modelType) {
 		ModelWriter writer = null;
 		switch (modelType) {
-			case SYN2 :
-				writer = new Syn2ModelWriter();
-				break;
 			case SYN1 :
 				writer = new Syn1ModelWriter();
+				break;
+			case SYN2 :
+				writer = new Syn2ModelWriter();
 				break;
 		}
 		return writer;
@@ -27,11 +27,11 @@ public class ModelWriterFactory {
 		ModelWriter writer = ModelWriterFactory.createModelWriter(modelType);
 		Visitor visitor = null;
 		switch (modelType) {
-			case SYN2 :
-				visitor = new Syn2ModelWriterDispatcher(json, (Syn2ModelWriter) writer);
-				break;
 			case SYN1 :
 				visitor = new Syn1ModelWriterDispatcher(json, (Syn1ModelWriter) writer);
+				break;
+			case SYN2 :
+				visitor = new Syn2ModelWriterDispatcher(json, (Syn2ModelWriter) writer);
 				break;
 		}
 		return visitor;


### PR DESCRIPTION
## Summary

- Add an object-oriented Type hierarchy replacing the flat `PropertyType` enum for resolved property types
- Add a Java type layer (`JavaType` interface + `JavaTypeFactory`) bridging concept types to Java codegen
- Migrate 7 codegen stages to use `JavaTypeFactory`, with old-code fallback for synthetic properties

Part of #1041. Foundation for G2 (type aliases) and G1 (union-as-root).

## Type system (G6.1)

New `Type` hierarchy in `models/concept/type/`:
- `EntityType` — references an `EntityModel`
- `UnionType` — list of `Type` variants + union rules
- `PrimitiveType` — STRING, BOOLEAN, NUMBER, INTEGER, OBJECT, ANY
- `ListType`, `MapType` — collection types with value type
- `PrimitiveUnionVariantType` — wraps `PrimitiveType` when in a union
- `RawType` — parser for the type DSL (`[Foo]`, `{Bar}`, `Foo|Bar|[Baz]`)
- `TypeVisitor` — visitor for walking the type tree

`CreatePropertyAndTypeModelsStage` resolves each property's raw type string into a `Type` object and sets `PropertyModel.resolvedType`. Type index added to `ConceptIndex`.

## Java type layer (G7.1)

New `JavaType` interface in `models/java/type/` with implementations:
- `PrimitiveJavaType`, `EntityJavaType`, `ListJavaType`, `MapJavaType`, `UnionJavaType`
- `JavaTypeFactory` — creates `JavaType` from concept `Type` using `SpecificationIndex` for entity FQN resolution

Migrated stages (old code paths retained as fallback):
- `CreateImplFieldsStage`
- `AbstractCreateMethodsStage` (getter, setter, add, remove, insert)
- `CreateInterfaceMethodsStage`, `CreateImplMethodsStage` (mapped node methods)
- `CreateUnionTypesStage`, `CreateUnionValueMethodsStage` (union is/as methods)

## Deferred

- **G6.2 / G7.2**: Readers/writers migration (35 call sites) — deferred to G1, these stages need root union dispatch changes anyway
- **G6.3**: Non-determinism fix — blocked by entity list union value resolution bug in `CreateUnionTypeValuesStage`

## Test plan

- [x] Synthetic snapshot test (115 expected files, 20 features) passes when run alone
- [x] `FullGeneratorTest` passes
- [x] `GeneratorTest` passes
- [x] `TypeParserTest` passes
- [ ] Pre-existing non-determinism causes snapshot test to fail when run after `FullGeneratorTest` (tracked as G6.3, not introduced by this PR)