### PR TITLE
fix: surface silently swallowed exceptions in VisitorUtil and NodeUtil (#1070)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
@@ -48,6 +48,7 @@ import io.apitomy.datamodels.models.visitors.Traverser;
 import io.apitomy.datamodels.models.visitors.Visitor;
 import io.apitomy.datamodels.paths.NodePath;
 import io.apitomy.datamodels.paths.NodePathSegment;
+import io.apitomy.datamodels.util.LoggerUtil;
 import io.apitomy.datamodels.util.NodeUtil;
 
 /**
@@ -196,8 +197,75 @@ public class VisitorUtil {
                     ((Node) current).accept(visitor);
                 }
             } catch (Exception e) {
-                // If any error occurs during traversal, stop gracefully
+                LoggerUtil.warn("Error during path traversal at segment '%s': %s",
+                        segment.getValue(), e.getMessage());
                 break;
+            }
+        }
+    }
+
+    /**
+     * Strict variant of {@link #visitPath(Node, NodePath, Visitor)} that throws on errors
+     * instead of silently stopping traversal. Use this when you need to ensure that the
+     * entire path was successfully traversed, and want errors to propagate to the caller.
+     *
+     * @param node The starting node (typically the root document)
+     * @param nodePath The path to traverse through the data model
+     * @param visitor The visitor to apply to each node along the path
+     * @throws DataModelsException if any error occurs during traversal
+     */
+    @SuppressWarnings("rawtypes")
+    public static void visitPathStrict(Node node, NodePath nodePath, Visitor visitor) {
+        List<NodePathSegment> segments = nodePath.getSegments();
+        Object current = node;
+
+        // Visit the starting node
+        if (NodeUtil.isNode(current)) {
+            ((Node) current).accept(visitor);
+        }
+
+        // Traverse each segment of the path
+        for (NodePathSegment segment : segments) {
+            if (current == null) {
+                break;
+            }
+
+            try {
+                if (!segment.isIndex()) {
+                    current = NodeUtil.getProperty(current, segment.getValue());
+                } else {
+                    if (NodeUtil.isUnion(current)) {
+                        Union union = (Union) current;
+                        current = union.unionValue();
+                    }
+
+                    if (NodeUtil.isNode(current)) {
+                        MappedNode mappedNode = (MappedNode) current;
+                        current = mappedNode.getItem(segment.getValue());
+                    } else if (NodeUtil.isList(current)) {
+                        int index = NodeUtil.toInteger(segment.getValue());
+                        List list = (List) current;
+                        if (index >= 0 && index < list.size()) {
+                            current = list.get(index);
+                        } else {
+                            break;
+                        }
+                    } else if (NodeUtil.isMap(current)) {
+                        Map map = (Map) current;
+                        current = NodeUtil.getMapItem(map, segment.getValue());
+                    }
+                }
+
+                if (current == null) {
+                    break;
+                }
+
+                if (NodeUtil.isNode(current)) {
+                    ((Node) current).accept(visitor);
+                }
+            } catch (Exception e) {
+                throw new DataModelsException("Error during path traversal at segment '"
+                        + segment.getValue() + "'", e);
             }
         }
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/util/NodeUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/util/NodeUtil.java
@@ -91,9 +91,11 @@ public class NodeUtil {
             Method method = node.getClass().getMethod(getterName);
             return method.invoke(node);
         } catch (NoSuchMethodException nsme) {
-            // Might be a boolean getter...
+            // Might be a boolean getter — fall through to try "is" prefix
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException
                 | InvocationTargetException e1) {
+            LoggerUtil.warn("Failed to get property '%s' (via %s) on Node '%s': %s",
+                    propertyName, getterName, node.getClass().getSimpleName(), e1.getMessage());
             return null;
         }
 
@@ -102,8 +104,12 @@ public class NodeUtil {
         try {
             Method method = node.getClass().getMethod(getterName);
             return method.invoke(node);
-        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+        } catch (NoSuchMethodException nsme) {
+            return null;
+        } catch (SecurityException | IllegalAccessException | IllegalArgumentException
                 | InvocationTargetException e1) {
+            LoggerUtil.warn("Failed to get property '%s' (via %s) on Node '%s': %s",
+                    propertyName, getterName, node.getClass().getSimpleName(), e1.getMessage());
             return null;
         }
     }

--- a/data-models/src/test/java/io/apitomy/datamodels/VisitorUtilTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/VisitorUtilTest.java
@@ -28,6 +28,7 @@ import io.apitomy.datamodels.models.Operation;
 import io.apitomy.datamodels.models.openapi.OpenApiResponse;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
 import io.apitomy.datamodels.models.visitors.AllNodeVisitor;
+import io.apitomy.datamodels.models.visitors.Visitor;
 import io.apitomy.datamodels.paths.NodePath;
 
 /**
@@ -303,5 +304,54 @@ public class VisitorUtilTest {
         Assertions.assertTrue(visitor2.visitedNodes.size() > 0, "Second path should visit nodes");
         Assertions.assertEquals(visitor1.visitedNodes.get(0), visitor2.visitedNodes.get(0),
             "Both should start with document");
+    }
+
+    // --- visitPathStrict tests ---
+
+    @Test
+    public void testVisitPathStrict_ValidPath() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+        NodePath path = NodePath.parse("/paths[/pets]/get/responses[200]");
+        NodeCollectorVisitor visitor = new NodeCollectorVisitor();
+
+        VisitorUtil.visitPathStrict(document, path, visitor);
+
+        Assertions.assertTrue(visitor.visitedNodes.size() >= 4, "Should visit at least 4 nodes");
+        Assertions.assertEquals(document, visitor.visitedNodes.get(0), "First node should be document");
+        Node lastNode = visitor.visitedNodes.get(visitor.visitedNodes.size() - 1);
+        Assertions.assertTrue(lastNode instanceof OpenApiResponse, "Last node should be a Response");
+    }
+
+    @Test
+    public void testVisitPathStrict_NonExistentPropertyStopsGracefully() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+        NodePath path = NodePath.parse("/nonExistentProperty");
+        NodeCollectorVisitor visitor = new NodeCollectorVisitor();
+
+        VisitorUtil.visitPathStrict(document, path, visitor);
+
+        Assertions.assertEquals(1, visitor.visitedNodes.size(),
+                "Should visit only the document when property returns null");
+    }
+
+    @Test
+    public void testVisitPathStrict_ThrowsOnTraversalError() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+        NodePath path = NodePath.parse("/info");
+
+        Visitor throwingVisitor = new AllNodeVisitor() {
+            private int count = 0;
+            @Override
+            protected void visitNode(Node node) {
+                count++;
+                if (count > 1) {
+                    throw new RuntimeException("Simulated visitor error");
+                }
+            }
+        };
+
+        Assertions.assertThrows(DataModelsException.class, () -> {
+            VisitorUtil.visitPathStrict(document, path, throwingVisitor);
+        });
     }
 }

--- a/data-models/src/test/java/io/apitomy/datamodels/util/NodeUtilTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/util/NodeUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apitomy.datamodels.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.models.Document;
+import io.apitomy.datamodels.models.Info;
+import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class NodeUtilTest {
+
+    private static final String SAMPLE_OPENAPI = "{\n" +
+            "  \"openapi\": \"3.0.1\",\n" +
+            "  \"info\": {\n" +
+            "    \"title\": \"Test API\",\n" +
+            "    \"version\": \"1.0.0\"\n" +
+            "  },\n" +
+            "  \"paths\": {}\n" +
+            "}";
+
+    @Test
+    public void testGetNodeProperty_ValidGetter() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+
+        Object info = NodeUtil.getNodeProperty(document, "info");
+
+        Assertions.assertNotNull(info, "Should return Info node");
+        Assertions.assertTrue(info instanceof Info, "Should be an Info instance");
+    }
+
+    @Test
+    public void testGetNodeProperty_StringProperty() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+        Info info = document.getInfo();
+
+        Object title = NodeUtil.getNodeProperty(info, "title");
+
+        Assertions.assertNotNull(title, "Should return title");
+        Assertions.assertEquals("Test API", title, "Should return the correct title");
+    }
+
+    @Test
+    public void testGetNodeProperty_NonExistentProperty() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+
+        Object result = NodeUtil.getNodeProperty(document, "nonExistentProperty");
+
+        Assertions.assertNull(result, "Should return null for non-existent property");
+    }
+
+    @Test
+    public void testGetProperty_NodeProperty() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+
+        Object info = NodeUtil.getProperty(document, "info");
+
+        Assertions.assertNotNull(info, "Should return Info node via getProperty");
+        Assertions.assertTrue(info instanceof Info, "Should be an Info instance");
+    }
+
+    @Test
+    public void testIsNode() {
+        OpenApi30Document document = (OpenApi30Document) Library.readDocumentFromJSONString(SAMPLE_OPENAPI);
+
+        Assertions.assertTrue(NodeUtil.isNode(document), "Document should be a Node");
+        Assertions.assertTrue(NodeUtil.isNode(document.getInfo()), "Info should be a Node");
+        Assertions.assertFalse(NodeUtil.isNode(null), "null should not be a Node");
+        Assertions.assertFalse(NodeUtil.isNode("a string"), "String should not be a Node");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `LoggerUtil.warn()` logging to the `catch` blocks in `VisitorUtil.visitPath()` and
  `NodeUtil.getNodeProperty()` that previously discarded exceptions silently
- Add `VisitorUtil.visitPathStrict()` variant that throws `DataModelsException` on traversal
  errors instead of silently stopping, for callers that need error propagation
- Separate `NoSuchMethodException` (expected fallthrough) from real reflection errors
  (`SecurityException`, `IllegalAccessException`, etc.) in `NodeUtil.getNodeProperty()`

## Related Issue

Fixes #1070

## Test Plan

- [ ] Existing `VisitorUtilTest` tests pass (backward compatibility)
- [ ] New `testVisitPathStrict_ValidPath` — strict variant works on valid paths
- [ ] New `testVisitPathStrict_NonExistentPropertyStopsGracefully` — null properties stop traversal without throwing
- [ ] New `testVisitPathStrict_ThrowsOnTraversalError` — exceptions propagate as `DataModelsException`
- [ ] New `NodeUtilTest` tests pass for `getNodeProperty`, `getProperty`, and `isNode`