### PR TITLE
feat(generator): type aliases — named, reusable union types (G2)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/UnionType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/UnionType.java
@@ -33,6 +33,8 @@ public class UnionType extends AbstractType {
     @lombok.Builder.Default
     private List<UnionRule> unionRules = new ArrayList<>();
 
+    private String aliasName;
+
     @Override
     public UnionType copy() {
         return UnionType.builder()
@@ -41,6 +43,7 @@ public class UnionType extends AbstractType {
                 .rawType(rawType)
                 .types(new ArrayList<>(types))
                 .unionRules(new ArrayList<>(unionRules))
+                .aliasName(aliasName)
                 .parent(parent)
                 .leaf(leaf)
                 .root(root)

--- a/generator/src/main/java/io/apitomy/umg/models/java/type/JavaTypeFactory.java
+++ b/generator/src/main/java/io/apitomy/umg/models/java/type/JavaTypeFactory.java
@@ -94,12 +94,16 @@ public class JavaTypeFactory {
                 .map(t -> createJavaType(t, namespaceContext, useCommonResolution))
                 .collect(Collectors.toList());
 
-        var sortedTypes = new ArrayList<>(unionType.getTypes());
-        sortedTypes.sort(Comparator.comparing(t -> getUnionComponentName(t).toLowerCase()));
-
-        var unionName = sortedTypes.stream()
-                .map(JavaTypeFactory::getUnionComponentName)
-                .collect(Collectors.joining()) + "Union";
+        String unionName;
+        if (unionType.getAliasName() != null) {
+            unionName = unionType.getAliasName();
+        } else {
+            var sortedTypes = new ArrayList<>(unionType.getTypes());
+            sortedTypes.sort(Comparator.comparing(t -> getUnionComponentName(t).toLowerCase()));
+            unionName = sortedTypes.stream()
+                    .map(JavaTypeFactory::getUnionComponentName)
+                    .collect(Collectors.joining()) + "Union";
+        }
         var unionFQN = unionTypesPackage + "." + unionName;
 
         return new UnionJavaType(unionType, unionName, unionFQN, variantJavaTypes);

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
@@ -40,6 +40,23 @@ public class CreatePropertyAndTypeModelsStage extends AbstractStage {
         getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
             var namespace = specVersion.getNamespace();
 
+            // Process type aliases FIRST so they're available for property type resolution
+            if (specVersion.getTypeAliases() != null) {
+                specVersion.getTypeAliases().forEach(alias -> {
+                    var rawType = RawType.parse(alias.getType());
+                    var resolvedType = resolveType(rawType, namespace);
+                    if (resolvedType instanceof UnionType unionType) {
+                        unionType.setAliasName(alias.getName());
+                        if (alias.getUnionRules() != null && !alias.getUnionRules().isEmpty()) {
+                            unionType.setUnionRules(alias.getUnionRules());
+                        }
+                    }
+                    var fqName = namespace + "." + alias.getName();
+                    getState().getConceptIndex().indexType(fqName, resolvedType);
+                    debug("Indexed type alias: %s -> %s", fqName, resolvedType);
+                });
+            }
+
             // Process trait properties
             specVersion.getTraits().forEach(trait -> {
                 var fqTraitName = namespace + "." + trait.getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractUnionTypeJavaStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractUnionTypeJavaStage.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.UnionType;
 
 public abstract class AbstractUnionTypeJavaStage extends AbstractJavaStage {
 
@@ -16,6 +18,7 @@ public abstract class AbstractUnionTypeJavaStage extends AbstractJavaStage {
             Collection<PropertyModelWithOrigin> allProperties = getState().getConceptIndex().getAllEntityProperties(entity);
             unionProperties.addAll(allProperties.stream().filter(property ->
                 isUnion(property.getProperty()) || isUnionList(property.getProperty()) || isUnionMap(property.getProperty())
+                || hasResolvedUnionType(property)
             ).collect(Collectors.toCollection(LinkedHashSet::new)));
         });
 
@@ -25,5 +28,14 @@ public abstract class AbstractUnionTypeJavaStage extends AbstractJavaStage {
     }
 
     protected abstract void doProcess(PropertyModelWithOrigin property);
+
+    private boolean hasResolvedUnionType(PropertyModelWithOrigin pwo) {
+        var resolved = pwo.getProperty().getResolvedType();
+        if (resolved instanceof UnionType) return true;
+        if (resolved instanceof CollectionType ct) {
+            return ct.getValueType() instanceof UnionType;
+        }
+        return false;
+    }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/ApplyUnionTypesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/ApplyUnionTypesStage.java
@@ -4,6 +4,13 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
 
 /**
  * A union type has already been created (as an interface like StringWidgetUnion) and now must be
@@ -26,6 +33,16 @@ public class ApplyUnionTypesStage extends AbstractUnionTypeJavaStage {
      * @param property
      */
     private void applyUnionType(PropertyModelWithOrigin property) {
+        // Check if this is a type alias (resolvedType is union but PropertyType is not)
+        Type resolved = property.getProperty().getResolvedType();
+        if (resolved instanceof CollectionType ct) {
+            resolved = ct.getValueType();
+        }
+        if (resolved instanceof UnionType resolvedUnion && resolvedUnion.getAliasName() != null) {
+            applyUnionTypeFromResolved(resolvedUnion, property);
+            return;
+        }
+
         // Extract the actual union type: for simple unions it's the property type itself,
         // for union maps/lists it's the nested type
         PropertyType actualUnionType = property.getProperty().getType();
@@ -52,6 +69,31 @@ public class ApplyUnionTypesStage extends AbstractUnionTypeJavaStage {
             }
             if (unionValueSource == null) {
                 throw new RuntimeException("[ApplyUnionTypesStage] Union type value NOT supported: " + nestedType);
+            }
+
+            unionValueSource.addImport(unionTypeSource);
+            unionValueSource.addInterface(unionTypeSource);
+        });
+    }
+
+    private void applyUnionTypeFromResolved(UnionType unionType, PropertyModelWithOrigin property) {
+        String unionTypeFQN = getUnionTypeFQN(unionType.getAliasName());
+        JavaInterfaceSource unionTypeSource = getState().getJavaIndex().lookupInterface(unionTypeFQN);
+        if (unionTypeSource == null) {
+            throw new RuntimeException("[ApplyUnionTypesStage] Union type interface not found: " + unionTypeFQN);
+        }
+
+        unionType.getTypes().forEach(variantType -> {
+            JavaInterfaceSource unionValueSource = null;
+            if (variantType instanceof PrimitiveType || variantType instanceof PrimitiveUnionVariantType) {
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueFQN = getUnionTypeFQN(typeName + "UnionValue");
+                unionValueSource = getState().getJavaIndex().lookupInterface(unionValueFQN);
+            } else if (variantType instanceof EntityType entityType) {
+                unionValueSource = resolveJavaEntity(property.getOrigin().getNamespace().fullName(), entityType.getName());
+            }
+            if (unionValueSource == null) {
+                throw new RuntimeException("[ApplyUnionTypesStage] Union type value NOT supported: " + variantType);
             }
 
             unionValueSource.addImport(unionTypeSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypeValuesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypeValuesStage.java
@@ -27,6 +27,9 @@ public class CreateUnionTypeValuesStage extends AbstractUnionTypeJavaStage {
      * @param property
      */
     private void createMissingUnionValues(PropertyModelWithOrigin property) {
+        if (!property.getProperty().getType().isUnion()) {
+            return;
+        }
         UnionPropertyType unionType = new UnionPropertyType(property.getProperty().getType());
         unionType.getNestedTypes().forEach(nestedType -> {
             JavaType nestedJT = new JavaType(nestedType, property.getOrigin().getNamespace());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionTypesStage.java
@@ -31,16 +31,32 @@ public class CreateUnionTypesStage extends AbstractUnionTypeJavaStage {
      */
     private void createUnionType(PropertyModelWithOrigin property) {
         debug("Creating union type for: " + property.getProperty().getName());
-        // Extract the actual union type: for simple unions it's the property type itself,
-        // for union maps/lists it's the nested type
-        PropertyType actualUnionType = property.getProperty().getType();
-        if (isUnionList(property.getProperty()) || isUnionMap(property.getProperty())) {
-            actualUnionType = property.getProperty().getType().getNested().iterator().next();
-        }
-        UnionPropertyType unionType = new UnionPropertyType(actualUnionType);
 
-        String name = unionType.getName();
+        // Extract the resolved union type
+        Type resolvedType = property.getProperty().getResolvedType();
+        if (resolvedType instanceof CollectionType collectionType) {
+            resolvedType = collectionType.getValueType();
+        }
+
+        String name;
+        if (resolvedType instanceof UnionType resolvedUnionType && resolvedUnionType.getAliasName() != null) {
+            name = resolvedUnionType.getAliasName();
+        } else {
+            // Extract the actual union type from PropertyType for anonymous unions
+            PropertyType actualUnionType = property.getProperty().getType();
+            if (isUnionList(property.getProperty()) || isUnionMap(property.getProperty())) {
+                actualUnionType = property.getProperty().getType().getNested().iterator().next();
+            }
+            UnionPropertyType ut = new UnionPropertyType(actualUnionType);
+            name = ut.getName();
+        }
+
         String _package = getUnionTypesPackageName();
+
+        // Skip if already created (type aliases may be referenced by multiple properties)
+        if (getState().getJavaIndex().lookupInterface(_package + "." + name) != null) {
+            return;
+        }
 
         // Create the main union type interface
         JavaInterfaceSource unionTypeInterface = Roaster.create(JavaInterfaceSource.class)
@@ -54,15 +70,15 @@ public class CreateUnionTypesStage extends AbstractUnionTypeJavaStage {
         unionTypeInterface.addImport(unionValueSource);
         unionTypeInterface.addInterface(unionValueSource);
 
-        // Now create the union methods.
-        Type resolvedType = property.getProperty().getResolvedType();
-        if (resolvedType instanceof CollectionType collectionType) {
-            resolvedType = collectionType.getValueType();
-        }
+        // Create the union methods
         if (resolvedType instanceof UnionType resolvedUnionType) {
             createUnionMethods(resolvedUnionType, unionTypeInterface, property.getOrigin().getNamespace());
         } else {
-            createUnionMethods(unionType, unionTypeInterface, property.getOrigin().getNamespace());
+            PropertyType actualUnionType = property.getProperty().getType();
+            if (isUnionList(property.getProperty()) || isUnionMap(property.getProperty())) {
+                actualUnionType = property.getProperty().getType().getNested().iterator().next();
+            }
+            createUnionMethods(new UnionPropertyType(actualUnionType), unionTypeInterface, property.getOrigin().getNamespace());
         }
 
         getState().getJavaIndex().index(unionTypeInterface);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionValueMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionValueMethodsStage.java
@@ -49,20 +49,58 @@ public class CreateUnionValueMethodsStage extends AbstractJavaStage {
      */
     private void createUnionValueMethods(PropertyModel property, EntityModel origin,
             NamespaceModel propertyOriginNamespace) {
-        // Extract the actual union type: for simple unions it's the property type itself,
-        // for union maps/lists it's the nested type
-        PropertyType actualUnionType = property.getType();
-        if ((property.getType().isList() || property.getType().isMap()) &&
-                property.getType().getNested().iterator().next().isUnion()) {
-            actualUnionType = property.getType().getNested().iterator().next();
-        }
-        UnionPropertyType unionType = new UnionPropertyType(actualUnionType);
-
         // Also extract the resolved union type if available
         final UnionType resolvedUnionType = extractResolvedUnionType(property);
 
+        // Extract the actual union type from PropertyType for legacy path
+        final UnionPropertyType unionType;
+        if (property.getType().isUnion() ||
+                ((property.getType().isList() || property.getType().isMap()) &&
+                        property.getType().getNested().iterator().next().isUnion())) {
+            PropertyType actualUnionType = property.getType();
+            if ((property.getType().isList() || property.getType().isMap())) {
+                actualUnionType = property.getType().getNested().iterator().next();
+            }
+            unionType = new UnionPropertyType(actualUnionType);
+        } else {
+            unionType = null;
+        }
+
         debug("Creating union value methods for property '" + property.getName() + "' of type '"
                 + property.getRawType() +"' on entity: " + origin.fullyQualifiedName());
+
+        // For type aliases, use the resolved union type exclusively
+        if (unionType == null && resolvedUnionType != null) {
+            resolvedUnionType.getTypes().forEach(variantType -> {
+                if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveType
+                        || variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType) {
+                    String unionValueTypeName = JavaTypeFactory.getUnionComponentName(variantType);
+                    String unionValueImplFQN = getUnionTypeFQN(unionValueTypeName + "UnionValueImpl");
+                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(unionValueImplFQN);
+                    if (unionValueImplSource != null) {
+                        createUnionImplMethods(null, resolvedUnionType, unionValueImplSource, unionValueTypeName, false, origin.getNamespace());
+                    }
+                } else if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
+                    String entityName = entityType.getName();
+                    String scopeNs = propertyOriginNamespace.fullName();
+                    List<EntityModel> leafEntities = getState().getConceptIndex().findEntities("").stream()
+                            .filter(e -> e.isLeaf() && e.getName().equals(entityName)
+                                    && e.getNamespace().fullName().startsWith(scopeNs))
+                            .collect(Collectors.toList());
+                    for (EntityModel leafEntity : leafEntities) {
+                        JavaClassSource implSource = resolveJavaEntityImpl(leafEntity);
+                        if (implSource != null) {
+                            createUnionImplMethods(null, resolvedUnionType, implSource, entityName, true, leafEntity.getNamespace());
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        if (unionType == null) {
+            return;
+        }
 
         unionType.getNestedTypes().forEach(nestedType -> {
             JavaType nestedJT = new JavaType(nestedType, origin.getNamespace());

--- a/generator/src/main/resources/openapi.json
+++ b/generator/src/main/resources/openapi.json
@@ -196,6 +196,12 @@
                     "majorVersionNamespace": {
                         "description": "",
                         "type": "string"
+                    },
+                    "typeAliases": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TypeAlias"
+                        }
                     }
                 },
                 "example": {
@@ -335,6 +341,40 @@
                     "ruleType": "propertyValue",
                     "propertyName": "type",
                     "propertyValue": "widget"
+                }
+            },
+            "TypeAlias": {
+                "title": "Root Type for TypeAlias",
+                "description": "A named, reusable type definition (typically a union) with optional discrimination rules.",
+                "required": [
+                    "name",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "unionRules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/UnionRule"
+                        }
+                    }
+                },
+                "example": {
+                    "name": "SchemaOrBoolean",
+                    "type": "boolean|Schema",
+                    "unionRules": [
+                        {
+                            "unionType": "Schema",
+                            "ruleType": "propertyExists",
+                            "propertyName": "type"
+                        }
+                    ]
                 }
             }
         }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
@@ -1,9 +1,14 @@
 package io.test.synthetic;
 
+import io.test.synthetic.union.SchemaOrBoolean;
 import java.util.List;
 import java.util.Map;
 
 public interface SynDocument extends Node {
+
+	public SchemaOrBoolean getAdditionalSchema();
+
+	public void setAdditionalSchema(SchemaOrBoolean value);
 
 	public SynInfo getInfo();
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
@@ -3,10 +3,11 @@ package io.test.synthetic;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.SchemaOrBoolean;
 import java.util.List;
 import java.util.Map;
 
-public interface SynSchema extends Node, BooleanSchemaUnion, BooleanSchemaSchemaListUnion {
+public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaUnion, BooleanSchemaSchemaListUnion {
 
 	public SynSchema createSchema();
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValue.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/BooleanUnionValue.java
@@ -3,6 +3,7 @@ package io.test.synthetic.union;
 public interface BooleanUnionValue
 		extends
 			PrimitiveUnionValue<Boolean>,
+			SchemaOrBoolean,
 			BooleanSchemaUnion,
 			BooleanSchemaSchemaListUnion {
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaOrBoolean.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/SchemaOrBoolean.java
@@ -1,0 +1,14 @@
+package io.test.synthetic.union;
+
+import io.test.synthetic.SynSchema;
+
+public interface SchemaOrBoolean extends Union {
+
+	public boolean isBoolean();
+
+	public Boolean asBoolean();
+
+	public boolean isSchema();
+
+	public SynSchema asSchema();
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -8,6 +8,7 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootNodeImpl;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -23,6 +24,7 @@ public class Syn1DocumentImpl extends RootNodeImpl implements Syn1Document {
 	private List<SynItem> items;
 	private List<String> tags;
 	private Map<String, String> metadata;
+	private SchemaOrBoolean additionalSchema;
 	private Map<String, JsonNode> extensions;
 
 	public Syn1DocumentImpl() {
@@ -130,6 +132,20 @@ public class Syn1DocumentImpl extends RootNodeImpl implements Syn1Document {
 	@Override
 	public void setMetadata(Map<String, String> value) {
 		this.metadata = value;
+	}
+
+	@Override
+	public SchemaOrBoolean getAdditionalSchema() {
+		return additionalSchema;
+	}
+
+	@Override
+	public void setAdditionalSchema(SchemaOrBoolean value) {
+		this.additionalSchema = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("additionalSchema");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+		}
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -67,6 +67,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 		Syn1Document model = (Syn1Document) node;
 		this.traverseNode("info", model.getInfo());
 		this.traverseList("items", model.getItems());
+		this.traverseNode("additionalSchema", model.getAdditionalSchema());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -8,6 +8,7 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootNodeImpl;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -24,6 +25,7 @@ public class Syn2DocumentImpl extends RootNodeImpl implements Syn2Document {
 	private List<String> tags;
 	private Map<String, String> metadata;
 	private Map<String, Syn2PathItem> webhooks;
+	private SchemaOrBoolean additionalSchema;
 	private Map<String, JsonNode> extensions;
 
 	public Syn2DocumentImpl() {
@@ -184,6 +186,20 @@ public class Syn2DocumentImpl extends RootNodeImpl implements Syn2Document {
 			((NodeImpl) value)._setParentPropertyName("webhooks");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public SchemaOrBoolean getAdditionalSchema() {
+		return additionalSchema;
+	}
+
+	@Override
+	public void setAdditionalSchema(SchemaOrBoolean value) {
+		this.additionalSchema = value;
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("additionalSchema");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -69,6 +69,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 		this.traverseNode("info", model.getInfo());
 		this.traverseList("items", model.getItems());
 		this.traverseMap("webhooks", model.getWebhooks());
+		this.traverseNode("additionalSchema", model.getAdditionalSchema());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
@@ -35,6 +35,15 @@ traits:
       - name: description
         type: string
 
+# Feature 21: Type aliases (named, reusable union types)
+typeAliases:
+  - name: SchemaOrBoolean
+    type: boolean|Schema
+    unionRules:
+      - unionType: Schema
+        ruleType: propertyExists
+        propertyName: type
+
 entities:
   # Feature 8: Root entity
   - name: Document
@@ -58,6 +67,9 @@ entities:
       - name: metadata
         # Feature 4: Map of primitives
         type: '{string}'
+      - name: additionalSchema
+        # Feature 21: Property using a type alias
+        type: SchemaOrBoolean
     # Feature 12: Property ordering
     propertyOrder:
       - $this

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
@@ -32,6 +32,14 @@ traits:
       - name: description
         type: string
 
+typeAliases:
+  - name: SchemaOrBoolean
+    type: boolean|Schema
+    unionRules:
+      - unionType: Schema
+        ruleType: propertyExists
+        propertyName: type
+
 entities:
   - name: Document
     root: true
@@ -51,6 +59,8 @@ entities:
       # Feature 13: v2 adds a new property (normalization test)
       - name: webhooks
         type: '{PathItem}'
+      - name: additionalSchema
+        type: SchemaOrBoolean
     propertyOrder:
       - $this
       - $Extensible


### PR DESCRIPTION
## Summary

- Add `typeAliases` section to spec YAML for defining named union types with discrimination rules
- Type alias names are used as the generated Java union interface name (e.g., `SchemaOrBoolean` instead of `BooleanSchemaUnion`)
- Union infrastructure stages updated to discover and process type-alias-backed properties

Part of #1041. Prerequisite for G1 (union-as-root).

## Spec syntax

```yaml
typeAliases:
  - name: SchemaOrBoolean
    type: boolean|Schema
    unionRules:
      - unionType: Schema
        ruleType: propertyExists
        propertyName: type

entities:
  - name: Document
    properties:
      - name: additionalSchema
        type: SchemaOrBoolean    # references the type alias
```

## What changes

| File | Change |
|------|--------|
| `openapi.json` | New `TypeAlias` schema, `typeAliases` on `SpecificationVersion` |
| `CreatePropertyAndTypeModelsStage` | Process type aliases before properties, index in ConceptIndex |
| `UnionType` | New `aliasName` field |
| `JavaTypeFactory` | Use alias name for union Java type naming |
| `AbstractUnionTypeJavaStage` | Union discovery includes resolvedType-based union check |
| `CreateUnionTypesStage` | Handle alias-named unions, deduplicate |
| `ApplyUnionTypesStage` | New path for type-alias unions using resolved types |
| `CreateUnionTypeValuesStage` | Guard against non-union PropertyType |
| `CreateUnionValueMethodsStage` | Handle type aliases via resolved union type |

## Test plan

- [x] Synthetic spec adds `SchemaOrBoolean` type alias + `additionalSchema` property
- [x] Generated `SchemaOrBoolean.java` union interface with `isBoolean()`/`asBoolean()`/`isSchema()`/`asSchema()`
- [x] Generated getter/setter use `SchemaOrBoolean` type (not `BooleanSchemaUnion`)
- [x] Entity impl classes implement `SchemaOrBoolean` interface
- [x] All 5 tests pass (including snapshot after FullGeneratorTest)