### PR TITLE
feat(generator): type-based reader methods for unions (G6.2)

### DIFF
--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -327,6 +327,10 @@ export class JsonUtil {
     public static setAnyProperty(json: object, propertyName: string, value: any): void {
         JsonUtil.setProperty(json, propertyName, value);
     }
+    /* Set a JSON (Array) property. */
+    public static setArrayProperty(json: object, propertyName: string, value: any[]): void {
+        JsonUtil.setProperty(json, propertyName, value);
+    }
     /* Set an array of anys property. */
     public static setAnyArrayProperty(json: object, propertyName: string, value: any[]): void {
         JsonUtil.setProperty(json, propertyName, value);
@@ -457,6 +461,18 @@ export class JsonUtil {
     }
 
     public static toJsonNode(value: any): any {
+        return value;
+    }
+
+    public static booleanToJsonNode(value: boolean): any {
+        return value;
+    }
+
+    public static stringToJsonNode(value: string): any {
+        return value;
+    }
+
+    public static numberToJsonNode(value: number): any {
         return value;
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -230,6 +230,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             javaEntity.addImport(nodeImplSource);
 
             body.append("if (value != null) {");
+            body.append("    ((NodeImpl) value).setParent(this);");
             body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
             body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("}");
@@ -247,12 +248,14 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
 
             body.append("if (value != null) {");
             body.append("    if (value.isEntity()) {");
+            body.append("        ((NodeImpl) value).setParent(this);");
             body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
             body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("    } else if (value.isEntityList()) {");
             body.append("        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();");
             body.append("        for (Object entity : entityList) {");
             body.append("            if (entity != null) {");
+            body.append("                ((NodeImpl) entity).setParent(this);");
             body.append("                ((NodeImpl) entity)._setParentPropertyName(\"${propertyName}\");");
             body.append("                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);");
             body.append("            }");
@@ -263,6 +266,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             body.append("        for (String key : keys) {");
             body.append("            NodeImpl entity = (NodeImpl) entityMap.get(key);");
             body.append("            if (entity != null) {");
+            body.append("                entity.setParent(this);");
             body.append("                entity._setParentPropertyName(\"${propertyName}\");");
             body.append("                entity._setParentPropertyType(ParentPropertyType.map);");
             body.append("                entity._setMapPropertyName(key);");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -79,10 +79,152 @@ public class CreateReadersStage extends AbstractJavaStage {
             }
         });
 
+        // Create type-based reader methods for unions and collections
+        createTypeBasedReaderMethods(specVersion, readerClassSource);
+
         // Create readRoot method based on the spec-level root type
         createReadRootFromSpec(specVersion, readerClassSource);
 
         getState().getJavaIndex().index(readerClassSource);
+    }
+
+    private void createTypeBasedReaderMethods(SpecificationVersion specVersion, JavaClassSource readerClassSource) {
+        var namespace = specVersion.getNamespace();
+
+        getState().getConceptIndex().findTypes(namespace).stream()
+                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
+                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .forEach(unionType -> createUnionReaderMethod(specVersion, readerClassSource, unionType));
+    }
+
+    private void createUnionReaderMethod(SpecificationVersion specVersion, JavaClassSource readerClassSource,
+                                          io.apitomy.umg.models.concept.type.UnionType unionType) {
+        var namespace = specVersion.getNamespace();
+        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String unionTypeName = jt.getSimpleName();
+        String methodName = "read" + unionTypeName;
+
+        // Skip if already created
+        if (readerClassSource.getMethod(methodName, JsonNode.class.getSimpleName()) != null) {
+            return;
+        }
+
+        debug("Creating union reader method: %s", methodName);
+
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(ObjectNode.class);
+        jt.addImportsTo(readerClassSource);
+
+        MethodSource<JavaClassSource> method = readerClassSource.addMethod()
+                .setName(methodName)
+                .setReturnType(jt.toJavaTypeString())
+                .setPrivate();
+        method.addParameter("JsonNode", "json");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (json == null) return null;");
+
+        // Generate dispatch for each variant
+        boolean first = true;
+        for (var variantType : unionType.getTypes()) {
+            if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
+                var entity = entityType.getEntity();
+                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
+                if (entity == null) continue;
+
+                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
+                JavaClassSource entityImplSource = lookupJavaEntityImpl(entity);
+                readerClassSource.addImport(entitySource);
+                readerClassSource.addImport(entityImplSource);
+
+                body.addContext("entityType", entitySource.getName());
+                body.addContext("entityImplType", entityImplSource.getName());
+                body.addContext("readMethodName", readMethodName(entity));
+
+                var rule = unionType.getRuleFor(entityType.getName());
+                String condition;
+                if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYEXISTS) {
+                    body.addContext("rulePropName", rule.getPropertyName());
+                    condition = "json.isObject() && json.has(\"${rulePropName}\")";
+                } else if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYVALUE) {
+                    body.addContext("rulePropName", rule.getPropertyName());
+                    body.addContext("rulePropValue", rule.getPropertyValue());
+                    condition = "JsonUtil.isObjectWithPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
+                } else {
+                    condition = "json.isObject()";
+                }
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (" + condition + ") {");
+                body.append("    ${entityType} node = new ${entityImplType}();");
+                body.append("    this.${readMethodName}((ObjectNode) json, node);");
+                body.append("    return node;");
+                body.append("}");
+            } else if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType puv) {
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                if (javaClass == null) continue;
+
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) continue;
+
+                readerClassSource.addImport(unionValueClass);
+
+                body.addContext("isMethod", "is" + javaClass.getSimpleName());
+                body.addContext("toMethod", "to" + javaClass.getSimpleName());
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.${isMethod}(json)) {");
+                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json));");
+                body.append("}");
+            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType
+                    && listType.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType listEntityType) {
+                var entity = listEntityType.getEntity();
+                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, listEntityType.getName());
+                if (entity == null) continue;
+
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) continue;
+
+                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
+                readerClassSource.addImport(entitySource);
+                readerClassSource.addImport(unionValueClass);
+                readerClassSource.addImport(java.util.List.class);
+                readerClassSource.addImport(java.util.ArrayList.class);
+
+                body.addContext("listValueType", entitySource.getName());
+                body.addContext("readMethodName", readMethodName(entity));
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.isArray(json)) {");
+                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
+                body.append("    List<${listValueType}> models = new ArrayList<>();");
+                body.append("    array.forEach(item -> {");
+                body.append("        ObjectNode object = JsonUtil.toObject(item);");
+                body.append("        ${listValueType} model = new ${listValueType}Impl();");
+                body.append("        this.${readMethodName}(object, model);");
+                body.append("        models.add(model);");
+                body.append("    });");
+                body.append("    @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
+                body.append("    ${unionValueClass} unionValue = new ${unionValueClass}((List) models);");
+                body.append("    return unionValue;");
+                body.append("}");
+            }
+        }
+        body.append("return null;");
+        method.setBody(body.toString());
     }
 
     private void createReadRootFromSpec(SpecificationVersion specVersion, JavaClassSource readerClassSource) {
@@ -325,6 +467,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                 handleStarProperty(body);
             } else if (property.getName().startsWith("/")) {
                 handleRegexProperty(body);
+            } else if (handleViaResolvedType(body)) {
+                // Handled by resolved type dispatch — union reader methods etc.
             } else if (property.getType().isEntityType()) {
                 handleEntityProperty(body);
             } else if (property.getType().isPrimitiveType()) {
@@ -343,6 +487,124 @@ public class CreateReadersStage extends AbstractJavaStage {
                 warn("Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
                 warn("       property type: " + property.getType());
             }
+        }
+
+        private boolean handleViaResolvedType(BodyBuilder body) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var resolved = property.getResolvedType();
+            if (resolved == null) return false;
+
+            // Only use resolved type dispatch when PropertyType doesn't recognize the
+            // type correctly (e.g., type alias properties where PropertyType is simple
+            // but resolvedType is a union). For properties where PropertyType already
+            // works (inline unions), fall through to the old code path.
+            var pt = property.getType();
+            if (pt.isUnion() || (pt.isList() && pt.getNested().iterator().next().isUnion())
+                    || (pt.isMap() && pt.getNested().iterator().next().isUnion())) {
+                return false;
+            }
+
+            // Direct union property (e.g., not: Schema where Schema is a type alias)
+            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionProperty(body, resolved);
+                return true;
+            }
+
+            // List of union (e.g., allOf: [Schema])
+            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
+                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionListProperty(body, lt);
+                return true;
+            }
+
+            // Map of union (e.g., definitions: {Schema})
+            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
+                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionMapProperty(body, mt);
+                return true;
+            }
+
+            return false;
+        }
+
+        private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var jt = getJavaTypeFactory().createJavaType(resolved, nsModel);
+            String readMethodName = "read" + jt.getSimpleName();
+
+            readerClassSource.addImport(JsonNode.class);
+            jt.addImportsTo(readerClassSource);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("setterMethodName", setterMethodName(property));
+            body.addContext("readMethodName", readMethodName);
+
+            body.append("{");
+            body.append("    JsonNode value = JsonUtil.consumeAnyProperty(json, \"${propertyName}\");");
+            body.append("    if (value != null) {");
+            body.append("        node.${setterMethodName}(this.${readMethodName}(value));");
+            body.append("    }");
+            body.append("}");
+        }
+
+        private void handleResolvedUnionListProperty(BodyBuilder body,
+                io.apitomy.umg.models.concept.type.ListType listType) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var valueJt = getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+            String readMethodName = "read" + valueJt.getSimpleName();
+
+            readerClassSource.addImport(JsonNode.class);
+            readerClassSource.addImport(java.util.List.class);
+            readerClassSource.addImport(java.util.ArrayList.class);
+            valueJt.addImportsTo(readerClassSource);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
+            body.addContext("readMethodName", readMethodName);
+            body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+            body.append("{");
+            body.append("    List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, \"${propertyName}\");");
+            body.append("    if (array != null) {");
+            body.append("        array.forEach(item -> {");
+            body.append("            ${unionJavaType} value = this.${readMethodName}(item);");
+            body.append("            if (value != null) node.${addMethodName}(value);");
+            body.append("        });");
+            body.append("    }");
+            body.append("}");
+        }
+
+        private void handleResolvedUnionMapProperty(BodyBuilder body,
+                io.apitomy.umg.models.concept.type.MapType mapType) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var valueJt = getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+            String readMethodName = "read" + valueJt.getSimpleName();
+
+            readerClassSource.addImport(JsonNode.class);
+            readerClassSource.addImport(ObjectNode.class);
+            readerClassSource.addImport(java.util.List.class);
+            valueJt.addImportsTo(readerClassSource);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
+            body.addContext("readMethodName", readMethodName);
+            body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+            body.append("{");
+            body.append("    ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
+            body.append("    if (mapObj != null) {");
+            body.append("        JsonUtil.keys(mapObj).forEach(key -> {");
+            body.append("            JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);");
+            body.append("            if (value != null) {");
+            body.append("                ${unionJavaType} model = this.${readMethodName}(value);");
+            body.append("                if (model != null) node.${addMethodName}(key, model);");
+            body.append("            }");
+            body.append("        });");
+            body.append("    }");
+            body.append("}");
         }
 
         private void handleStarProperty(BodyBuilder body) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -71,10 +71,102 @@ public class CreateWritersStage extends AbstractJavaStage {
             }
         });
 
