### PR TITLE
feat(generator): add parent awareness to union values

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/DeleteAllChildSchemasCommand.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/cmd/commands/DeleteAllChildSchemasCommand.java
@@ -67,8 +67,8 @@ public class DeleteAllChildSchemasCommand extends AbstractSchemaInhCommand {
             for (int i = 0; i < schemas.size(); i++) {
                 Schema s = schemas.get(i);
                 if (has$Ref(s)) {
-                    removeAnyOfSchema(schema, s);
                     addOldSchema(s);
+                    removeAnyOfSchema(schema, s);
                 }
             }
             if (getAnyOfSchemas(schema).isEmpty()) {
@@ -80,8 +80,8 @@ public class DeleteAllChildSchemasCommand extends AbstractSchemaInhCommand {
             for (int i = 0; i < schemas.size(); i++) {
                 Schema s = schemas.get(i);
                 if (has$Ref(s)) {
-                    removeOneOfSchema(schema, s);
                     addOldSchema(s);
+                    removeOneOfSchema(schema, s);
                 }
             }
             if (getOneOfSchemas(schema).isEmpty()) {

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi2NodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi2NodeImporter.java
@@ -44,7 +44,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedChannelBinding"), getComponentNames(components.getChannelBindings()));
             components.addChannelBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -66,7 +65,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedCorrelationID"), getComponentNames(components.getCorrelationIds()));
             components.addCorrelationId(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -80,7 +78,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessage"), getComponentNames(components.getMessages()));
             components.addMessage(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -94,7 +91,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessageBinding"), getComponentNames(components.getMessageBindings()));
             components.addMessageBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -108,7 +104,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessageTrait"), getComponentNames(components.getMessageTraits()));
             components.addMessageTrait(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -122,7 +117,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedOperationBinding"), getComponentNames(components.getOperationBindings()));
             components.addOperationBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -136,7 +130,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedOperationTrait"), getComponentNames(components.getOperationTraits()));
             components.addOperationTrait(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -150,7 +143,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedParameter"), getComponentNames(components.getParameters()));
             components.addParameter(name, (AsyncApiParameter) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -172,7 +164,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedSecurityScheme"), getComponentNames(components.getSecuritySchemes()));
             components.addSecurityScheme(name, (AsyncApiSecurityScheme) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -194,7 +185,6 @@ public class AsyncApi2NodeImporter extends ReferencedNodeImporter {
             AsyncApiComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedServerBinding"), getComponentNames(components.getServerBindings()));
             components.addServerBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi3NodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi3NodeImporter.java
@@ -73,7 +73,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedChannelBinding"), getComponentNames(components.getChannelBindings()));
             components.addChannelBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -87,7 +86,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedChannel"), getComponentNames(components.getChannels()));
             components.addChannel(name, (AsyncApi3xChannel) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -101,7 +99,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedCorrelationID"), getComponentNames(components.getCorrelationIds()));
             components.addCorrelationId(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -116,7 +113,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             Map<String, ?> externalDocs = ((AsyncApi3xComponents) components).getExternalDocs();
             String name = generateNodeName(getNameHintFromRef("ImportedExternalDocs"), getComponentNames(externalDocs));
             ((AsyncApi3xComponents) components).addExternalDoc(name, (AsyncApi3xExternalDocumentation) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -130,7 +126,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessage"), getComponentNames(components.getMessages()));
             components.addMessage(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -144,7 +139,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessageBinding"), getComponentNames(components.getMessageBindings()));
             components.addMessageBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -158,7 +152,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedMessageTrait"), getComponentNames(components.getMessageTraits()));
             components.addMessageTrait(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -173,7 +166,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             String name = generateNodeName(getNameHintFromRef("ImportedSchema"), getComponentNames(components.getSchemas()));
             // AsyncAPI 3.0 schemas are a union type, use addSchema() method
             components.addSchema(name, (AsyncApi3xMultiFormatSchema) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -187,7 +179,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedOperation"), getComponentNames(components.getOperations()));
             components.addOperation(name, (AsyncApi3xOperation) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -201,7 +192,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedOperationBinding"), getComponentNames(components.getOperationBindings()));
             components.addOperationBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -215,7 +205,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedReply"), getComponentNames(components.getReplies()));
             components.addReply(name, (AsyncApi3xOperationReply) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -229,7 +218,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedReplyAddress"), getComponentNames(components.getReplyAddresses()));
             components.addReplyAddress(name, (AsyncApi3xOperationReplyAddress) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -243,7 +231,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedOperationTrait"), getComponentNames(components.getOperationTraits()));
             components.addOperationTrait(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -257,7 +244,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedParameter"), getComponentNames(components.getParameters()));
             components.addParameter(name, (AsyncApiParameter) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -311,17 +297,14 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             if (isAvroSchema(node)) {
                 AsyncApi3xMultiFormatSchema multiFormatSchema = wrapInMultiFormatSchema(node, "avro");
                 components.addSchema(name, multiFormatSchema);
-                multiFormatSchema.attach(components);
                 setPathToImportedNode(multiFormatSchema, componentType, name);
             } else if (isProtobufSchema(node)) {
                 AsyncApi3xMultiFormatSchema multiFormatSchema = wrapInMultiFormatSchema(node, "protobuf");
                 components.addSchema(name, multiFormatSchema);
-                multiFormatSchema.attach(components);
                 setPathToImportedNode(multiFormatSchema, componentType, name);
             } else {
                 // Cast to MultiFormatSchemaSchemaUnion (AsyncApi3xSchema implements this)
                 components.addSchema(name, (MultiFormatSchemaSchemaUnion) node);
-                node.attach(components);
                 setPathToImportedNode(node, componentType, name);
             }
         }
@@ -336,7 +319,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedSecurityScheme"), getComponentNames(components.getSecuritySchemes()));
             components.addSecurityScheme(name, (AsyncApiSecurityScheme) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -350,7 +332,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedServer"), getComponentNames(components.getServers()));
             components.addServer(name, (AsyncApi3xServer) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -364,7 +345,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedServerBinding"), getComponentNames(components.getServerBindings()));
             components.addServerBinding(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -378,7 +358,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedServerVariable"), getComponentNames(components.getServerVariables()));
             components.addServerVariable(name, (AsyncApi3xServerVariable) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -392,7 +371,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
             AsyncApi3xComponents components = ensureAsyncApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedTag"), getComponentNames(components.getTags()));
             components.addTag(name, (AsyncApi3xTag) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -422,7 +400,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
 
         // Add to components
         components.addSchema(name, multiFormatSchema);
-        multiFormatSchema.attach(components);
         setPathToImportedNode(multiFormatSchema, componentType, name);
     }
 
@@ -449,7 +426,6 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
 
         // Add to components
         components.addSchema(name, multiFormatSchema);
-        multiFormatSchema.attach(components);
         setPathToImportedNode(multiFormatSchema, componentType, name);
     }
 

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/OpenApi2NodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/OpenApi2NodeImporter.java
@@ -47,7 +47,6 @@ public class OpenApi2NodeImporter extends ReferencedNodeImporter {
             }
             String name = generateNodeName(getNameHintFromRef("ImportedParameter"), params.getItemNames());
             params.addItem(name, (OpenApi20Parameter) node);
-            node.attach(params);
             setPathToImportedNode(node, collection, name);
         }
     }
@@ -74,7 +73,6 @@ public class OpenApi2NodeImporter extends ReferencedNodeImporter {
             }
             String name = generateNodeName(getNameHintFromRef("ImportedResponse"), responses.getItemNames());
             responses.addItem(name, (OpenApi20Response) node);
-            node.attach(responses);
             setPathToImportedNode(node, collection, name);
         }
     }
@@ -93,7 +91,6 @@ public class OpenApi2NodeImporter extends ReferencedNodeImporter {
             }
             String name = generateNodeName(getNameHintFromRef("ImportedSchema"), definitions.getItemNames());
             definitions.addItem(name, (OpenApi20Schema) node);
-            node.attach(definitions);
             setPathToImportedNode(node, collection, name);
         }
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/OpenApi3NodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/OpenApi3NodeImporter.java
@@ -53,7 +53,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             String name = generateNodeName(getNameHintFromRef("ImportedSchema"), getComponentNames(components.getSchemas()));
             // Cast to OpenApiSchema (OpenApi30Schema and OpenApi31Schema implement this)
             components.addSchema(name, (io.apitomy.datamodels.models.openapi.OpenApiSchema) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -67,7 +66,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedCallback"), getComponentNames(components.getCallbacks()));
             components.addCallback(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -81,7 +79,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedExample"), getComponentNames(components.getExamples()));
             components.addExample(name, (OpenApiExample) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -95,7 +92,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedHeader"), getComponentNames(components.getHeaders()));
             components.addHeader(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -109,7 +105,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedLink"), getComponentNames(components.getLinks()));
             components.addLink(name, (OpenApiLink) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -123,7 +118,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedParameter"), getComponentNames(components.getParameters()));
             components.addParameter(name, (OpenApiParameter) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -145,7 +139,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedRequestBody"), getComponentNames(components.getRequestBodies()));
             components.addRequestBody(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -159,7 +152,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedResponse"), getComponentNames(components.getResponses()));
             components.addResponse(name, node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -181,7 +173,6 @@ public class OpenApi3NodeImporter extends ReferencedNodeImporter {
             OpenApiComponents components = ensureOpenApiComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedSecurityScheme"), getComponentNames(components.getSecuritySchemes()));
             components.addSecurityScheme(name, (OpenApiSecurityScheme) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/OpenRpcNodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/OpenRpcNodeImporter.java
@@ -40,7 +40,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedSchema"), getComponentNames(components.getSchemas()));
             components.addSchema(name, (OpenRpcSchema) node);
-            node.attach(components);
             setPathToImportedNode(node, componentType, name);
         }
     }
@@ -54,7 +53,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedContentDescriptor"), getComponentNames(components.getContentDescriptors()));
             components.addContentDescriptor(name, node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }
@@ -68,7 +66,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedExample"), getComponentNames(components.getExamples()));
             components.addExample(name, (io.apitomy.datamodels.models.openrpc.OpenRpcExample) node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }
@@ -82,7 +79,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedLink"), getComponentNames(components.getLinks()));
             components.addLink(name, (OpenRpcLink) node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }
@@ -96,7 +92,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedError"), getComponentNames(components.getErrors()));
             components.addError(name, node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }
@@ -110,7 +105,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedExamplePairing"), getComponentNames(components.getExamplePairings()));
             components.addExamplePairing(name, node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }
@@ -124,7 +118,6 @@ public class OpenRpcNodeImporter extends ReferencedNodeImporter {
             OpenRpcComponents components = ensureOpenRpcComponents();
             String name = generateNodeName(getNameHintFromRef("ImportedTag"), getComponentNames(components.getTags()));
             components.addTag(name, (OpenRpcTag) node);
-            ((Node) node).attach(components);
             setPathToImportedNode((Node) node, componentType, name);
         }
     }

--- a/data-models/src/main/ts/tests/dereference.test.ts
+++ b/data-models/src/main/ts/tests/dereference.test.ts
@@ -52,7 +52,7 @@ class DereferenceTestReferenceResolver implements IReferenceResolver {
 
     private toModel(jsonNode: any, from: Node): Node {
         let rval: Node = from.emptyClone();
-        rval.attach(from.parent());
+        (rval as any)._setParent(from.parent());
         return Library.readNode(jsonNode, rval);
     }
 

--- a/data-models/src/main/ts/tests/validation.test.ts
+++ b/data-models/src/main/ts/tests/validation.test.ts
@@ -72,7 +72,7 @@ class ValidationTestReferenceResolver implements IReferenceResolver {
 
     private toModel(jsonNode: any, from: Node): Node {
         let rval: Node = from.emptyClone();
-        rval.attach(from.parent());
+        (rval as any)._setParent(from.parent());
         return Library.readNode(jsonNode, rval);
     }
 

--- a/data-models/src/test/java/io/apitomy/datamodels/refs/DereferenceTestReferenceResolver.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/refs/DereferenceTestReferenceResolver.java
@@ -77,7 +77,7 @@ public class DereferenceTestReferenceResolver implements IReferenceResolver {
 
     private Node toModel(ObjectNode jsonNode, Node from) {
         Node rval = from.emptyClone();
-        rval.attach(from.parent());
+        ((io.apitomy.datamodels.models.NodeImpl) rval)._setParent(from.parent());
         return Library.readNode(jsonNode, rval);
     }
 

--- a/data-models/src/test/java/io/apitomy/datamodels/validation/ValidationTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/validation/ValidationTest.java
@@ -193,7 +193,7 @@ public class ValidationTest implements IReferenceResolver {
                 ObjectNode resolvedContent = ReferenceUtil.resolveFragmentFromJS(content, fragment);
                 Assertions.assertNotNull(resolvedContent, "Failed to resolve fragment: " + fragment);
                 Node emptyClone = from.emptyClone();
-                emptyClone.attach(from.parent());
+                ((io.apitomy.datamodels.models.NodeImpl) emptyClone)._setParent(from.parent());
                 Node node = Library.readNode(resolvedContent, emptyClone);
                 return ResolvedReference.fromNode(node);
             }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -147,6 +147,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 javaEntity.addImport(nodeImplSource);
 
                 body.append("if (item != null) {");
+                body.append("    ((NodeImpl) item)._setParent(this);");
                 body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
                 body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
                 body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
@@ -175,6 +176,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 javaEntity.addImport(nodeImplSource);
 
                 body.append("if (item != null) {");
+                body.append("    ((NodeImpl) item)._setParent(this);");
                 body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
                 body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
                 body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
@@ -190,7 +192,12 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             method.addParameter("String", "name");
             method.setReturnType(mappedNodeType);
             BodyBuilder body = new BodyBuilder();
-            body.append("return this._items.remove(name);");
+            body.addContext("mappedNodeType", mappedNodeType);
+            body.append("${mappedNodeType} removed = this._items.remove(name);");
+            if (isEntity(property)) {
+                body.append("if (removed != null) removed.detach();");
+            }
+            body.append("return removed;");
             method.setBody(body.toString());
         }
 
@@ -200,6 +207,11 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             method.addAnnotation(Override.class);
             method.setReturnTypeVoid();
             BodyBuilder body = new BodyBuilder();
+            if (isEntity(property)) {
+                body.append("this._items.values().forEach(item -> {");
+                body.append("    if (item != null) item.detach();");
+                body.append("});");
+            }
             body.append("this._items.clear();");
             method.setBody(body.toString());
         }
@@ -230,7 +242,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             javaEntity.addImport(nodeImplSource);
 
             body.append("if (value != null) {");
-            body.append("    ((NodeImpl) value).setParent(this);");
+            body.append("    ((NodeImpl) value)._setParent(this);");
             body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
             body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("}");
@@ -241,6 +253,8 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             javaEntity.addImport(nodeImplSource);
             JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
             javaEntity.addImport(unionValueSource);
+            JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
+            javaEntity.addImport(unionValueImplSource);
 
             javaEntity.addImport(Collection.class);
             javaEntity.addImport(List.class);
@@ -248,30 +262,40 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
 
             body.append("if (value != null) {");
             body.append("    if (value.isEntity()) {");
-            body.append("        ((NodeImpl) value).setParent(this);");
+            body.append("        ((NodeImpl) value)._setParent(this);");
             body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
             body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("    } else if (value.isEntityList()) {");
+            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();");
             body.append("        for (Object entity : entityList) {");
             body.append("            if (entity != null) {");
-            body.append("                ((NodeImpl) entity).setParent(this);");
+            body.append("                ((NodeImpl) entity)._setParent(this);");
             body.append("                ((NodeImpl) entity)._setParentPropertyName(\"${propertyName}\");");
             body.append("                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);");
             body.append("            }");
             body.append("        }");
             body.append("    } else if (value.isEntityMap()) {");
+            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();");
             body.append("        Collection<String> keys = entityMap.keySet();");
             body.append("        for (String key : keys) {");
             body.append("            NodeImpl entity = (NodeImpl) entityMap.get(key);");
             body.append("            if (entity != null) {");
-            body.append("                entity.setParent(this);");
+            body.append("                entity._setParent(this);");
             body.append("                entity._setParentPropertyName(\"${propertyName}\");");
             body.append("                entity._setParentPropertyType(ParentPropertyType.map);");
             body.append("                entity._setMapPropertyName(key);");
             body.append("            }");
             body.append("        }");
+            body.append("    } else {");
+            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("    }");
             body.append("}");
         }
@@ -294,7 +318,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
         BodyBuilder body = new BodyBuilder();
         body.addContext("implClass", entityImpl.getName());
         body.append("${implClass} node = new ${implClass}();");
-        body.append("node.setParent(this);");
+        body.append("node._setParent(this);");
         body.append("return node;");
         method.setBody(body.toString());
     }
@@ -324,6 +348,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
 
                     body.append("if (value != null) {");
+                    body.append("    ((NodeImpl) value)._setParent(this);");
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
                     body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
@@ -356,6 +381,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
 
                     body.append("if (value != null) {");
+                    body.append("    ((NodeImpl) value)._setParent(this);");
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
                     body.append("}");
@@ -367,9 +393,19 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
                     javaEntity.addImport(unionValueSource);
 
-                    body.append("if (value != null && value.isEntity()) {");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
+                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
+                    javaEntity.addImport(unionValueImplSource);
+
+                    body.append("if (value != null) {");
+                    body.append("    if (value.isEntity()) {");
+                    body.append("        ((NodeImpl) value)._setParent(this);");
+                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
+                    body.append("    } else {");
+                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);");
+                    body.append("    }");
                     body.append("}");
                 }
             }
@@ -381,11 +417,24 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
     @Override
     protected void createClearMethodBody(PropertyModel property, MethodSource<?> method) {
         String fieldName = getFieldName(property);
+        PropertyType nestedType = property.getType().getNested().iterator().next();
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
-        body.append("if (this.${fieldName} != null) {");
-        body.append("    this.${fieldName}.clear();");
-        body.append("}");
+        if (nestedType.isEntityType() || nestedType.isUnion()) {
+            String valuesExpr = property.getType().isMap()
+                    ? "this." + fieldName + ".values()" : "this." + fieldName;
+            body.addContext("valuesExpr", valuesExpr);
+            body.append("if (this.${fieldName} != null) {");
+            body.append("    ${valuesExpr}.forEach(item -> {");
+            body.append("        if (item != null) item.detach();");
+            body.append("    });");
+            body.append("    this.${fieldName}.clear();");
+            body.append("}");
+        } else {
+            body.append("if (this.${fieldName} != null) {");
+            body.append("    this.${fieldName}.clear();");
+            body.append("}");
+        }
         method.setBody(body.toString());
     }
 
@@ -395,13 +444,22 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
 
-        body.append("if (this.${fieldName} != null) {");
+        PropertyType nestedType = property.getType().getNested().iterator().next();
         if (property.getType().isList()) {
-            body.append("    this.${fieldName}.remove(value);");
+            body.append("if (this.${fieldName} != null) {");
+            if (nestedType.isEntityType() || nestedType.isUnion()) {
+                body.append("    if (value != null && this.${fieldName}.remove(value)) {");
+                body.append("        value.detach();");
+                body.append("    }");
+            } else {
+                body.append("    this.${fieldName}.remove(value);");
+            }
+            body.append("}");
         } else {
+            body.append("if (this.${fieldName} != null) {");
             body.append("    this.${fieldName}.remove(name);");
+            body.append("}");
         }
-        body.append("}");
 
         method.setBody(body.toString());
     }
@@ -436,6 +494,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
 
                     body.append("if (value != null) {");
+                    body.append("    ((NodeImpl) value)._setParent(this);");
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
                     body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
@@ -472,6 +531,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
 
                     body.append("if (value != null) {");
+                    body.append("    ((NodeImpl) value)._setParent(this);");
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
                     body.append("}");
@@ -483,9 +543,19 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
                     javaEntity.addImport(unionValueSource);
 
-                    body.append("if (value != null && value.isEntity()) {");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
+                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
+                    javaEntity.addImport(unionValueImplSource);
+
+                    body.append("if (value != null) {");
+                    body.append("    if (value.isEntity()) {");
+                    body.append("        ((NodeImpl) value)._setParent(this);");
+                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
+                    body.append("    } else {");
+                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);");
+                    body.append("    }");
                     body.append("}");
                 }
             }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -637,8 +637,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                 body.append("        ObjectNode object = JsonUtil.consumeObjectProperty(json, name);");
                 body.append("        if (object != null) {");
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
-                body.append("            this.${readMethodName}(object, model);");
                 body.append("            node.${addMethodName}(name, model);");
+                body.append("            this.${readMethodName}(object, model);");
                 body.append("        }");
                 body.append("    });");
                 body.append("}");
@@ -695,8 +695,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                 body.append("        ObjectNode object = JsonUtil.consumeObjectProperty(json, name);");
                 body.append("        if (object != null) {");
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
-                body.append("            this.${readMethodName}(object, model);");
                 body.append("            node.${addMethodName}(name, model);");
+                body.append("            this.${readMethodName}(object, model);");
                 body.append("        }");
                 body.append("    });");
                 body.append("}");
@@ -808,8 +808,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                 body.append("    if (objects != null) {");
                 body.append("        objects.forEach(object -> {");
                 body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
-                body.append("            this.${readMethodName}(object, model);");
                 body.append("            node.${addMethodName}(model);");
+                body.append("            this.${readMethodName}(object, model);");
                 body.append("        });");
                 body.append("    }");
                 body.append("}");
@@ -862,8 +862,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                 body.append("        ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);");
                 body.append("        if (mapValue != null) {");
                 body.append("            ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
-                body.append("            this.${readMethodName}(mapValue, model);");
                 body.append("            node.${addMethodName}(name, model);");
+                body.append("            this.${readMethodName}(mapValue, model);");
                 body.append("        }");
                 body.append("    });");
                 body.append("}");
@@ -1058,6 +1058,8 @@ public class CreateReadersStage extends AbstractJavaStage {
                     readerClassSource.addImport(JsonNode.class);
                     readerClassSource.addImport(List.class);
                     readerClassSource.addImport(ArrayList.class);
+                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
+                    readerClassSource.addImport(nodeImplSource);
 
                     body.addContext("unionValueInterfaceName", unionValueInterfaceName);
                     body.addContext("unionValueClassName", unionValueClassName);
@@ -1073,6 +1075,7 @@ public class CreateReadersStage extends AbstractJavaStage {
                     body.append("    array.forEach(item -> {");
                     body.append("        ObjectNode object = JsonUtil.toObject(item);");
                     body.append("        ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
+                    body.append("        ((NodeImpl) model)._setParent(node);");
                     body.append("        this.${readMethodName}(object, model);");
                     body.append("        models.add(model);");
                     body.append("    });");
@@ -1208,8 +1211,8 @@ public class CreateReadersStage extends AbstractJavaStage {
 
                     body.append("    ObjectNode object = JsonUtil.toObject(value);");
                     body.append("    ${propertyEntityType} model = (${propertyEntityType}) node.${createMethodName}();");
-                    body.append("    ${readMethodName}(object, model);");
                     body.append("    node.${addMethodName}(model);");
+                    body.append("    ${readMethodName}(object, model);");
                     body.append("}");
                 } else {
                     warn("UNION LIST property '" + property.getName() + "' not read (unsupported union subtype) for entity: " + entityModel.fullyQualifiedName());
@@ -1339,8 +1342,8 @@ public class CreateReadersStage extends AbstractJavaStage {
 
                             body.append("    ObjectNode object = JsonUtil.toObject(value);");
                             body.append("    ${propertyEntityType} model = (${propertyEntityType}) node.${createMethodName}();");
-                            body.append("    ${readMethodName}(object, model);");
                             body.append("    node.${addMethodName}(key, model);");
+                            body.append("    ${readMethodName}(object, model);");
                             body.append("}");
                         }
                     }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/Any.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/Any.java
@@ -1,7 +1,61 @@
 package io.apitomy.umg.base;
 
+/**
+ * Common supertype for all tree values — both {@link Node} (entities) and
+ * {@link io.apitomy.umg.base.union.Union} (union values including primitives).
+ * <p>
+ * <b>Parent-child relationships:</b>
+ * <ul>
+ *   <li>Every value in the tree has at most one parent (a {@link Node}).</li>
+ *   <li>Parent and property metadata are set automatically by generated setters,
+ *       collection add methods, and factory methods ({@code createXxx()}).</li>
+ *   <li>Parent and property metadata are cleared automatically by generated
+ *       collection remove/clear methods, and by {@link #detach()}.</li>
+ *   <li>There is no need to manage parent relationships manually in normal usage.</li>
+ * </ul>
+ * <p>
+ * <b>Attachment state:</b>
+ * <ul>
+ *   <li>A value is <em>attached</em> if it has a non-null parent ({@link #isAttached()}).
+ *       Note: this only checks for an immediate parent, not whether the value is
+ *       reachable from a root.</li>
+ *   <li>A value is <em>fully attached</em> (reachable from a root) if {@link #root()}
+ *       returns non-null.</li>
+ *   <li>Calling {@link #detach()} clears the parent and all property metadata,
+ *       making the value unattached.</li>
+ * </ul>
+ * <p>
+ * <b>Root nodes:</b> A {@link RootCapable} node is the root of the tree when
+ * {@link RootCapable#isRoot()} returns {@code true} (i.e., it was created with a
+ * {@code ModelType}). The root's {@link #parent()} is {@code null}, and
+ * {@link #root()} returns itself.
+ */
 public interface Any {
 
     boolean isNode();
+
+    Node parent();
+
+    String parentPropertyName();
+
+    ParentPropertyType parentPropertyType();
+
+    String mapPropertyName();
+
+    RootCapable root();
+
+    boolean isAttached();
+
+    /**
+     * Detaches this value from its parent by clearing the parent reference
+     * and all property metadata (parentPropertyName, parentPropertyType,
+     * mapPropertyName). After calling this method, {@link #isAttached()}
+     * returns {@code false} and {@link #root()} returns {@code null}.
+     * <p>
+     * Note: this does NOT remove the value from the parent's collection
+     * or property. The caller is responsible for that, or should use the
+     * generated remove/clear methods which call detach automatically.
+     */
+    void detach();
 
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/Node.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/Node.java
@@ -5,25 +5,27 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+/**
+ * A tree node representing an entity in the data model. Extends {@link Any}
+ * (which provides parent/metadata/root access) and {@link Visitable} (for
+ * the visitor pattern).
+ * <p>
+ * Nodes form a tree structure where each node has at most one parent.
+ * Parent relationships are managed automatically by generated setters
+ * and collection methods — see {@link Any} for details.
+ */
 public interface Node extends Any, Visitable {
 
-    public int modelId();
-    public RootCapable root();
-    public Node parent();
-    public String parentPropertyName();
-    public ParentPropertyType parentPropertyType();
-    public String mapPropertyName();
-    public Object getNodeAttribute(String attributeName);
-    public void setNodeAttribute(String attributeName, Object attributeValue);
-    public Collection<String> getNodeAttributeNames();
-    public void clearNodeAttributes();
-    public void addExtraProperty(String key, JsonNode value);
-    public JsonNode removeExtraProperty(String name);
-    public boolean hasExtraProperties();
-    public List<String> getExtraPropertyNames();
-    public JsonNode getExtraProperty(String name);
-    public boolean isAttached();
-    public void attach(Node parent);
-    public Node emptyClone();
+    int modelId();
+    Object getNodeAttribute(String attributeName);
+    void setNodeAttribute(String attributeName, Object attributeValue);
+    Collection<String> getNodeAttributeNames();
+    void clearNodeAttributes();
+    void addExtraProperty(String key, JsonNode value);
+    JsonNode removeExtraProperty(String name);
+    boolean hasExtraProperties();
+    List<String> getExtraPropertyNames();
+    JsonNode getExtraProperty(String name);
+    Node emptyClone();
 
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
@@ -32,7 +32,7 @@ public abstract class NodeImpl implements Node {
         if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
             return (RootCapable) this;
         }
-        return this._parent.root();
+        return this._parent != null ? this._parent.root() : null;
     }
 
     @Override
@@ -55,7 +55,7 @@ public abstract class NodeImpl implements Node {
         return this._mapPropertyName;
     }
 
-    public void setParent(Node parent) {
+    public void _setParent(Node parent) {
         this._parent = parent;
     }
 
@@ -69,6 +69,14 @@ public abstract class NodeImpl implements Node {
 
     public void _setMapPropertyName(String name) {
         this._mapPropertyName = name;
+    }
+
+    @Override
+    public void detach() {
+        this._parent = null;
+        this._parentPropertyName = null;
+        this._parentPropertyType = null;
+        this._mapPropertyName = null;
     }
 
     @Override
@@ -148,17 +156,7 @@ public abstract class NodeImpl implements Node {
 
     @Override
     public boolean isAttached() {
-        if (_parent == null) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public void attach(Node parent) {
-        if (!parent.isAttached())
-            throw new IllegalArgumentException("Target parent node (method argument) is not itself attached.");
-        this.setParent(parent);
+        return _parent != null;
     }
 
     /*

--- a/generator/src/main/resources/base/io/apitomy/umg/base/union/UnionValueImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/union/UnionValueImpl.java
@@ -1,6 +1,9 @@
 package io.apitomy.umg.base.union;
 
 import io.apitomy.umg.base.ModelType;
+import io.apitomy.umg.base.Node;
+import io.apitomy.umg.base.ParentPropertyType;
+import io.apitomy.umg.base.RootCapable;
 import io.apitomy.umg.base.visitors.Visitor;
 
 /**
@@ -11,6 +14,10 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
 
     private T value;
     private ModelType _modelType;
+    private Node _parent;
+    private String _parentPropertyName;
+    private ParentPropertyType _parentPropertyType;
+    private String _mapPropertyName;
 
     public UnionValueImpl() {
     }
@@ -30,6 +37,55 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
 
     public ModelType modelType() {
         return this._modelType;
+    }
+
+    @Override
+    public Node parent() {
+        return this._parent;
+    }
+
+    @Override
+    public String parentPropertyName() {
+        return this._parentPropertyName;
+    }
+
+    @Override
+    public ParentPropertyType parentPropertyType() {
+        return this._parentPropertyType;
+    }
+
+    public void _setParent(Node parent) {
+        this._parent = parent;
+    }
+
+    public void _setParentPropertyName(String name) {
+        this._parentPropertyName = name;
+    }
+
+    public void _setParentPropertyType(ParentPropertyType type) {
+        this._parentPropertyType = type;
+    }
+
+    @Override
+    public String mapPropertyName() {
+        return this._mapPropertyName;
+    }
+
+    public void _setMapPropertyName(String name) {
+        this._mapPropertyName = name;
+    }
+
+    @Override
+    public RootCapable root() {
+        return this._parent != null ? this._parent.root() : null;
+    }
+
+    @Override
+    public void detach() {
+        this._parent = null;
+        this._parentPropertyName = null;
+        this._parentPropertyType = null;
+        this._mapPropertyName = null;
     }
 
     @Override
@@ -60,6 +116,11 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
     @Override
     public boolean isNode() {
         return false;
+    }
+
+    @Override
+    public boolean isAttached() {
+        return this._parent != null;
     }
 
     @Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Any.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Any.java
@@ -1,7 +1,62 @@
 package io.test.synthetic;
 
+/**
+ * Common supertype for all tree values — both {@link Node} (entities) and
+ * {@link io.apitomy.umg.base.union.Union} (union values including primitives).
+ * <p>
+ * <b>Parent-child relationships:</b>
+ * <ul>
+ * <li>Every value in the tree has at most one parent (a {@link Node}).</li>
+ * <li>Parent and property metadata are set automatically by generated setters,
+ * collection add methods, and factory methods ({@code createXxx()}).</li>
+ * <li>Parent and property metadata are cleared automatically by generated
+ * collection remove/clear methods, and by {@link #detach()}.</li>
+ * <li>There is no need to manage parent relationships manually in normal
+ * usage.</li>
+ * </ul>
+ * <p>
+ * <b>Attachment state:</b>
+ * <ul>
+ * <li>A value is <em>attached</em> if it has a non-null parent
+ * ({@link #isAttached()}). Note: this only checks for an immediate parent, not
+ * whether the value is reachable from a root.</li>
+ * <li>A value is <em>fully attached</em> (reachable from a root) if
+ * {@link #root()} returns non-null.</li>
+ * <li>Calling {@link #detach()} clears the parent and all property metadata,
+ * making the value unattached.</li>
+ * </ul>
+ * <p>
+ * <b>Root nodes:</b> A {@link RootCapable} node is the root of the tree when
+ * {@link RootCapable#isRoot()} returns {@code true} (i.e., it was created with
+ * a {@code ModelType}). The root's {@link #parent()} is {@code null}, and
+ * {@link #root()} returns itself.
+ */
 public interface Any {
 
 	boolean isNode();
+
+	Node parent();
+
+	String parentPropertyName();
+
+	ParentPropertyType parentPropertyType();
+
+	String mapPropertyName();
+
+	RootCapable root();
+
+	boolean isAttached();
+
+	/**
+	 * Detaches this value from its parent by clearing the parent reference and all
+	 * property metadata (parentPropertyName, parentPropertyType, mapPropertyName).
+	 * After calling this method, {@link #isAttached()} returns {@code false} and
+	 * {@link #root()} returns {@code null}.
+	 * <p>
+	 * Note: this does NOT remove the value from the parent's collection or
+	 * property. The caller is responsible for that, or should use the generated
+	 * remove/clear methods which call detach automatically.
+	 */
+	void detach();
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Node.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/Node.java
@@ -4,25 +4,27 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * A tree node representing an entity in the data model. Extends {@link Any}
+ * (which provides parent/metadata/root access) and {@link Visitable} (for the
+ * visitor pattern).
+ * <p>
+ * Nodes form a tree structure where each node has at most one parent. Parent
+ * relationships are managed automatically by generated setters and collection
+ * methods — see {@link Any} for details.
+ */
 public interface Node extends Any, Visitable {
 
-	public int modelId();
-	public RootCapable root();
-	public Node parent();
-	public String parentPropertyName();
-	public ParentPropertyType parentPropertyType();
-	public String mapPropertyName();
-	public Object getNodeAttribute(String attributeName);
-	public void setNodeAttribute(String attributeName, Object attributeValue);
-	public Collection<String> getNodeAttributeNames();
-	public void clearNodeAttributes();
-	public void addExtraProperty(String key, JsonNode value);
-	public JsonNode removeExtraProperty(String name);
-	public boolean hasExtraProperties();
-	public List<String> getExtraPropertyNames();
-	public JsonNode getExtraProperty(String name);
-	public boolean isAttached();
-	public void attach(Node parent);
-	public Node emptyClone();
+	int modelId();
+	Object getNodeAttribute(String attributeName);
+	void setNodeAttribute(String attributeName, Object attributeValue);
+	Collection<String> getNodeAttributeNames();
+	void clearNodeAttributes();
+	void addExtraProperty(String key, JsonNode value);
+	JsonNode removeExtraProperty(String name);
+	boolean hasExtraProperties();
+	List<String> getExtraPropertyNames();
+	JsonNode getExtraProperty(String name);
+	Node emptyClone();
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
@@ -31,7 +31,7 @@ public abstract class NodeImpl implements Node {
 		if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
 			return (RootCapable) this;
 		}
-		return this._parent.root();
+		return this._parent != null ? this._parent.root() : null;
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public abstract class NodeImpl implements Node {
 		return this._mapPropertyName;
 	}
 
-	public void setParent(Node parent) {
+	public void _setParent(Node parent) {
 		this._parent = parent;
 	}
 
@@ -68,6 +68,14 @@ public abstract class NodeImpl implements Node {
 
 	public void _setMapPropertyName(String name) {
 		this._mapPropertyName = name;
+	}
+
+	@Override
+	public void detach() {
+		this._parent = null;
+		this._parentPropertyName = null;
+		this._parentPropertyType = null;
+		this._mapPropertyName = null;
 	}
 
 	@Override
@@ -147,17 +155,7 @@ public abstract class NodeImpl implements Node {
 
 	@Override
 	public boolean isAttached() {
-		if (_parent == null) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public void attach(Node parent) {
-		if (!parent.isAttached())
-			throw new IllegalArgumentException("Target parent node (method argument) is not itself attached.");
-		this.setParent(parent);
+		return _parent != null;
 	}
 
 	/*

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValueImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/union/UnionValueImpl.java
@@ -1,6 +1,9 @@
 package io.test.synthetic.union;
 
 import io.test.synthetic.ModelType;
+import io.test.synthetic.Node;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.RootCapable;
 import io.test.synthetic.visitors.Visitor;
 
 /**
@@ -12,6 +15,10 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
 
 	private T value;
 	private ModelType _modelType;
+	private Node _parent;
+	private String _parentPropertyName;
+	private ParentPropertyType _parentPropertyType;
+	private String _mapPropertyName;
 
 	public UnionValueImpl() {
 	}
@@ -31,6 +38,55 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
 
 	public ModelType modelType() {
 		return this._modelType;
+	}
+
+	@Override
+	public Node parent() {
+		return this._parent;
+	}
+
+	@Override
+	public String parentPropertyName() {
+		return this._parentPropertyName;
+	}
+
+	@Override
+	public ParentPropertyType parentPropertyType() {
+		return this._parentPropertyType;
+	}
+
+	public void _setParent(Node parent) {
+		this._parent = parent;
+	}
+
+	public void _setParentPropertyName(String name) {
+		this._parentPropertyName = name;
+	}
+
+	public void _setParentPropertyType(ParentPropertyType type) {
+		this._parentPropertyType = type;
+	}
+
+	@Override
+	public String mapPropertyName() {
+		return this._mapPropertyName;
+	}
+
+	public void _setMapPropertyName(String name) {
+		this._mapPropertyName = name;
+	}
+
+	@Override
+	public RootCapable root() {
+		return this._parent != null ? this._parent.root() : null;
+	}
+
+	@Override
+	public void detach() {
+		this._parent = null;
+		this._parentPropertyName = null;
+		this._parentPropertyType = null;
+		this._mapPropertyName = null;
 	}
 
 	@Override
@@ -61,6 +117,11 @@ public abstract class UnionValueImpl<T> implements UnionValue<T>, Union {
 	@Override
 	public boolean isNode() {
 		return false;
+	}
+
+	@Override
+	public boolean isAttached() {
+		return this._parent != null;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -44,7 +44,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("info");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -53,14 +53,14 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public Syn1Info createInfo() {
 		Syn1InfoImpl node = new Syn1InfoImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
 	@Override
 	public Syn1Item createItem() {
 		Syn1ItemImpl node = new Syn1ItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -76,6 +76,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		}
 		this.items.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("items");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -84,6 +85,10 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
+			this.items.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.items.clear();
 		}
 	}
@@ -91,7 +96,9 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public void removeItem(SynItem value) {
 		if (this.items != null) {
-			this.items.remove(value);
+			if (value != null && this.items.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -104,6 +111,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("items");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -138,7 +146,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("additionalSchema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -37,7 +37,7 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("contact");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -46,7 +46,7 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	@Override
 	public Syn1Contact createContact() {
 		Syn1ContactImpl node = new Syn1ContactImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -8,6 +8,7 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -110,7 +111,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("schema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -119,7 +120,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	@Override
 	public Syn1Schema createSchema() {
 		Syn1SchemaImpl node = new Syn1SchemaImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -143,30 +144,40 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value).setParent(this);
+				((NodeImpl) value)._setParent(this);
 				((NodeImpl) value)._setParentPropertyName("defaultValue");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity).setParent(this);
+						((NodeImpl) entity)._setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("defaultValue");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
-						entity.setParent(this);
+						entity._setParent(this);
 						entity._setParentPropertyName("defaultValue");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);
 					}
 				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -54,7 +54,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	@Override
 	public Syn1Item createItem() {
 		Syn1ItemImpl node = new Syn1ItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -70,6 +70,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 		}
 		this.parameters.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("parameters");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -78,6 +79,10 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
+			this.parameters.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.parameters.clear();
 		}
 	}
@@ -85,7 +90,9 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	@Override
 	public void removeParameter(SynItem value) {
 		if (this.parameters != null) {
-			this.parameters.remove(value);
+			if (value != null && this.parameters.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -98,6 +105,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("parameters");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -49,7 +49,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("get");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -58,7 +58,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	@Override
 	public Syn1Operation createOperation() {
 		Syn1OperationImpl node = new Syn1OperationImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -71,7 +71,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("put");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -86,7 +86,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("post");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -41,6 +41,7 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 	public void addItem(String name, SynPathItem item) {
 		this._items.put(name, item);
 		if (item != null) {
+			((NodeImpl) item)._setParent(this);
 			((NodeImpl) item)._setParentPropertyName(null);
 			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) item)._setMapPropertyName(name);
@@ -51,6 +52,7 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 	public void insertItem(String name, SynPathItem item, int atIndex) {
 		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
 		if (item != null) {
+			((NodeImpl) item)._setParent(this);
 			((NodeImpl) item)._setParentPropertyName(null);
 			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) item)._setMapPropertyName(name);
@@ -59,18 +61,25 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 
 	@Override
 	public SynPathItem removeItem(String name) {
-		return this._items.remove(name);
+		SynPathItem removed = this._items.remove(name);
+		if (removed != null)
+			removed.detach();
+		return removed;
 	}
 
 	@Override
 	public void clearItems() {
+		this._items.values().forEach(item -> {
+			if (item != null)
+				item.detach();
+		});
 		this._items.clear();
 	}
 
 	@Override
 	public Syn1PathItem createPathItem() {
 		Syn1PathItemImpl node = new Syn1PathItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -11,6 +11,7 @@ import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -69,30 +70,40 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value).setParent(this);
+				((NodeImpl) value)._setParent(this);
 				((NodeImpl) value)._setParentPropertyName("items");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity).setParent(this);
+						((NodeImpl) entity)._setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("items");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
-						entity.setParent(this);
+						entity._setParent(this);
 						entity._setParentPropertyName("items");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);
 					}
 				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 			}
 		}
 	}
@@ -100,7 +111,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public Syn1Schema createSchema() {
 		Syn1SchemaImpl node = new Syn1SchemaImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -125,6 +136,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
+			this.properties.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.properties.clear();
 		}
 	}
@@ -162,15 +177,26 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf.add(value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("allOf");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("allOf");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
+			this.allOf.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.allOf.clear();
 		}
 	}
@@ -178,7 +204,9 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void removeAllOf(BooleanSchemaUnion value) {
 		if (this.allOf != null) {
-			this.allOf.remove(value);
+			if (value != null && this.allOf.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -190,9 +218,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		} else {
 			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("allOf");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("allOf");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
@@ -217,6 +252,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
+			this.definitions.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.definitions.clear();
 		}
 	}
@@ -255,6 +294,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.nestedSchemas.put(name, value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -264,6 +304,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
+			this.nestedSchemas.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.nestedSchemas.clear();
 		}
 	}
@@ -284,6 +328,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -302,6 +347,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("composedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -310,6 +356,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
+			this.composedSchemas.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.composedSchemas.clear();
 		}
 	}
@@ -317,7 +367,9 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void removeComposedSchema(SchemaOrBoolean value) {
 		if (this.composedSchemas != null) {
-			this.composedSchemas.remove(value);
+			if (value != null && this.composedSchemas.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -330,6 +382,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("composedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -3,6 +3,7 @@ package io.test.synthetic.v1.io;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
+import io.test.synthetic.NodeImpl;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
@@ -46,8 +47,8 @@ public class Syn1ModelReader implements ModelReader {
 			if (objects != null) {
 				objects.forEach(object -> {
 					Syn1Item model = (Syn1Item) node.createItem();
-					this.readItem(object, model);
 					node.addItem(model);
+					this.readItem(object, model);
 				});
 			}
 		}
@@ -209,6 +210,7 @@ public class Syn1ModelReader implements ModelReader {
 					array.forEach(item -> {
 						ObjectNode object = JsonUtil.toObject(item);
 						Syn1Schema model = (Syn1Schema) node.createSchema();
+						((NodeImpl) model)._setParent(node);
 						this.readSchema(object, model);
 						models.add(model);
 					});
@@ -234,8 +236,8 @@ public class Syn1ModelReader implements ModelReader {
 						if (JsonUtil.isObject(value)) {
 							ObjectNode object = JsonUtil.toObject(value);
 							Syn1Schema model = (Syn1Schema) node.createSchema();
-							readSchema(object, model);
 							node.addProperty(key, model);
+							readSchema(object, model);
 						} else if (JsonUtil.isBoolean(value)) {
 							Boolean pValue = JsonUtil.toBoolean(value);
 							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -252,8 +254,8 @@ public class Syn1ModelReader implements ModelReader {
 					if (JsonUtil.isObject(value)) {
 						ObjectNode object = JsonUtil.toObject(value);
 						Syn1Schema model = (Syn1Schema) node.createSchema();
-						readSchema(object, model);
 						node.addAllOf(model);
+						readSchema(object, model);
 					} else if (JsonUtil.isBoolean(value)) {
 						Boolean pValue = JsonUtil.toBoolean(value);
 						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -272,8 +274,8 @@ public class Syn1ModelReader implements ModelReader {
 						if (JsonUtil.isObject(value)) {
 							ObjectNode object = JsonUtil.toObject(value);
 							Syn1Schema model = (Syn1Schema) node.createSchema();
-							readSchema(object, model);
 							node.addDefinition(key, model);
+							readSchema(object, model);
 						} else if (JsonUtil.isBoolean(value)) {
 							Boolean pValue = JsonUtil.toBoolean(value);
 							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -335,8 +337,8 @@ public class Syn1ModelReader implements ModelReader {
 				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
 				if (object != null) {
 					Syn1PathItem model = (Syn1PathItem) node.createPathItem();
-					this.readPathItem(object, model);
 					node.addItem(name, model);
+					this.readPathItem(object, model);
 				}
 			});
 		}
@@ -408,8 +410,8 @@ public class Syn1ModelReader implements ModelReader {
 			if (objects != null) {
 				objects.forEach(object -> {
 					Syn1Item model = (Syn1Item) node.createItem();
-					this.readItem(object, model);
 					node.addParameter(model);
+					this.readItem(object, model);
 				});
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -45,7 +45,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("info");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -54,14 +54,14 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public Syn2Info createInfo() {
 		Syn2InfoImpl node = new Syn2InfoImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
 	@Override
 	public Syn2Item createItem() {
 		Syn2ItemImpl node = new Syn2ItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -77,6 +77,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 		this.items.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("items");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -85,6 +86,10 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
+			this.items.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.items.clear();
 		}
 	}
@@ -92,7 +97,9 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void removeItem(SynItem value) {
 		if (this.items != null) {
-			this.items.remove(value);
+			if (value != null && this.items.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -105,6 +112,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("items");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -133,7 +141,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public Syn2PathItem createPathItem() {
 		Syn2PathItemImpl node = new Syn2PathItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -149,6 +157,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 		this.webhooks.put(name, value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("webhooks");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -158,6 +167,10 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void clearWebhooks() {
 		if (this.webhooks != null) {
+			this.webhooks.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.webhooks.clear();
 		}
 	}
@@ -178,6 +191,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("webhooks");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -193,7 +207,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("additionalSchema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -38,7 +38,7 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("contact");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -47,7 +47,7 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	@Override
 	public Syn2Contact createContact() {
 		Syn2ContactImpl node = new Syn2ContactImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -8,6 +8,7 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -111,7 +112,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("schema");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -120,7 +121,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	@Override
 	public Syn2Schema createSchema() {
 		Syn2SchemaImpl node = new Syn2SchemaImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -144,30 +145,40 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value).setParent(this);
+				((NodeImpl) value)._setParent(this);
 				((NodeImpl) value)._setParentPropertyName("defaultValue");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity).setParent(this);
+						((NodeImpl) entity)._setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("defaultValue");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
-						entity.setParent(this);
+						entity._setParent(this);
 						entity._setParentPropertyName("defaultValue");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);
 					}
 				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -54,7 +54,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	@Override
 	public Syn2Item createItem() {
 		Syn2ItemImpl node = new Syn2ItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -70,6 +70,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 		}
 		this.parameters.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("parameters");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -78,6 +79,10 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
+			this.parameters.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.parameters.clear();
 		}
 	}
@@ -85,7 +90,9 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	@Override
 	public void removeParameter(SynItem value) {
 		if (this.parameters != null) {
-			this.parameters.remove(value);
+			if (value != null && this.parameters.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -98,6 +105,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("parameters");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -50,7 +50,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("get");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -59,7 +59,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	@Override
 	public Syn2Operation createOperation() {
 		Syn2OperationImpl node = new Syn2OperationImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -72,7 +72,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("put");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -87,7 +87,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("post");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}
@@ -102,7 +102,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setDelete(Syn2Operation value) {
 		this.delete = value;
 		if (value != null) {
-			((NodeImpl) value).setParent(this);
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("delete");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -41,6 +41,7 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 	public void addItem(String name, SynPathItem item) {
 		this._items.put(name, item);
 		if (item != null) {
+			((NodeImpl) item)._setParent(this);
 			((NodeImpl) item)._setParentPropertyName(null);
 			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) item)._setMapPropertyName(name);
@@ -51,6 +52,7 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 	public void insertItem(String name, SynPathItem item, int atIndex) {
 		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
 		if (item != null) {
+			((NodeImpl) item)._setParent(this);
 			((NodeImpl) item)._setParentPropertyName(null);
 			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) item)._setMapPropertyName(name);
@@ -59,18 +61,25 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 
 	@Override
 	public SynPathItem removeItem(String name) {
-		return this._items.remove(name);
+		SynPathItem removed = this._items.remove(name);
+		if (removed != null)
+			removed.detach();
+		return removed;
 	}
 
 	@Override
 	public void clearItems() {
+		this._items.values().forEach(item -> {
+			if (item != null)
+				item.detach();
+		});
 		this._items.clear();
 	}
 
 	@Override
 	public Syn2PathItem createPathItem() {
 		Syn2PathItemImpl node = new Syn2PathItemImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -11,6 +11,7 @@ import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
 import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -69,30 +70,40 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value).setParent(this);
+				((NodeImpl) value)._setParent(this);
 				((NodeImpl) value)._setParentPropertyName("items");
 				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity).setParent(this);
+						((NodeImpl) entity)._setParent(this);
 						((NodeImpl) entity)._setParentPropertyName("items");
 						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
 					NodeImpl entity = (NodeImpl) entityMap.get(key);
 					if (entity != null) {
-						entity.setParent(this);
+						entity._setParent(this);
 						entity._setParentPropertyName("items");
 						entity._setParentPropertyType(ParentPropertyType.map);
 						entity._setMapPropertyName(key);
 					}
 				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("items");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
 			}
 		}
 	}
@@ -100,7 +111,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public Syn2Schema createSchema() {
 		Syn2SchemaImpl node = new Syn2SchemaImpl();
-		node.setParent(this);
+		node._setParent(this);
 		return node;
 	}
 
@@ -125,6 +136,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
+			this.properties.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.properties.clear();
 		}
 	}
@@ -162,15 +177,26 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf.add(value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("allOf");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("allOf");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
+			this.allOf.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.allOf.clear();
 		}
 	}
@@ -178,7 +204,9 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void removeAllOf(BooleanSchemaUnion value) {
 		if (this.allOf != null) {
-			this.allOf.remove(value);
+			if (value != null && this.allOf.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -190,9 +218,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		} else {
 			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("allOf");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("allOf");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
@@ -217,6 +252,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
+			this.definitions.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.definitions.clear();
 		}
 	}
@@ -255,6 +294,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.nestedSchemas.put(name, value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -264,6 +304,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
+			this.nestedSchemas.values().forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.nestedSchemas.clear();
 		}
 	}
@@ -284,6 +328,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -302,6 +347,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("composedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}
@@ -310,6 +356,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
+			this.composedSchemas.forEach(item -> {
+				if (item != null)
+					item.detach();
+			});
 			this.composedSchemas.clear();
 		}
 	}
@@ -317,7 +367,9 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void removeComposedSchema(SchemaOrBoolean value) {
 		if (this.composedSchemas != null) {
-			this.composedSchemas.remove(value);
+			if (value != null && this.composedSchemas.remove(value)) {
+				value.detach();
+			}
 		}
 	}
 
@@ -330,6 +382,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
+			((NodeImpl) value)._setParent(this);
 			((NodeImpl) value)._setParentPropertyName("composedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -3,6 +3,7 @@ package io.test.synthetic.v2.io;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
+import io.test.synthetic.NodeImpl;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
@@ -46,8 +47,8 @@ public class Syn2ModelReader implements ModelReader {
 			if (objects != null) {
 				objects.forEach(object -> {
 					Syn2Item model = (Syn2Item) node.createItem();
-					this.readItem(object, model);
 					node.addItem(model);
+					this.readItem(object, model);
 				});
 			}
 		}
@@ -65,8 +66,8 @@ public class Syn2ModelReader implements ModelReader {
 				ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);
 				if (mapValue != null) {
 					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
-					this.readPathItem(mapValue, model);
 					node.addWebhook(name, model);
+					this.readPathItem(mapValue, model);
 				}
 			});
 		}
@@ -228,6 +229,7 @@ public class Syn2ModelReader implements ModelReader {
 					array.forEach(item -> {
 						ObjectNode object = JsonUtil.toObject(item);
 						Syn2Schema model = (Syn2Schema) node.createSchema();
+						((NodeImpl) model)._setParent(node);
 						this.readSchema(object, model);
 						models.add(model);
 					});
@@ -253,8 +255,8 @@ public class Syn2ModelReader implements ModelReader {
 						if (JsonUtil.isObject(value)) {
 							ObjectNode object = JsonUtil.toObject(value);
 							Syn2Schema model = (Syn2Schema) node.createSchema();
-							readSchema(object, model);
 							node.addProperty(key, model);
+							readSchema(object, model);
 						} else if (JsonUtil.isBoolean(value)) {
 							Boolean pValue = JsonUtil.toBoolean(value);
 							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -271,8 +273,8 @@ public class Syn2ModelReader implements ModelReader {
 					if (JsonUtil.isObject(value)) {
 						ObjectNode object = JsonUtil.toObject(value);
 						Syn2Schema model = (Syn2Schema) node.createSchema();
-						readSchema(object, model);
 						node.addAllOf(model);
+						readSchema(object, model);
 					} else if (JsonUtil.isBoolean(value)) {
 						Boolean pValue = JsonUtil.toBoolean(value);
 						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -291,8 +293,8 @@ public class Syn2ModelReader implements ModelReader {
 						if (JsonUtil.isObject(value)) {
 							ObjectNode object = JsonUtil.toObject(value);
 							Syn2Schema model = (Syn2Schema) node.createSchema();
-							readSchema(object, model);
 							node.addDefinition(key, model);
+							readSchema(object, model);
 						} else if (JsonUtil.isBoolean(value)) {
 							Boolean pValue = JsonUtil.toBoolean(value);
 							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
@@ -354,8 +356,8 @@ public class Syn2ModelReader implements ModelReader {
 				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
 				if (object != null) {
 					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
-					this.readPathItem(object, model);
 					node.addItem(name, model);
+					this.readPathItem(object, model);
 				}
 			});
 		}
@@ -434,8 +436,8 @@ public class Syn2ModelReader implements ModelReader {
 			if (objects != null) {
 				objects.forEach(object -> {
 					Syn2Item model = (Syn2Item) node.createItem();
-					this.readItem(object, model);
 					node.addParameter(model);
+					this.readItem(object, model);
 				});
 			}
 		}


### PR DESCRIPTION
## Summary

Move parent/metadata to the `Any` interface so ALL values in the tree (including non-entity union values like `BooleanUnionValue`) track their parent node. This fixes 57 `NodePath` resolution failures where union values had `_parent == null`.

Part of #1041. Unblocks the JSON Schema spec rewrite.

## Changes

- `Any.java` — add `parent()`, `parentPropertyName()`, `parentPropertyType()` with default null
- `UnionValueImpl.java` — add `_parent`, `_parentPropertyName`, `_parentPropertyType` fields + setters
- `CreateImplMethodsStage` — generated setters and collection add methods now set parent/metadata on all union values (not just entity variants)

## How it works

Before: `node.setNot(booleanUnionValue)` → setter checks `isEntity()` → false → no parent set → `booleanUnionValue.parent()` returns null

After: `node.setNot(booleanUnionValue)` → setter checks `isEntity()` → false → falls to else branch → sets `_setParent(this)`, `_setParentPropertyName("not")` → `booleanUnionValue.parent()` returns the owning entity

## Test plan

- [x] All 1129 project tests pass
- [x] Synthetic snapshot compiles
- [x] FullGeneratorTest compiles all generated files