### PR TITLE
Remove stale version.com.fasterxml.jackson.dataformat property (#1071)

### DIFF
--- a/generator/src/test/resources/pom.xml
+++ b/generator/src/test/resources/pom.xml
@@ -62,7 +62,6 @@
 
         <!-- Dependency Versions -->
         <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.dataformat>2.10.0.pr1</version.com.fasterxml.jackson.dataformat>
         <version.commons-io>2.22.0</version.commons-io>
         <version.junit>4.13.2</version.junit>
         <version.org.jsweet>3.1.0</version.org.jsweet>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
 
         <!-- Dependency Versions (shared) -->
         <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.dataformat>2.10.0.pr1</version.com.fasterxml.jackson.dataformat>
         <version.commons-lang3>3.20.0</version.commons-lang3>
         <version.commons-io>2.22.0</version.commons-io>
         <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
## Summary
- Remove the unused `version.com.fasterxml.jackson.dataformat` property (set to pre-release
  `2.10.0.pr1` from 2019) from both `pom.xml` and `generator/src/test/resources/pom.xml`
- The property was never referenced by any dependency — `jackson-dataformat-yaml` correctly uses
  `${version.com.fasterxml.jackson}` (2.22.0)

## Related Issue
Fixes #1071

## Test Plan
- [ ] Verify `grep -rn 'jackson.dataformat' --include='*.xml' --exclude-dir=target` returns no
  hits for the removed property
- [ ] Run `mvn clean install` to confirm the build still succeeds