+        // Create type-based writer methods for unions
+        createTypeBasedWriterMethods(specVersion, writerClassSource);
+
         // Create writeRoot method based on the spec-level root type
         createWriteRootFromSpec(specVersion, writerClassSource);
 
         getState().getJavaIndex().index(writerClassSource);
+    }
+
+    private void createTypeBasedWriterMethods(SpecificationVersion specVersion, JavaClassSource writerClassSource) {
+        var namespace = specVersion.getNamespace();
+
+        getState().getConceptIndex().findTypes(namespace).stream()
+                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
+                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .forEach(unionType -> createUnionWriterMethod(specVersion, writerClassSource, unionType));
+    }
+
+    private void createUnionWriterMethod(SpecificationVersion specVersion, JavaClassSource writerClassSource,
+                                          io.apitomy.umg.models.concept.type.UnionType unionType) {
+        var namespace = specVersion.getNamespace();
+        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String unionTypeName = jt.getSimpleName();
+        String methodName = "write" + unionTypeName;
+
+        if (hasMethod(writerClassSource, methodName)) {
+            return;
+        }
+
+        debug("Creating union writer method: %s", methodName);
+
+        writerClassSource.addImport(ObjectNode.class);
+        writerClassSource.addImport(JsonNode.class);
+        jt.addImportsTo(writerClassSource);
+
+        MethodSource<JavaClassSource> method = writerClassSource.addMethod()
+                .setName(methodName)
+                .setReturnType("JsonNode")
+                .setPrivate();
+        method.addParameter(jt.toJavaTypeString(), "union");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (union == null) return null;");
+
+        for (var variantType : unionType.getTypes()) {
+            if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
+                var entity = entityType.getEntity();
+                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
+                if (entity == null) continue;
+
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
+                writerClassSource.addImport(entitySource);
+
+                body.addContext("isMethod", "is" + typeName);
+                body.addContext("asMethod", "as" + typeName);
+                body.addContext("entityType", entitySource.getName());
+                body.addContext("writeMethodName", writeMethodName(entity));
+
+                body.append("if (union.${isMethod}()) {");
+                body.append("    ObjectNode jsonValue = JsonUtil.objectNode();");
+                body.append("    this.${writeMethodName}((${entityType}) union.${asMethod}(), jsonValue);");
+                body.append("    return jsonValue;");
+                body.append("}");
+            } else if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType puv) {
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                if (javaClass == null) continue;
+
+                body.addContext("isMethod", "is" + typeName);
+                body.addContext("asMethod", "as" + typeName);
+
+                if (JsonNode.class.isAssignableFrom(javaClass)) {
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    return union.${asMethod}();");
+                    body.append("}");
+                } else {
+                    String toJsonMethod;
+                    if (Boolean.class.equals(javaClass)) toJsonMethod = "booleanToJsonNode";
+                    else if (String.class.equals(javaClass)) toJsonMethod = "stringToJsonNode";
+                    else toJsonMethod = "numberToJsonNode";
+
+                    body.addContext("toJsonMethod", toJsonMethod);
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    return JsonUtil.${toJsonMethod}(union.${asMethod}());");
+                    body.append("}");
+                }
+            }
+        }
+        body.append("return null;");
+        method.setBody(body.toString());
+    }
+
+    private boolean hasMethod(JavaClassSource source, String name) {
+        return source.getMethods().stream().anyMatch(m -> m.getName().equals(name));
     }
 
     private void createWriteRootFromSpec(SpecificationVersion specVersion, JavaClassSource writerClassSource) {
@@ -269,6 +361,8 @@ public class CreateWritersStage extends AbstractJavaStage {
                 handleStarProperty(body);
             } else if (isRegexProperty(property)) {
                 handleRegexProperty(body);
+            } else if (handleViaResolvedType(body)) {
+                // Handled by resolved type dispatch
             } else if (isEntity(property)) {
                 handleEntityProperty(body);
             } else if (isPrimitive(property)) {
@@ -287,6 +381,117 @@ public class CreateWritersStage extends AbstractJavaStage {
                 warn("Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
                 warn("       property type: " + property.getType());
             }
+        }
+
+        private boolean handleViaResolvedType(BodyBuilder body) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var resolved = property.getResolvedType();
+            if (resolved == null) return false;
+
+            // Only use resolved type dispatch for type-alias-backed unions
+            var pt = property.getType();
+            if (pt.isUnion() || (pt.isList() && pt.getNested().iterator().next().isUnion())
+                    || (pt.isMap() && pt.getNested().iterator().next().isUnion())) {
+                return false;
+            }
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionProperty(body, resolved);
+                return true;
+            }
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
+                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionListProperty(body, lt);
+                return true;
+            }
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
+                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleResolvedUnionMapProperty(body, mt);
+                return true;
+            }
+
+            return false;
+        }
+
+        private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var jt = getJavaTypeFactory().createJavaType(resolved, nsModel);
+            String writeMethodName = "write" + jt.getSimpleName();
+
+            jt.addImportsTo(writerClassSource);
+            writerClassSource.addImport(JsonNode.class);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("getterMethodName", getterMethodName(property));
+            body.addContext("writeMethodName", writeMethodName);
+
+            body.append("{");
+            body.append("    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());");
+            body.append("    if (value != null) JsonUtil.setAnyProperty(json, \"${propertyName}\", value);");
+            body.append("}");
+        }
+
+        private void handleResolvedUnionListProperty(BodyBuilder body,
+                io.apitomy.umg.models.concept.type.ListType listType) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var valueJt = getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+            String writeMethodName = "write" + valueJt.getSimpleName();
+
+            valueJt.addImportsTo(writerClassSource);
+            writerClassSource.addImport(JsonNode.class);
+            writerClassSource.addImport(ArrayNode.class);
+            writerClassSource.addImport(List.class);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("getterMethodName", getterMethodName(property));
+            body.addContext("writeMethodName", writeMethodName);
+            body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+            body.append("{");
+            body.append("    List<${unionJavaType}> items = node.${getterMethodName}();");
+            body.append("    if (items != null && !items.isEmpty()) {");
+            body.append("        ArrayNode array = JsonUtil.arrayNode();");
+            body.append("        items.forEach(item -> {");
+            body.append("            JsonNode value = this.${writeMethodName}(item);");
+            body.append("            if (value != null) array.add(value);");
+            body.append("        });");
+            body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+            body.append("    }");
+            body.append("}");
+        }
+
+        private void handleResolvedUnionMapProperty(BodyBuilder body,
+                io.apitomy.umg.models.concept.type.MapType mapType) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+            var valueJt = getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+            String writeMethodName = "write" + valueJt.getSimpleName();
+
+            valueJt.addImportsTo(writerClassSource);
+            writerClassSource.addImport(JsonNode.class);
+            writerClassSource.addImport(ObjectNode.class);
+            writerClassSource.addImport(Map.class);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("getterMethodName", getterMethodName(property));
+            body.addContext("writeMethodName", writeMethodName);
+            body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+            body.append("{");
+            body.append("    Map<String, ${unionJavaType}> items = node.${getterMethodName}();");
+            body.append("    if (items != null && !items.isEmpty()) {");
+            body.append("        ObjectNode mapJson = JsonUtil.objectNode();");
+            body.append("        items.forEach((key, item) -> {");
+            body.append("            JsonNode value = this.${writeMethodName}(item);");
+            body.append("            if (value != null) JsonUtil.setAnyProperty(mapJson, key, value);");
+            body.append("        });");
+            body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", mapJson);");
+            body.append("    }");
+            body.append("}");
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -734,7 +939,7 @@ public class CreateWritersStage extends AbstractJavaStage {
             });
 
             body.append("        });");
