### PR TITLE
fix(generator): traverser accepts Any for map/list traversal

### DIFF
--- a/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
@@ -29,6 +29,9 @@ public abstract class NodeImpl implements Node {
 
     @Override
     public RootCapable root() {
+        if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
+            return (RootCapable) this;
+        }
         return this._parent.root();
     }
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/RootCapableImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/RootCapableImpl.java
@@ -14,11 +14,6 @@ public abstract class RootCapableImpl extends NodeImpl implements RootCapable {
     }
 
     @Override
-    public RootCapable root() {
-        return this;
-    }
-
-    @Override
     public ModelType modelType() {
         return this._modelType;
     }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -3,6 +3,7 @@ package io.apitomy.umg.base.visitors;
 import java.util.Collection;
 import java.util.Map;
 
+import io.apitomy.umg.base.Any;
 import io.apitomy.umg.base.MappedNode;
 import io.apitomy.umg.base.Node;
 import io.apitomy.umg.base.Visitable;
@@ -61,15 +62,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      * @param items
      */
     @SuppressWarnings("unchecked")
-    protected void traverseList(String propertyName, Collection<? extends Node> items) {
+    protected void traverseList(String propertyName, Collection<? extends Any> items) {
         if (items != null) {
             int index = 0;
             traversalContext.pushProperty(propertyName);
-            Collection<? extends Node> clonedItems = (Collection<? extends Node>) JsonUtil.cloneCollection(items);
-            for (Node node : clonedItems) {
-                if (node != null) {
+            Collection<? extends Any> clonedItems = (Collection<? extends Any>) JsonUtil.cloneCollection(items);
+            for (Any item : clonedItems) {
+                if (item != null && item.isNode()) {
                     traversalContext.pushListIndex(index);
-                    doTraverseNode(node);
+                    doTraverseNode((Visitable) item);
                     traversalContext.pop();
                 }
                 index++;
@@ -85,15 +86,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      * @param items
      */
     @SuppressWarnings("unchecked")
-    protected void traverseMap(String propertyName, Map<String, ? extends Node> items) {
+    protected void traverseMap(String propertyName, Map<String, ? extends Any> items) {
         if (items != null) {
             traversalContext.pushProperty(propertyName);
             Collection<String> keys = (Collection<String>) JsonUtil.cloneCollection(items.keySet());
             keys.forEach(key -> {
-                Node value = items.get(key);
-                if (value != null) {
+                Any value = items.get(key);
+                if (value != null && value.isNode()) {
                     this.traversalContext.pushMapIndex(key);
-                    this.doTraverseNode(value);
+                    this.doTraverseNode((Visitable) value);
                     this.traversalContext.pop();
                 }
             });

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
@@ -28,6 +28,9 @@ public abstract class NodeImpl implements Node {
 
 	@Override
 	public RootCapable root() {
+		if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
+			return (RootCapable) this;
+		}
 		return this._parent.root();
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootCapableImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/RootCapableImpl.java
@@ -14,11 +14,6 @@ public abstract class RootCapableImpl extends NodeImpl implements RootCapable {
 	}
 
 	@Override
-	public RootCapable root() {
-		return this;
-	}
-
-	@Override
 	public ModelType modelType() {
 		return this._modelType;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
@@ -21,6 +21,16 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaUnion, Bo
 
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex);
 
+	public List<SchemaOrBoolean> getComposedSchemas();
+
+	public void addComposedSchema(SchemaOrBoolean value);
+
+	public void clearComposedSchemas();
+
+	public void removeComposedSchema(SchemaOrBoolean value);
+
+	public void insertComposedSchema(SchemaOrBoolean value, int atIndex);
+
 	public Map<String, BooleanSchemaUnion> getDefinitions();
 
 	public void addDefinition(String name, BooleanSchemaUnion value);
@@ -46,6 +56,16 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaUnion, Bo
 	public Integer getMinLength();
 
 	public void setMinLength(Integer value);
+
+	public Map<String, SchemaOrBoolean> getNestedSchemas();
+
+	public void addNestedSchema(String name, SchemaOrBoolean value);
+
+	public void clearNestedSchemas();
+
+	public void removeNestedSchema(String name);
+
+	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex);
 
 	public Map<String, BooleanSchemaUnion> getProperties();
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -9,6 +9,7 @@ import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
@@ -27,6 +28,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	private Map<String, BooleanSchemaUnion> properties;
 	private List<BooleanSchemaUnion> allOf;
 	private Map<String, BooleanSchemaUnion> definitions;
+	private Map<String, SchemaOrBoolean> nestedSchemas;
+	private List<SchemaOrBoolean> composedSchemas;
 	private Integer minLength;
 	private Integer maxLength;
 	private List<JsonNode> _enum;
@@ -234,6 +237,98 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			((NodeImpl) value)._setParentPropertyName("definitions");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public Map<String, SchemaOrBoolean> getNestedSchemas() {
+		return nestedSchemas;
+	}
+
+	@Override
+	public void addNestedSchema(String name, SchemaOrBoolean value) {
+		if (this.nestedSchemas == null) {
+			this.nestedSchemas = new LinkedHashMap<>();
+		}
+		this.nestedSchemas.put(name, value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearNestedSchemas() {
+		if (this.nestedSchemas != null) {
+			this.nestedSchemas.clear();
+		}
+	}
+
+	@Override
+	public void removeNestedSchema(String name) {
+		if (this.nestedSchemas != null) {
+			this.nestedSchemas.remove(name);
+		}
+	}
+
+	@Override
+	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
+		if (this.nestedSchemas == null) {
+			this.nestedSchemas = new LinkedHashMap<>();
+			this.nestedSchemas.put(name, value);
+		} else {
+			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public List<SchemaOrBoolean> getComposedSchemas() {
+		return composedSchemas;
+	}
+
+	@Override
+	public void addComposedSchema(SchemaOrBoolean value) {
+		if (this.composedSchemas == null) {
+			this.composedSchemas = new ArrayList<>();
+		}
+		this.composedSchemas.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("composedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearComposedSchemas() {
+		if (this.composedSchemas != null) {
+			this.composedSchemas.clear();
+		}
+	}
+
+	@Override
+	public void removeComposedSchema(SchemaOrBoolean value) {
+		if (this.composedSchemas != null) {
+			this.composedSchemas.remove(value);
+		}
+	}
+
+	@Override
+	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
+		if (this.composedSchemas == null) {
+			this.composedSchemas = new ArrayList<>();
+			this.composedSchemas.add(value);
+		} else {
+			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("composedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -43,6 +43,8 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 		node.accept(this.visitor);
 		Syn1Schema model = (Syn1Schema) node;
 		this.traverseUnion("items", model.getItems());
+		this.traverseMap("nestedSchemas", model.getNestedSchemas());
+		this.traverseList("composedSchemas", model.getComposedSchemas());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -9,6 +9,7 @@ import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
@@ -27,6 +28,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	private Map<String, BooleanSchemaUnion> properties;
 	private List<BooleanSchemaUnion> allOf;
 	private Map<String, BooleanSchemaUnion> definitions;
+	private Map<String, SchemaOrBoolean> nestedSchemas;
+	private List<SchemaOrBoolean> composedSchemas;
 	private Integer minLength;
 	private Integer maxLength;
 	private List<JsonNode> _enum;
@@ -234,6 +237,98 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			((NodeImpl) value)._setParentPropertyName("definitions");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public Map<String, SchemaOrBoolean> getNestedSchemas() {
+		return nestedSchemas;
+	}
+
+	@Override
+	public void addNestedSchema(String name, SchemaOrBoolean value) {
+		if (this.nestedSchemas == null) {
+			this.nestedSchemas = new LinkedHashMap<>();
+		}
+		this.nestedSchemas.put(name, value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public void clearNestedSchemas() {
+		if (this.nestedSchemas != null) {
+			this.nestedSchemas.clear();
+		}
+	}
+
+	@Override
+	public void removeNestedSchema(String name) {
+		if (this.nestedSchemas != null) {
+			this.nestedSchemas.remove(name);
+		}
+	}
+
+	@Override
+	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
+		if (this.nestedSchemas == null) {
+			this.nestedSchemas = new LinkedHashMap<>();
+			this.nestedSchemas.put(name, value);
+		} else {
+			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+			((NodeImpl) value)._setMapPropertyName(name);
+		}
+	}
+
+	@Override
+	public List<SchemaOrBoolean> getComposedSchemas() {
+		return composedSchemas;
+	}
+
+	@Override
+	public void addComposedSchema(SchemaOrBoolean value) {
+		if (this.composedSchemas == null) {
+			this.composedSchemas = new ArrayList<>();
+		}
+		this.composedSchemas.add(value);
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("composedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		}
+	}
+
+	@Override
+	public void clearComposedSchemas() {
+		if (this.composedSchemas != null) {
+			this.composedSchemas.clear();
+		}
+	}
+
+	@Override
+	public void removeComposedSchema(SchemaOrBoolean value) {
+		if (this.composedSchemas != null) {
+			this.composedSchemas.remove(value);
+		}
+	}
+
+	@Override
+	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
+		if (this.composedSchemas == null) {
+			this.composedSchemas = new ArrayList<>();
+			this.composedSchemas.add(value);
+		} else {
+			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
+		}
+		if (value != null) {
+			((NodeImpl) value)._setParentPropertyName("composedSchemas");
+			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -43,6 +43,8 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 		node.accept(this.visitor);
 		Syn2Schema model = (Syn2Schema) node;
 		this.traverseUnion("items", model.getItems());
+		this.traverseMap("nestedSchemas", model.getNestedSchemas());
+		this.traverseList("composedSchemas", model.getComposedSchemas());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -1,5 +1,6 @@
 package io.test.synthetic.visitors;
 
+import io.test.synthetic.Any;
 import io.test.synthetic.MappedNode;
 import io.test.synthetic.Node;
 import io.test.synthetic.Visitable;
@@ -60,15 +61,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 * @param items
 	 */
 	@SuppressWarnings("unchecked")
-	protected void traverseList(String propertyName, Collection<? extends Node> items) {
+	protected void traverseList(String propertyName, Collection<? extends Any> items) {
 		if (items != null) {
 			int index = 0;
 			traversalContext.pushProperty(propertyName);
-			Collection<? extends Node> clonedItems = (Collection<? extends Node>) JsonUtil.cloneCollection(items);
-			for (Node node : clonedItems) {
-				if (node != null) {
+			Collection<? extends Any> clonedItems = (Collection<? extends Any>) JsonUtil.cloneCollection(items);
+			for (Any item : clonedItems) {
+				if (item != null && item.isNode()) {
 					traversalContext.pushListIndex(index);
-					doTraverseNode(node);
+					doTraverseNode((Visitable) item);
 					traversalContext.pop();
 				}
 				index++;
@@ -84,15 +85,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 * @param items
 	 */
 	@SuppressWarnings("unchecked")
-	protected void traverseMap(String propertyName, Map<String, ? extends Node> items) {
+	protected void traverseMap(String propertyName, Map<String, ? extends Any> items) {
 		if (items != null) {
 			traversalContext.pushProperty(propertyName);
 			Collection<String> keys = (Collection<String>) JsonUtil.cloneCollection(items.keySet());
 			keys.forEach(key -> {
-				Node value = items.get(key);
-				if (value != null) {
+				Any value = items.get(key);
+				if (value != null && value.isNode()) {
 					this.traversalContext.pushMapIndex(key);
-					this.doTraverseNode(value);
+					this.doTraverseNode((Visitable) value);
 					this.traversalContext.pop();
 				}
 			});

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v1.yaml
@@ -166,6 +166,12 @@ entities:
       # Feature 19: Map of unions
       - name: definitions
         type: '{boolean|Schema}'
+      # Feature 22: Map of type alias (union)
+      - name: nestedSchemas
+        type: '{SchemaOrBoolean}'
+      # Feature 22: List of type alias (union)
+      - name: composedSchemas
+        type: '[SchemaOrBoolean]'
       - name: minLength
         type: integer
       - name: maxLength

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/synthetic-v2.yaml
@@ -151,6 +151,10 @@ entities:
         type: '[boolean|Schema]'
       - name: definitions
         type: '{boolean|Schema}'
+      - name: nestedSchemas
+        type: '{SchemaOrBoolean}'
+      - name: composedSchemas
+        type: '[SchemaOrBoolean]'
       - name: minLength
         type: integer
       - name: maxLength


### PR DESCRIPTION
## Summary

Change `AbstractTraverser.traverseList` and `traverseMap` to accept `Collection<? extends Any>` and `Map<String, ? extends Any>` instead of `Node`-typed collections. Items are filtered by `isNode()` at runtime.

Part of #1041.

## Problem

When a property uses a type alias (named union) in a map or list context (e.g., `{SchemaOrBoolean}` or `[SchemaOrBoolean]`), the generated traverser calls `traverseMap(Map<String, SchemaOrBoolean>)`. Since `SchemaOrBoolean` extends `Union` (via `Any`), not `Node`, the call fails to compile against the old `Map<String, ? extends Node>` signature.

## Fix

`traverseList` and `traverseMap` now accept `Any`-typed collections. Inside, each item is checked with `isNode()` before traversal — non-node union values (like `BooleanUnionValue`) are skipped. This matches the legacy traverser pattern (`traverseAnyList`/`traverseAnyMap`).

## Test plan

- [x] Synthetic spec adds `nestedSchemas: {SchemaOrBoolean}` and `composedSchemas: [SchemaOrBoolean]`
- [x] All 117 generated files compile
- [x] All 901 project tests pass