### PR TITLE
docs: update documentation for recent features and fix stale content

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -444,6 +444,127 @@ Read a Swagger 2.0 document, transform it to OpenAPI 3.0, and write out the resu
 
 ---
 
+## Read and Validate an AsyncAPI Document
+
+Read an AsyncAPI 2.6 document, inspect its channels and operations, and validate it.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.Library;
+    import io.apitomy.datamodels.TraverserDirection;
+    import io.apitomy.datamodels.models.Document;
+    import io.apitomy.datamodels.models.asyncapi.v2x.AsyncApi2xDocument;
+    import io.apitomy.datamodels.models.asyncapi.AsyncApiChannelItem;
+    import io.apitomy.datamodels.models.asyncapi.AsyncApiOperation;
+    import io.apitomy.datamodels.models.visitors.CombinedVisitorAdapter;
+    import io.apitomy.datamodels.validation.ValidationProblem;
+    import java.util.List;
+
+    String json = """
+        {
+          "asyncapi": "2.6.0",
+          "info": {
+            "title": "User Events",
+            "version": "1.0.0"
+          },
+          "channels": {
+            "user/signedup": {
+              "subscribe": {
+                "operationId": "onUserSignedUp",
+                "message": {
+                  "payload": {
+                    "type": "object",
+                    "properties": {
+                      "userId": { "type": "string" },
+                      "email": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    Document doc = Library.readDocumentFromJSONString(json);
+    AsyncApi2xDocument asyncDoc = (AsyncApi2xDocument) doc;
+    System.out.println("Title: " + asyncDoc.getInfo().getTitle());
+
+    // Walk the channels and operations
+    Library.visitTree(doc, new CombinedVisitorAdapter() {
+        @Override
+        public void visitChannelItem(AsyncApiChannelItem node) {
+            System.out.println("Channel: " + node.mapPropertyName());
+        }
+
+        @Override
+        public void visitOperation(AsyncApiOperation node) {
+            System.out.println("  Operation: " + node.getOperationId());
+        }
+    }, TraverserDirection.down);
+
+    // Validate
+    List<ValidationProblem> problems = Library.validate(doc, null);
+    System.out.println("Validation problems: " + problems.size());
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import {
+        Library, TraverserDirection, Document,
+        AsyncApi2xDocument, AsyncApiChannelItem, AsyncApiOperation,
+        CombinedVisitorAdapter, ValidationProblem
+    } from '@apitomy/data-models';
+
+    const json = {
+        asyncapi: '2.6.0',
+        info: {
+            title: 'User Events',
+            version: '1.0.0',
+        },
+        channels: {
+            'user/signedup': {
+                subscribe: {
+                    operationId: 'onUserSignedUp',
+                    message: {
+                        payload: {
+                            type: 'object',
+                            properties: {
+                                userId: { type: 'string' },
+                                email: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const doc: Document = Library.readDocument(json);
+    const asyncDoc = doc as AsyncApi2xDocument;
+    console.log('Title:', asyncDoc.getInfo().getTitle());
+
+    // Walk the channels and operations
+    class ChannelPrinter extends CombinedVisitorAdapter {
+        visitChannelItem(node: AsyncApiChannelItem): void {
+            console.log('Channel:', node.mapPropertyName());
+        }
+        visitOperation(node: AsyncApiOperation): void {
+            console.log('  Operation:', node.getOperationId());
+        }
+    }
+
+    Library.visitTree(doc, new ChannelPrinter(), TraverserDirection.down);
+
+    // Validate
+    const problems: ValidationProblem[] = Library.validate(doc, null);
+    console.log('Validation problems:', problems.length);
+    ```
+
+---
+
 ## Implement a Custom Reference Resolver
 
 Resolve external `$ref` references by fetching content from a map (simulating a file

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ depending on your platform.
 ## Prerequisites
 
 - **Java**: JDK 17 or later
-- **Node.js**: 18 or later (for the TypeScript/JavaScript library)
+- **Node.js**: 20 or later (for the TypeScript/JavaScript library)
 
 ## Installation
 
@@ -17,14 +17,14 @@ depending on your platform.
     <dependency>
         <groupId>io.apitomy</groupId>
         <artifactId>apitomy-data-models</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy
-    implementation 'io.apitomy:apitomy-data-models:3.1.0'
+    implementation 'io.apitomy:apitomy-data-models:3.1.1'
     ```
 
 === "npm"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # Apitomy Data Models
 
-A Java and TypeScript library for reading, writing, and manipulating OpenAPI and AsyncAPI
-documents using a rich, typed object model.
+A Java and TypeScript library for reading, writing, and manipulating OpenAPI, AsyncAPI,
+OpenRPC, and JSON Schema documents using a rich, typed object model.
 
 ## Key Features
 
-- **Multi-Spec Support** — OpenAPI 2.0, 3.0, 3.1, 3.2 and AsyncAPI 2.x, 3.x
+- **Multi-Spec Support** — OpenAPI 2.0, 3.0, 3.1, 3.2; AsyncAPI 2.x, 3.x; OpenRPC 1.x; JSON Schema Draft 4–2020-12
 - **Read & Write** — Parse from JSON or YAML, serialize back to any format
 - **Validation** — Built-in validation engine with hundreds of spec-compliance rules
 - **Visitor Pattern** — Powerful visitor and traverser patterns for querying and transforming
@@ -31,14 +31,14 @@ documents using a rich, typed object model.
     <dependency>
         <groupId>io.apitomy</groupId>
         <artifactId>apitomy-data-models</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy
-    implementation 'io.apitomy:apitomy-data-models:3.1.0'
+    implementation 'io.apitomy:apitomy-data-models:3.1.1'
     ```
 
 === "npm"

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -177,6 +177,35 @@ Undoing the aggregate undoes all of its child commands in reverse order.
 
 ---
 
+## Error Handling
+
+Command marshalling and unmarshalling errors throw `CommandException` (a subclass of
+`DataModelsException`).
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.cmd.CommandException;
+
+    try {
+        ICommand cmd = CommandFactory.unmarshall(commandJson);
+    } catch (CommandException e) {
+        System.err.println("Invalid command: " + e.getMessage());
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    try {
+        const cmd = CommandFactory.unmarshall(commandJson);
+    } catch (e) {
+        console.error('Invalid command:', e.message);
+    }
+    ```
+
+---
+
 ## Available Command Categories
 
 The library provides commands for all common document mutations:

--- a/docs/user-guide/dereferencing.md
+++ b/docs/user-guide/dereferencing.md
@@ -38,8 +38,8 @@ in a self-contained document.
 
 ## Strict Mode
 
-By default, unresolvable references are silently skipped. Enable strict mode to preserve them
-as-is (the `$ref` remains in the output).
+By default, unresolvable references are silently skipped. Enable strict mode to throw a
+`DataModelsException` if any external references could not be resolved.
 
 === "Java"
 

--- a/docs/user-guide/document-transformation.md
+++ b/docs/user-guide/document-transformation.md
@@ -62,6 +62,14 @@ Call `Library.transformDocument()` with the source document and the target `Mode
 | From | To | Description |
 |------|----|-------------|
 | AsyncAPI 2.x | AsyncAPI 2.y (y > x) | Incremental upgrades within the 2.x series |
+| AsyncAPI 2.x | AsyncAPI 3.x | Cross-major upgrade from any 2.x version to 3.0 or 3.1 |
+| AsyncAPI 3.0 | AsyncAPI 3.1 | Upgrade within the 3.x series |
+
+!!! note
+    AsyncAPI transformations update the version identifier and re-parse the document using
+    the target version's data model. Structural changes between major versions (e.g., the
+    channel/operation model differences between 2.x and 3.x) are handled by the library's
+    reader, which maps the existing JSON structure into the target model.
 
 ---
 
@@ -83,6 +91,36 @@ intermediate conversions internally.
     ```typescript
     // Direct upgrade from 2.0 to 3.2 in one step
     const openApi32 = Library.transformDocument(swagger, ModelType.OPENAPI32);
+    ```
+
+---
+
+## Error Handling
+
+Unsupported transformations throw `TransformationException` (a subclass of
+`DataModelsException`). For example, transforming an OpenRPC document or downgrading
+from a newer version to an older one will throw this exception.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.TransformationException;
+
+    try {
+        Document result = Library.transformDocument(source, ModelType.OPENAPI30);
+    } catch (TransformationException e) {
+        System.err.println("Transformation not supported: " + e.getMessage());
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    try {
+        const result = Library.transformDocument(source, ModelType.OPENAPI30);
+    } catch (e) {
+        console.error('Transformation not supported:', e.message);
+    }
     ```
 
 ---

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -43,6 +43,11 @@ strict mode, and implementing custom reference resolvers for external content.
 Transform documents between specification versions, such as upgrading from OpenAPI 2.0 to 3.0
 or from OpenAPI 3.0 to 3.1.
 
+### [Schema Compatibility](schema-compatibility.md)
+
+Check backward, forward, and full compatibility between JSON Schema versions. Useful for
+detecting breaking changes when evolving API schemas.
+
 ---
 
 ## Supported Specifications

--- a/docs/user-guide/reading-and-writing.md
+++ b/docs/user-guide/reading-and-writing.md
@@ -220,6 +220,43 @@ Create a deep copy of a document. The clone is fully independent of the original
 
 ---
 
+## Error Handling
+
+The library uses a typed exception hierarchy rooted at `DataModelsException` (which extends
+`RuntimeException` for backward compatibility). When reading a document with an unrecognized
+specification version, the library throws `UnsupportedModelTypeException`.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.UnsupportedModelTypeException;
+
+    try {
+        Document doc = Library.readDocumentFromJSONString(json);
+    } catch (UnsupportedModelTypeException e) {
+        System.err.println("Unsupported spec version: " + e.getMessage());
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    try {
+        const doc = Library.readDocumentFromJSONString(json);
+    } catch (e) {
+        console.error('Unsupported spec version:', e.message);
+    }
+    ```
+
+| Exception | Thrown When |
+|-----------|------------|
+| `DataModelsException` | Base class for all library exceptions |
+| `UnsupportedModelTypeException` | Unknown or unsupported specification version |
+| `TransformationException` | Unsupported document transformation (see [Document Transformation](document-transformation.md)) |
+| `CommandException` | Command marshalling or unmarshalling failure (see [Commands](commands.md)) |
+
+---
+
 ## Extra Properties
 
 API specifications allow vendor extensions (properties prefixed with `x-`). These are

--- a/docs/user-guide/schema-compatibility.md
+++ b/docs/user-guide/schema-compatibility.md
@@ -1,0 +1,185 @@
+# Schema Compatibility
+
+The library includes a JSON Schema compatibility checker for detecting breaking changes
+between schema versions. This is useful when evolving APIs to ensure that updated schemas
+remain compatible with existing data.
+
+!!! warning "Experimental"
+    This API is experimental and subject to change in future versions.
+
+## Compatibility Types
+
+| Type | Meaning |
+|------|---------|
+| **Backward compatible** | Data written with the *original* schema can be read using the *updated* schema |
+| **Forward compatible** | Data written with the *updated* schema can be read using the *original* schema |
+| **Fully compatible** | Both backward and forward compatible |
+
+---
+
+## Quick Checks
+
+Use the boolean convenience methods for simple pass/fail checks.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.jsonschema.compat.JsonSchemaCompatibilityChecker;
+
+    String original = """
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "integer" }
+          },
+          "required": ["name"]
+        }
+        """;
+
+    String updated = """
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "integer" },
+            "email": { "type": "string" }
+          },
+          "required": ["name"]
+        }
+        """;
+
+    // Adding an optional property is backward compatible
+    boolean backwardOk = JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated);
+    System.out.println("Backward compatible: " + backwardOk); // true
+
+    // Check forward compatibility
+    boolean forwardOk = JsonSchemaCompatibilityChecker.isForwardCompatible(original, updated);
+
+    // Check full compatibility (both directions)
+    boolean fullyOk = JsonSchemaCompatibilityChecker.isFullyCompatible(original, updated);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { JsonSchemaCompatibilityChecker } from '@apitomy/data-models';
+
+    const original = JSON.stringify({
+        type: 'object',
+        properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+        },
+        required: ['name'],
+    });
+
+    const updated = JSON.stringify({
+        type: 'object',
+        properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+            email: { type: 'string' },
+        },
+        required: ['name'],
+    });
+
+    // Adding an optional property is backward compatible
+    const backwardOk = JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated);
+    console.log('Backward compatible:', backwardOk); // true
+
+    // Check forward compatibility
+    const forwardOk = JsonSchemaCompatibilityChecker.isForwardCompatible(original, updated);
+
+    // Check full compatibility (both directions)
+    const fullyOk = JsonSchemaCompatibilityChecker.isFullyCompatible(original, updated);
+    ```
+
+---
+
+## Detailed Diff
+
+Use `checkBackwardCompatibility()` to get a `DiffContext` with all detected differences,
+including which are compatible and which are not.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.jsonschema.compat.DiffContext;
+    import io.apitomy.datamodels.jsonschema.compat.Difference;
+
+    DiffContext result = JsonSchemaCompatibilityChecker.checkBackwardCompatibility(
+            original, updated);
+
+    if (result.foundAllDifferencesAreCompatible()) {
+        System.out.println("All changes are backward compatible.");
+    } else {
+        System.out.println("Incompatible changes found:");
+        for (Difference diff : result.getIncompatibleDifferences()) {
+            System.out.println("  " + diff.getDiffType() + " at " + diff.getPathUpdated());
+        }
+    }
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { JsonSchemaCompatibilityChecker, DiffContext } from '@apitomy/data-models';
+
+    const result = JsonSchemaCompatibilityChecker.checkBackwardCompatibility(
+        original, updated);
+
+    if (result.foundAllDifferencesAreCompatible()) {
+        console.log('All changes are backward compatible.');
+    } else {
+        console.log('Incompatible changes found:');
+        result.getIncompatibleDifferences().forEach(diff => {
+            console.log(`  ${diff.getDiffType()} at ${diff.getPathUpdated()}`);
+        });
+    }
+    ```
+
+You can also get just the incompatible differences directly:
+
+=== "Java"
+
+    ```java
+    Set<Difference> breaking = JsonSchemaCompatibilityChecker.getIncompatibleDifferences(
+            original, updated);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const breaking = JsonSchemaCompatibilityChecker.getIncompatibleDifferences(
+        original, updated);
+    ```
+
+---
+
+## Common Breaking Changes
+
+The checker detects a wide range of schema differences. Here are some common examples:
+
+| Change | Backward Compatible? |
+|--------|---------------------|
+| Adding an optional property | Yes |
+| Adding a required property | **No** |
+| Removing a required property | Yes |
+| Widening a type (e.g., `integer` → `number`) | Yes |
+| Narrowing a type (e.g., `number` → `integer`) | **No** |
+| Increasing `maxLength` / `maximum` | Yes |
+| Decreasing `maxLength` / `maximum` | **No** |
+| Decreasing `minLength` / `minimum` | Yes |
+| Increasing `minLength` / `minimum` | **No** |
+| Adding an enum member | Yes |
+| Removing an enum member | **No** |
+| Setting `additionalProperties: false` | **No** |
+
+---
+
+## Supported Versions
+
+The compatibility checker currently supports JSON Schema Draft 4, Draft 6, and Draft 7.
+Modern versions (2019-09, 2020-12) are detected but flagged as unsupported in the diff
+context via `hasUnsupportedFeatures()`.

--- a/docs/user-guide/validation.md
+++ b/docs/user-guide/validation.md
@@ -59,16 +59,40 @@ Each `ValidationProblem` includes the following fields:
 
 ## Error Code Prefixes
 
-Validation error codes follow a consistent naming convention. The prefix indicates the type
-of rule:
+Validation error codes use an entity-based naming convention. The prefix identifies which
+part of the specification the rule applies to:
 
-| Prefix | Meaning | Example |
-|--------|---------|---------|
-| `REQ` | Required property is missing | `REQ-001` |
-| `INF` | Invalid format | `INF-001` |
-| `INV` | Invalid value | `INV-001` |
-| `UNQ` | Uniqueness violation | `UNQ-001` |
-| `MUT` | Mutual exclusivity violation | `MUT-001` |
+| Prefix | Entity | Example |
+|--------|--------|---------| 
+| `INF` | Info | `INF-001` |
+| `OP` | Operation | `OP-001` |
+| `PAR` | Parameter | `PAR-001` |
+| `PATH` | Path Item | `PATH-001` |
+| `SCH` | Schema | `SCH-001` |
+| `HEAD` | Header | `HEAD-001` |
+| `RES` | Response | `RES-001` |
+| `RB` | Request Body | `RB-001` |
+| `SS` | Security Scheme | `SS-001` |
+| `SREQ` | Security Requirement | `SREQ-001` |
+| `SRV` | Server | `SRV-001` |
+| `SVAR` | Server Variable | `SVAR-001` |
+| `TAG` | Tag | `TAG-001` |
+| `FLOW` | OAuth Flow | `FLOW-001` |
+| `LINK` | Link | `LINK-001` |
+| `ENC` | Encoding | `ENC-001` |
+| `MT` | Media Type | `MT-001` |
+| `DISC` | Discriminator | `DISC-001` |
+| `LIC` | License | `LIC-001` |
+| `CTC` | Contact | `CTC-001` |
+| `XML` | XML | `XML-001` |
+| `COMP` | Components | `COMP-001` |
+| `EX` | Example | `EX-001` |
+| `CHAN` | Channel (AsyncAPI) | `CHAN-001` |
+| `AAD`, `AAM`, `AAO` | AsyncAPI Document, Message, Operation | `AAD-001` |
+| `ORPC` | OpenRPC | `ORPC-001` |
+
+Codes with a `DEF` suffix (e.g., `SDEF`, `PDEF`, `RDEF`) apply to component definitions
+(the reusable entries under `components/`).
 
 ---
 

--- a/docs/user-guide/visitor-pattern.md
+++ b/docs/user-guide/visitor-pattern.md
@@ -283,6 +283,41 @@ Find all vendor extensions (`x-` properties) across the document.
     detector.extensions.forEach(ext => console.log(ext));
     ```
 
+### Visiting Along a Node Path
+
+Use `VisitorUtil.visitPath()` to visit each node along a specific path. By default, errors
+during traversal are logged and traversal stops silently. Use `visitPathStrict()` for
+fail-fast behavior — it throws `DataModelsException` if an error occurs.
+
+=== "Java"
+
+    ```java
+    import io.apitomy.datamodels.VisitorUtil;
+    import io.apitomy.datamodels.paths.NodePath;
+
+    NodePath path = Library.parseNodePath("/paths[/pets]/get");
+
+    // Silent — logs warnings on errors, stops traversal
+    VisitorUtil.visitPath(doc, path, visitor);
+
+    // Strict — throws DataModelsException on errors
+    VisitorUtil.visitPathStrict(doc, path, visitor);
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { VisitorUtil, NodePath } from '@apitomy/data-models';
+
+    const path = Library.parseNodePath('/paths[/pets]/get');
+
+    // Silent — logs warnings on errors, stops traversal
+    VisitorUtil.visitPath(doc, path, visitor);
+
+    // Strict — throws on errors
+    VisitorUtil.visitPathStrict(doc, path, visitor);
+    ```
+
 ### Walking Up the Tree
 
 Use `TraverserDirection.up` to find ancestors of a node. For example, finding which path

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Apitomy Data Models
-site_description: A library for reading, writing, and manipulating OpenAPI and AsyncAPI documents
+site_description: A library for reading, writing, and manipulating OpenAPI, AsyncAPI, OpenRPC, and JSON Schema documents
 site_author: Apitomy
 site_url: https://www.apitomy.io/projects/data-models/docs/
 
@@ -51,6 +51,7 @@ nav:
     - Node Paths: user-guide/node-paths.md
     - Dereferencing: user-guide/dereferencing.md
     - Document Transformation: user-guide/document-transformation.md
+    - Schema Compatibility: user-guide/schema-compatibility.md
   - Examples: examples/index.md
 
 docs_dir: ./docs


### PR DESCRIPTION
## Summary

- **Fix stale content**: update version references (3.1.0 → 3.1.1), Node.js prerequisite (18 → 20), expand spec coverage mentions to include OpenRPC and JSON Schema, fix incorrect strict mode description in dereferencing docs, replace inaccurate validation error code prefix table with actual entity-based codes
- **Document new features**: typed exception hierarchy (`DataModelsException`, `TransformationException`, `UnsupportedModelTypeException`, `CommandException`), `visitPathStrict()`, AsyncAPI transformation paths, and JSON Schema compatibility checker
- **Add new content**: Schema Compatibility user guide page for `JsonSchemaCompatibilityChecker`, AsyncAPI read/validate example

## Test plan

- [ ] Verify mkdocs builds without errors (`mkdocs build`)
- [ ] Spot-check that code examples in new sections use correct import paths and API signatures
- [ ] Verify Schema Compatibility page renders correctly with tabbed code blocks and admonitions
- [ ] Confirm navigation includes the new Schema Compatibility entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)