-            body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+            body.append("        JsonUtil.setArrayProperty(json, \"${propertyName}\", array);");
             body.append("    }");
             body.append("}");
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -704,6 +704,25 @@ public class JsonUtil {
         return factory.textNode(value);
     }
 
+    public static void setArrayProperty(ObjectNode json, String propertyName, ArrayNode value) {
+        if (value != null) {
+            json.set(propertyName, value);
+        }
+    }
+
+    public static JsonNode booleanToJsonNode(Boolean value) {
+        return value != null ? factory.booleanNode(value) : null;
+    }
+
+    public static JsonNode stringToJsonNode(String value) {
+        return value != null ? factory.textNode(value) : null;
+    }
+
+    public static JsonNode numberToJsonNode(Number value) {
+        if (value == null) return null;
+        return factory.numberNode(value.doubleValue());
+    }
+
     public static void addToArray(ArrayNode array, JsonNode value) {
         array.add(value);
     }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -703,6 +703,26 @@ public class JsonUtil {
 		return factory.textNode(value);
 	}
 
+	public static void setArrayProperty(ObjectNode json, String propertyName, ArrayNode value) {
+		if (value != null) {
+			json.set(propertyName, value);
+		}
+	}
+
+	public static JsonNode booleanToJsonNode(Boolean value) {
+		return value != null ? factory.booleanNode(value) : null;
+	}
+
+	public static JsonNode stringToJsonNode(String value) {
+		return value != null ? factory.textNode(value) : null;
+	}
+
+	public static JsonNode numberToJsonNode(Number value) {
+		if (value == null)
+			return null;
+		return factory.numberNode(value.doubleValue());
+	}
+
 	public static void addToArray(ArrayNode array, JsonNode value) {
 		array.add(value);
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -44,6 +44,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("info");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -137,6 +138,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("additionalSchema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -37,6 +37,7 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("contact");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -110,6 +110,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("schema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -142,12 +143,14 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
+				((NodeImpl) value).setParent(this);
 				((NodeImpl) value)._setParentPropertyName("defaultValue");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
+						((NodeImpl) entity).setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("defaultValue");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
@@ -158,6 +161,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
+						entity.setParent(this);
 						entity._setParentPropertyName("defaultValue");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -49,6 +49,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("get");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -70,6 +71,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("put");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -84,6 +86,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("post");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -69,12 +69,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
+				((NodeImpl) value).setParent(this);
 				((NodeImpl) value)._setParentPropertyName("items");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
+						((NodeImpl) entity).setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("items");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
@@ -85,6 +87,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
+						entity.setParent(this);
 						entity._setParentPropertyName("items");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
 import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.util.ReaderUtil;
 import io.test.synthetic.v1.Syn1Contact;
@@ -56,6 +58,12 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			Map<String, String> value = JsonUtil.consumeStringMapProperty(json, "metadata");
 			node.setMetadata(value);
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
+			if (value != null) {
+				node.setAdditionalSchema(this.readSchemaOrBoolean(value));
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
@@ -276,6 +284,29 @@ public class Syn1ModelReader implements ModelReader {
 			}
 		}
 		{
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "nestedSchemas");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
+					if (value != null) {
+						SchemaOrBoolean model = this.readSchemaOrBoolean(value);
+						if (model != null)
+							node.addNestedSchema(key, model);
+					}
+				});
+			}
+		}
+		{
+			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
+			if (array != null) {
+				array.forEach(item -> {
+					SchemaOrBoolean value = this.readSchemaOrBoolean(item);
+					if (value != null)
+						node.addComposedSchema(value);
+				});
+			}
+		}
+		{
 			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
 			node.setMinLength(value);
 		}
