### PR TITLE
feat: replace bare RuntimeException with typed exception hierarchy

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/DataModelsException.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/DataModelsException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apitomy.datamodels;
+
+/**
+ * Base exception for all errors thrown by the data-models library.
+ * Extends {@link RuntimeException} to maintain backward compatibility.
+ */
+public class DataModelsException extends RuntimeException {
+
+    /**
+     * @param message the detail message
+     */
+    public DataModelsException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message the detail message
+     * @param cause the underlying cause
+     */
+    public DataModelsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param cause the underlying cause
+     */
+    public DataModelsException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/Library.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/Library.java
@@ -257,7 +257,7 @@ public class Library {
             return newDoc;
         }
 
-        throw new RuntimeException("Transformation not supported.");
+        throw new TransformationException("Transformation not supported.");
     }
 
     /**
@@ -286,7 +286,7 @@ public class Library {
             return transformer.getResult();
         }
 
-        throw new RuntimeException("No single-step transformation from " + fromType + " to " + toType);
+        throw new TransformationException("No single-step transformation from " + fromType + " to " + toType);
     }
 
     /**

--- a/data-models/src/main/java/io/apitomy/datamodels/ModelTypeDetector.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/ModelTypeDetector.java
@@ -46,7 +46,7 @@ public class ModelTypeDetector {
             } else if (asyncapi.startsWith("3.1")) {
                 return ModelType.ASYNCAPI31;
             } else {
-                throw new RuntimeException("Unknown/unsupported AsyncAPI version: " + asyncapi);
+                throw new UnsupportedModelTypeException("Unknown/unsupported AsyncAPI version: " + asyncapi);
             }
         }
         if (openapi != null) {
@@ -59,14 +59,14 @@ public class ModelTypeDetector {
             } else if (openapi.startsWith("3.2")) {
                 return ModelType.OPENAPI32;
             } else {
-                throw new RuntimeException("Unknown/unsupported OpenAPI version: " + openapi);
+                throw new UnsupportedModelTypeException("Unknown/unsupported OpenAPI version: " + openapi);
             }
         }
         if (swagger != null) {
             if (swagger.startsWith("2.")) {
                 return ModelType.OPENAPI20;
             } else {
-                throw new RuntimeException("Unknown/unsupported OpenAPI/Swagger version: " + swagger);
+                throw new UnsupportedModelTypeException("Unknown/unsupported OpenAPI/Swagger version: " + swagger);
             }
         }
 
@@ -77,7 +77,7 @@ public class ModelTypeDetector {
             } else if (openrpc.startsWith("1.4")) {
                 return ModelType.OPENRPC14;
             } else {
-                throw new RuntimeException("Unknown/unsupported OpenRPC version: " + openrpc);
+                throw new UnsupportedModelTypeException("Unknown/unsupported OpenRPC version: " + openrpc);
             }
         }
 
@@ -94,7 +94,7 @@ public class ModelTypeDetector {
             } else if (schema.contains("2020-12")) {
                 return ModelType.JS202012;
             } else {
-                throw new RuntimeException("Unknown/unsupported JSON Schema version: " + schema);
+                throw new UnsupportedModelTypeException("Unknown/unsupported JSON Schema version: " + schema);
             }
         }
 

--- a/data-models/src/main/java/io/apitomy/datamodels/TransformationException.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/TransformationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apitomy.datamodels;
+
+/**
+ * Thrown when a document transformation between specification versions is not supported.
+ */
+public class TransformationException extends DataModelsException {
+
+    /**
+     * @param message the detail message
+     */
+    public TransformationException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message the detail message
+     * @param cause the underlying cause
+     */
+    public TransformationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/UnsupportedModelTypeException.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/UnsupportedModelTypeException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apitomy.datamodels;
+
+/**
+ * Thrown when an unknown or unsupported specification version or model type is encountered.
+ */
+public class UnsupportedModelTypeException extends DataModelsException {
+
+    /**
+     * @param message the detail message
+     */
+    public UnsupportedModelTypeException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message the detail message
+     * @param cause the underlying cause
+     */
+    public UnsupportedModelTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
@@ -125,7 +125,7 @@ public class VisitorUtil {
             }
         }
         if (traverser == null) {
-            throw new RuntimeException("Traverser not found for type: " + type);
+            throw new UnsupportedModelTypeException("Traverser not found for type: " + type);
         }
         traverser.traverse(node);
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/CommandException.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/CommandException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apitomy.datamodels.cmd;
+
+import io.apitomy.datamodels.DataModelsException;
+
+/**
+ * Thrown when command marshalling or unmarshalling fails.
+ */
+public class CommandException extends DataModelsException {
+
+    /**
+     * @param message the detail message
+     */
+    public CommandException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message the detail message
+     * @param cause the underlying cause
+     */
+    public CommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddExampleDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddExampleDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.Example;
@@ -84,7 +85,7 @@ public class AddExampleDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenRpcModel(document)) {
             return new OpenRpcHelper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddExampleDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddHeaderDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddHeaderDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.openapi.OpenApiDocument;
@@ -80,7 +81,7 @@ public class AddHeaderDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddHeaderDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddParameterDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddParameterDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.Parameter;
@@ -91,7 +92,7 @@ public class AddParameterDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isAsyncApi2Model(document)) {
             return new AsyncApi2Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddParameterDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddRequestBodyDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddRequestBodyDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.openapi.OpenApiDocument;
@@ -80,7 +81,7 @@ public class AddRequestBodyDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddRequestBodyDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddResponseDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddResponseDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.openapi.OpenApiDocument;
@@ -87,7 +88,7 @@ public class AddResponseDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddResponseDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddSchemaDefinitionCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddSchemaDefinitionCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.Schema;
@@ -95,7 +96,7 @@ public class AddSchemaDefinitionCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenRpcModel(document)) {
             return new OpenRpcHelper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddSchemaDefinitionCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddSchemaPropertyCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/AddSchemaPropertyCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.Schema;
@@ -94,7 +95,7 @@ public class AddSchemaPropertyCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface AddSchemaPropertyCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/DeleteSchemaPropertyCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/DeleteSchemaPropertyCommand.java
@@ -2,6 +2,7 @@ package io.apitomy.datamodels.cmd.commands;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.cmd.AbstractCommand;
 import io.apitomy.datamodels.models.Document;
 import io.apitomy.datamodels.models.Schema;
@@ -115,7 +116,7 @@ public class DeleteSchemaPropertyCommand extends AbstractCommand {
         if (ModelTypeUtil.isOpenApi31Model(document)) {
             return new OpenApi31Helper();
         }
-        throw new RuntimeException("Unsupported model type: " + document.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + document.root().modelType());
     }
 
     private interface DeleteSchemaPropertyCommandHelper {

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/Dereferencer.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/Dereferencer.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.apitomy.datamodels.DataModelsException;
 import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.TraverserDirection;
 import io.apitomy.datamodels.VisitorUtil;
 import io.apitomy.datamodels.models.Document;
@@ -62,7 +64,7 @@ public class Dereferencer {
 
         // Fail if strict mode is enabled and at least one ref was not resolved.
         if (this.strict && unresolveableRefCount > 0) {
-            throw new RuntimeException("Could not resolve at least one external reference.");
+            throw new DataModelsException("Could not resolve at least one external reference.");
         }
 
         return doc;
@@ -175,7 +177,7 @@ public class Dereferencer {
         } else if (ModelTypeUtil.isOpenRpcModel(doc)) {
             return new OpenRpcNodeImporter(doc, nodeWithUnresolvedRef, ref, shouldInline);
         }
-        throw new RuntimeException("Unsupported model type: " + doc.root().modelType());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + doc.root().modelType());
     }
 
     /**

--- a/data-models/src/main/java/io/apitomy/datamodels/util/CommandUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/util/CommandUtil.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import io.apitomy.datamodels.cmd.CommandException;
 import io.apitomy.datamodels.cmd.ICommand;
 import io.apitomy.datamodels.paths.NodePath;
 
@@ -118,7 +119,7 @@ public class CommandUtil {
             Class<?> aClass = Class.forName(cmdFQCN);
             return (ICommand) aClass.getConstructor().newInstance();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new CommandException("Error creating command: " + cmdType, e);
         }
     }
 
@@ -131,7 +132,7 @@ public class CommandUtil {
     public static ICommand unmarshall(ObjectNode from) {
         String type = from.get("__type").asText();
         if (type == null) {
-            throw new RuntimeException("Missing __type from source data.");
+            throw new CommandException("Missing __type from source data.");
         }
 
         try {
@@ -139,9 +140,9 @@ public class CommandUtil {
             ICommand cmd = mapper.treeToValue((TreeNode) from, cmdClass);
             return cmd;
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Error unmarshalling command: " + type, e);
+            throw new CommandException("Error unmarshalling command: " + type, e);
         } catch (NullPointerException e) {
-            throw new RuntimeException("Missing command from unmarshalling factory: " + type, e);
+            throw new CommandException("Missing command from unmarshalling factory: " + type, e);
         }
     }
 
@@ -198,7 +199,7 @@ public class CommandUtil {
                                 result.set(field.getName(), commandsArray);
                             }
                         } catch (IllegalAccessException e) {
-                            throw new RuntimeException("Error marshalling command list field: " + field.getName(), e);
+                            throw new CommandException("Error marshalling command list field: " + field.getName(), e);
                         }
                     }
                 }

--- a/data-models/src/main/java/io/apitomy/datamodels/util/ModelTypeUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/util/ModelTypeUtil.java
@@ -1,5 +1,6 @@
 package io.apitomy.datamodels.util;
 
+import io.apitomy.datamodels.UnsupportedModelTypeException;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.Node;
 
@@ -52,7 +53,7 @@ public class ModelTypeUtil {
             case OPENRPC14:
                 return "1.4.0";
         }
-        throw new RuntimeException("Unsupported model type: " + type.name());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + type.name());
     }
 
     /**
@@ -89,7 +90,7 @@ public class ModelTypeUtil {
             case JS202012:
                 return "$schema";
         }
-        throw new RuntimeException("Unsupported model type: " + type.name());
+        throw new UnsupportedModelTypeException("Unsupported model type: " + type.name());
     }
 
     public static boolean isOpenApiModel(Node node) {

--- a/data-models/src/main/java/io/apitomy/datamodels/util/NodeUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/util/NodeUtil.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import io.apitomy.datamodels.DataModelsException;
 import io.apitomy.datamodels.models.Node;
 import io.apitomy.datamodels.models.union.Union;
 import io.apitomy.datamodels.visitors.DefinitionDetectionVisitor;
@@ -72,9 +73,9 @@ public class NodeUtil {
                             + " with " + args.length + " parameter(s) on " + target.getClass().getSimpleName()));
             return method.invoke(target, args);
         } catch (InvocationTargetException e) {
-            throw new RuntimeException(e.getCause());
+            throw new DataModelsException(e.getCause());
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new DataModelsException(e);
         }
     }
 

--- a/data-models/src/main/java/io/apitomy/datamodels/util/ValidationUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/util/ValidationUtil.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.apitomy.datamodels.DataModelsException;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.Node;
 import io.apitomy.datamodels.validation.ValidationRule;
@@ -49,7 +50,7 @@ public class ValidationUtil {
             return (ValidationRule) constructor.newInstance(ruleInfo);
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                 | IllegalArgumentException | InvocationTargetException e) {
-            throw new RuntimeException(e);
+            throw new DataModelsException(e);
         }
     }
 

--- a/data-models/src/main/java/io/apitomy/datamodels/validation/ValidationRuleSet.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/ValidationRuleSet.java
@@ -1,5 +1,6 @@
 package io.apitomy.datamodels.validation;
 
+import io.apitomy.datamodels.DataModelsException;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.util.ValidationUtil;
 import io.apitomy.datamodels.validation.rules.invalid.format.AaInvalidAsyncApiVersionFormatRule;
@@ -618,12 +619,12 @@ public class ValidationRuleSet {
 
         for (ValidationRuleMetaData rule : this.rules) {
             if (codes.contains(rule.code)) {
-                throw new RuntimeException("Duplicate rule code found: " + rule.code);
+                throw new DataModelsException("Duplicate rule code found: " + rule.code);
             } else {
                 codes.add(rule.code);
             }
             if (names.contains(rule.name)) {
-                throw new RuntimeException("Duplicate rule name found: " + rule.name);
+                throw new DataModelsException("Duplicate rule name found: " + rule.name);
             } else {
                 names.add(rule.name);
             }


### PR DESCRIPTION
## Summary

- Introduced a `DataModelsException` base class (extends `RuntimeException`) with three
  typed subclasses: `UnsupportedModelTypeException`, `TransformationException`, and
  `CommandException`
- Replaced 30 bare `RuntimeException` throw sites across 17 files with the appropriate
  typed exception, enabling callers to programmatically distinguish failure modes
- Left 2 `RuntimeException` sites in `GenerateCoreTs.java` unchanged (build tool, not
  library API)

## Related Issue

Fixes #1066

## Test Plan

- [x] Full Maven build passes (`build.sh`) — compilation, tests, JSweet transpilation, npm packaging
- [ ] Verify consumers catching `RuntimeException` still work (all new exceptions extend it)
- [ ] Verify callers can now catch specific exception types (e.g. `UnsupportedModelTypeException`)