### PR TITLE
Remove unused commons-beanutils-core dependency with known CVEs (#1065)

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -19,11 +19,6 @@
             <version>${version.commons-io}</version>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils-core</artifactId>
-            <version>${version.commons-beanutils}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${version.commons-lang3}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <version.junit>4.13.2</version.junit>
 
         <!-- Dependency Versions (generator-specific) -->
-        <version.commons-beanutils>1.8.3</version.commons-beanutils>
         <version.commons-collections4>4.5.0</version.commons-collections4>
         <version.roaster>2.31.0.Final</version.roaster>
         <version.modeshape-common>5.4.1.Final</version.modeshape-common>


### PR DESCRIPTION
## Summary

- Removed the unused `commons-beanutils-core` 1.8.3 dependency from the generator module
- Removed the `version.commons-beanutils` property from the root POM
- The dependency was never imported or used anywhere in the generator source code, so removal is safe and eliminates CVE-2014-0114 and CVE-2019-10086

## Related Issue

Fixes #1065

## Test Plan

- [x] Full build passes (`./build.sh`) — all four modules build successfully
- [x] All existing generator tests pass
- [ ] Verify no security scan warnings for commons-beanutils