@@ -390,6 +421,57 @@ public class Syn1ModelReader implements ModelReader {
 			});
 		}
 		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject() && json.has("type")) {
+			Syn1Schema node = new Syn1SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
+	}
+
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject()) {
+			Syn1Schema node = new Syn1SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isArray(json)) {
+			List<JsonNode> array = JsonUtil.toList(json);
+			List<Syn1Schema> models = new ArrayList<>();
+			array.forEach(item -> {
+				ObjectNode object = JsonUtil.toObject(item);
+				Syn1Schema model = new Syn1SchemaImpl();
+				this.readSchema(object, model);
+				models.add(model);
+			});
+			@SuppressWarnings({"unchecked", "rawtypes"})
+			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
+			return unionValue;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
+	}
+
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject()) {
+			Syn1Schema node = new Syn1SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -9,6 +9,7 @@ import io.test.synthetic.SynSchema;
 import io.test.synthetic.io.ModelWriter;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.util.WriterUtil;
 import io.test.synthetic.v1.Syn1Contact;
@@ -50,6 +51,11 @@ public class Syn1ModelWriter implements ModelWriter {
 		}
 		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
 		JsonUtil.setStringMapProperty(json, "metadata", node.getMetadata());
+		{
+			JsonNode value = this.writeSchemaOrBoolean(node.getAdditionalSchema());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "additionalSchema", value);
+		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
@@ -203,7 +209,7 @@ public class Syn1ModelWriter implements ModelWriter {
 						JsonUtil.addToArray(array, object);
 					}
 				});
-				JsonUtil.setAnyProperty(json, "allOf", array);
+				JsonUtil.setArrayProperty(json, "allOf", array);
 			}
 		}
 		{
@@ -222,6 +228,30 @@ public class Syn1ModelWriter implements ModelWriter {
 					}
 				});
 				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+			}
+		}
+		{
+			Map<String, SchemaOrBoolean> items = node.getNestedSchemas();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				items.forEach((key, item) -> {
+					JsonNode value = this.writeSchemaOrBoolean(item);
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
+				});
+				JsonUtil.setObjectProperty(json, "nestedSchemas", mapJson);
+			}
+		}
+		{
+			List<SchemaOrBoolean> items = node.getComposedSchemas();
+			if (items != null && !items.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				items.forEach(item -> {
+					JsonNode value = this.writeSchemaOrBoolean(item);
+					if (value != null)
+						array.add(value);
+				});
+				JsonUtil.setAnyProperty(json, "composedSchemas", array);
 			}
 		}
 		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
@@ -331,6 +361,48 @@ public class Syn1ModelWriter implements ModelWriter {
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	private JsonNode writeSchemaOrBoolean(SchemaOrBoolean union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
+	}
+
+	private JsonNode writeBooleanSchemaSchemaListUnion(BooleanSchemaSchemaListUnion union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
+	}
+
+	private JsonNode writeBooleanSchemaUnion(BooleanSchemaUnion union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -45,6 +45,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("info");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -192,6 +193,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("additionalSchema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -38,6 +38,7 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("contact");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -111,6 +111,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("schema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -143,12 +144,14 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
+				((NodeImpl) value).setParent(this);
 				((NodeImpl) value)._setParentPropertyName("defaultValue");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
+						((NodeImpl) entity).setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("defaultValue");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
@@ -159,6 +162,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
+						entity.setParent(this);
 						entity._setParentPropertyName("defaultValue");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -50,6 +50,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("get");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -71,6 +72,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("put");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -85,6 +87,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("post");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -99,6 +102,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setDelete(Syn2Operation value) {
 		this.delete = value;
 		if (value != null) {
+			((NodeImpl) value).setParent(this);
 			((NodeImpl) value)._setParentPropertyName("delete");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -69,12 +69,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
+				((NodeImpl) value).setParent(this);
 				((NodeImpl) value)._setParentPropertyName("items");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
+						((NodeImpl) entity).setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("items");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
@@ -85,6 +87,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
+						entity.setParent(this);
 						entity._setParentPropertyName("items");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
+import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
 import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.util.ReaderUtil;
 import io.test.synthetic.v2.Syn2Contact;
@@ -67,6 +69,12 @@ public class Syn2ModelReader implements ModelReader {
 					node.addWebhook(name, model);
 				}
 			});
+		}
+		{
+			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
+			if (value != null) {
+				node.setAdditionalSchema(this.readSchemaOrBoolean(value));
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
@@ -295,6 +303,29 @@ public class Syn2ModelReader implements ModelReader {
 			}
 		}
 		{
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "nestedSchemas");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
+					if (value != null) {
+						SchemaOrBoolean model = this.readSchemaOrBoolean(value);
+						if (model != null)
+							node.addNestedSchema(key, model);
+					}
+				});
+			}
+		}
+		{
+			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
+			if (array != null) {
+				array.forEach(item -> {
+					SchemaOrBoolean value = this.readSchemaOrBoolean(item);
+					if (value != null)
+						node.addComposedSchema(value);
+				});
+			}
+		}
+		{
 			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
 			node.setMinLength(value);
 		}
@@ -416,6 +447,57 @@ public class Syn2ModelReader implements ModelReader {
 			});
 		}
 		ReaderUtil.readExtraProperties(json, node);
+	}
+
+	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject() && json.has("type")) {
+			Syn2Schema node = new Syn2SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
+	}
+
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject()) {
+			Syn2Schema node = new Syn2SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isArray(json)) {
+			List<JsonNode> array = JsonUtil.toList(json);
+			List<Syn2Schema> models = new ArrayList<>();
+			array.forEach(item -> {
+				ObjectNode object = JsonUtil.toObject(item);
+				Syn2Schema model = new Syn2SchemaImpl();
+				this.readSchema(object, model);
+				models.add(model);
+			});
+			@SuppressWarnings({"unchecked", "rawtypes"})
+			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
+			return unionValue;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
+	}
+
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
+		if (json == null)
+			return null;
+		if (json.isObject()) {
+			Syn2Schema node = new Syn2SchemaImpl();
+			this.readSchema((ObjectNode) json, node);
+			return node;
+		} else if (JsonUtil.isBoolean(json)) {
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+		}
+		return null;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -10,6 +10,7 @@ import io.test.synthetic.SynSchema;
 import io.test.synthetic.io.ModelWriter;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.util.WriterUtil;
 import io.test.synthetic.v2.Syn2Contact;
@@ -62,6 +63,11 @@ public class Syn2ModelWriter implements ModelWriter {
 				});
 				JsonUtil.setObjectProperty(json, "webhooks", object);
 			}
+		}
+		{
+			JsonNode value = this.writeSchemaOrBoolean(node.getAdditionalSchema());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "additionalSchema", value);
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
@@ -218,7 +224,7 @@ public class Syn2ModelWriter implements ModelWriter {
 						JsonUtil.addToArray(array, object);
 					}
 				});
-				JsonUtil.setAnyProperty(json, "allOf", array);
+				JsonUtil.setArrayProperty(json, "allOf", array);
 			}
 		}
 		{
@@ -237,6 +243,30 @@ public class Syn2ModelWriter implements ModelWriter {
 					}
 				});
 				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+			}
+		}
+		{
+			Map<String, SchemaOrBoolean> items = node.getNestedSchemas();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				items.forEach((key, item) -> {
+					JsonNode value = this.writeSchemaOrBoolean(item);
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
+				});
+				JsonUtil.setObjectProperty(json, "nestedSchemas", mapJson);
+			}
+		}
+		{
+			List<SchemaOrBoolean> items = node.getComposedSchemas();
+			if (items != null && !items.isEmpty()) {
+				ArrayNode array = JsonUtil.arrayNode();
+				items.forEach(item -> {
+					JsonNode value = this.writeSchemaOrBoolean(item);
+					if (value != null)
+						array.add(value);
+				});
+				JsonUtil.setAnyProperty(json, "composedSchemas", array);
 			}
 		}
 		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
@@ -353,6 +383,48 @@ public class Syn2ModelWriter implements ModelWriter {
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
+	}
+
+	private JsonNode writeSchemaOrBoolean(SchemaOrBoolean union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
+	}
+
+	private JsonNode writeBooleanSchemaSchemaListUnion(BooleanSchemaSchemaListUnion union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
+	}
+
+	private JsonNode writeBooleanSchemaUnion(BooleanSchemaUnion union) {
+		if (union == null)
+			return null;
+		if (union.isSchema()) {
+			ObjectNode jsonValue = JsonUtil.objectNode();
+			this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
+			return jsonValue;
+		}
+		if (union.isBoolean()) {
+			return JsonUtil.booleanToJsonNode(union.asBoolean());
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Generate one reader method per indexed union type instead of inline dispatch per property. Type-alias-backed union properties call the type-based method; inline unions continue using the existing code path (to be unified in a follow-up).

Part of #1041. Unblocks the JSON Schema spec rewrite where `{Schema}` / `[Schema]` type alias properties need correct union-map/union-list reading.

## How it works

For each indexed union type (e.g., `SchemaOrBoolean = boolean|Schema`), a reader method is generated:

```java
private SchemaOrBoolean readSchemaOrBoolean(JsonNode json) {
    if (json == null) return null;
    if (json.isObject() && json.has("type")) {
        Syn1Schema node = new Syn1SchemaImpl();
        this.readSchema((ObjectNode) json, node);
        return node;
    } else if (JsonUtil.isBoolean(json)) {
        return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
    }
    return null;
}
```

Properties with type-alias-backed unions call this method:
```java
node.setNot(this.readSchemaOrBoolean(value));
node.setProperties(...); // map iteration calls readSchemaOrBoolean per value
```

Also adds `setParent(this)` to generated setters for entity and union properties, fixing parent attachment for nodes created outside factory methods.

## Test plan

- [x] All 1129 project tests pass
- [x] Synthetic snapshot compiles (117 files)
- [x] FullGeneratorTest compiles all generated files
- [x] Existing inline union properties unchanged (narrowed scope)