### PR TITLE
feat(generator): migrate CreateImplMethodsStage to resolvedType dispatch

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/CreatePropertyAndTypeModelsStage.java
@@ -112,6 +112,11 @@ public class CreatePropertyAndTypeModelsStage extends AbstractStage {
         var propertyType = PropertyType.parse(property.getType());
         var rawType = RawType.parse(property.getType());
         var resolvedType = resolveType(rawType, namespace);
+        if (resolvedType instanceof UnionType ut
+                && property.getUnionRules() != null && !property.getUnionRules().isEmpty()
+                && (ut.getUnionRules() == null || ut.getUnionRules().isEmpty())) {
+            ut.setUnionRules(property.getUnionRules());
+        }
         indexTypesRecursively(resolvedType, namespace);
 
         var builder = PropertyModel.builder()

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -17,6 +17,8 @@ import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.PropertyType;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 
 /**
@@ -235,7 +237,10 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
         body.addContext("fieldName", fieldName);
         body.addContext("propertyName", propertyName);
         body.append("this.${fieldName} = value;");
-        if (isEntity(property)) {
+        Type resolvedType = property.getResolvedType();
+        boolean isEntityType = resolvedType != null ? resolvedType.isEntityType() : isEntity(property);
+        boolean isUnionType = resolvedType != null ? resolvedType.isUnionType() : isUnion(property);
+        if (isEntityType) {
             JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
             javaEntity.addImport(parentPropertyTypeSource);
             JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -246,7 +251,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
             body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
             body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
             body.append("}");
-        } else if (isUnion(property)) {
+        } else if (isUnionType) {
             JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
             javaEntity.addImport(parentPropertyTypeSource);
             JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -325,15 +330,23 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
 
     @Override
     protected void createAddMethodBody(JavaSource<?> javaEntity, PropertyModel property, MethodSource<?> method) {
-        PropertyType type = property.getType().getNested().iterator().next();
         String fieldName = getFieldName(property);
         String propertyName = property.getName();
+
+        Type resolvedValueType = null;
+        if (property.getResolvedType() != null && property.getResolvedType().isCollectionType()) {
+            resolvedValueType = ((CollectionType) property.getResolvedType()).getValueType();
+        }
+        PropertyType type = property.getType().getNested().iterator().next();
+        boolean isEntityValue = resolvedValueType != null ? resolvedValueType.isEntityType() : type.isEntityType();
+        boolean isUnionValue = resolvedValueType != null ? resolvedValueType.isUnionType() : type.isUnion();
+        boolean isPrimitiveValue = resolvedValueType != null ? resolvedValueType.isPrimitiveType() : type.isPrimitiveType();
 
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
         body.addContext("propertyName", propertyName);
 
-        if (type.isEntityType() || type.isPrimitiveType() || type.isUnion()) {
+        if (isEntityValue || isPrimitiveValue || isUnionValue) {
             if (property.getType().isMap()) {
                 javaEntity.addImport(LinkedHashMap.class);
 
@@ -341,7 +354,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 body.append("    this.${fieldName} = new LinkedHashMap<>();");
                 body.append("}");
                 body.append("this.${fieldName}.put(name, value);");
-                if (type.isEntityType()) {
+                if (isEntityValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -353,7 +366,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
                     body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
                     body.append("}");
-                } else if (type.isUnion()) {
+                } else if (isUnionValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -374,7 +387,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 body.append("    this.${fieldName} = new ArrayList<>();");
                 body.append("}");
                 body.append("this.${fieldName}.add(value);");
-                if (type.isEntityType()) {
+                if (isEntityValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -385,7 +398,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
                     body.append("}");
-                } else if (type.isUnion()) {
+                } else if (isUnionValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -417,10 +430,17 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
     @Override
     protected void createClearMethodBody(PropertyModel property, MethodSource<?> method) {
         String fieldName = getFieldName(property);
+        Type resolvedValueType = null;
+        if (property.getResolvedType() != null && property.getResolvedType().isCollectionType()) {
+            resolvedValueType = ((CollectionType) property.getResolvedType()).getValueType();
+        }
         PropertyType nestedType = property.getType().getNested().iterator().next();
+        boolean needsDetach = resolvedValueType != null
+                ? (resolvedValueType.isEntityType() || resolvedValueType.isUnionType())
+                : (nestedType.isEntityType() || nestedType.isUnion());
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
-        if (nestedType.isEntityType() || nestedType.isUnion()) {
+        if (needsDetach) {
             String valuesExpr = property.getType().isMap()
                     ? "this." + fieldName + ".values()" : "this." + fieldName;
             body.addContext("valuesExpr", valuesExpr);
@@ -444,10 +464,17 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
 
+        Type resolvedValueType = null;
+        if (property.getResolvedType() != null && property.getResolvedType().isCollectionType()) {
+            resolvedValueType = ((CollectionType) property.getResolvedType()).getValueType();
+        }
         PropertyType nestedType = property.getType().getNested().iterator().next();
+        boolean needsDetach = resolvedValueType != null
+                ? (resolvedValueType.isEntityType() || resolvedValueType.isUnionType())
+                : (nestedType.isEntityType() || nestedType.isUnion());
         if (property.getType().isList()) {
             body.append("if (this.${fieldName} != null) {");
-            if (nestedType.isEntityType() || nestedType.isUnion()) {
+            if (needsDetach) {
                 body.append("    if (value != null && this.${fieldName}.remove(value)) {");
                 body.append("        value.detach();");
                 body.append("    }");
@@ -466,15 +493,23 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
 
     @Override
     protected void createInsertMethodBody(JavaSource<?> javaEntity, PropertyModel property, MethodSource<?> method) {
-        PropertyType type = property.getType().getNested().iterator().next();
         String fieldName = getFieldName(property);
         String propertyName = property.getName();
+
+        Type resolvedValueType = null;
+        if (property.getResolvedType() != null && property.getResolvedType().isCollectionType()) {
+            resolvedValueType = ((CollectionType) property.getResolvedType()).getValueType();
+        }
+        PropertyType type = property.getType().getNested().iterator().next();
+        boolean isEntityValue = resolvedValueType != null ? resolvedValueType.isEntityType() : type.isEntityType();
+        boolean isUnionValue = resolvedValueType != null ? resolvedValueType.isUnionType() : type.isUnion();
+        boolean isPrimitiveValue = resolvedValueType != null ? resolvedValueType.isPrimitiveType() : type.isPrimitiveType();
 
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
         body.addContext("propertyName", propertyName);
 
-        if (type.isEntityType() || type.isPrimitiveType() || type.isUnion()) {
+        if (isEntityValue || isPrimitiveValue || isUnionValue) {
             if (property.getType().isMap()) {
                 JavaClassSource dataModelUtilSource = getState().getJavaIndex().lookupClass(getDataModelUtilFQCN());
                 javaEntity.addImport(dataModelUtilSource);
@@ -487,7 +522,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 body.append("    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);");
                 body.append("}");
 
-                if (type.isEntityType()) {
+                if (isEntityValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -499,7 +534,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
                     body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
                     body.append("}");
-                } else if (type.isUnion()) {
+                } else if (isUnionValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -524,7 +559,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                 body.append("} else {");
                 body.append("    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);");
                 body.append("}");
-                if (type.isEntityType()) {
+                if (isEntityValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
@@ -535,7 +570,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
                     body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
                     body.append("}");
-                } else if (type.isUnion()) {
+                } else if (isUnionValue) {
                     JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
                     javaEntity.addImport(parentPropertyTypeSource);
                     JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -373,11 +373,21 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
                     JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
                     javaEntity.addImport(unionValueSource);
+                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
+                    javaEntity.addImport(unionValueImplSource);
 
-                    body.append("if (value != null && value.isEntity()) {");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
+                    body.append("if (value != null) {");
+                    body.append("    if (value.isEntity()) {");
+                    body.append("        ((NodeImpl) value)._setParent(this);");
+                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
+                    body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
+                    body.append("    } else {");
+                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);");
+                    body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
+                    body.append("    }");
                     body.append("}");
                 }
             } else {
@@ -541,11 +551,21 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
                     javaEntity.addImport(nodeImplSource);
                     JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
                     javaEntity.addImport(unionValueSource);
+                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
+                    javaEntity.addImport(unionValueImplSource);
 
-                    body.append("if (value != null && value.isEntity()) {");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
+                    body.append("if (value != null) {");
+                    body.append("    if (value.isEntity()) {");
+                    body.append("        ((NodeImpl) value)._setParent(this);");
+                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
+                    body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
+                    body.append("    } else {");
+                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
+                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);");
+                    body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
+                    body.append("    }");
                     body.append("}");
                 }
             } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -106,7 +106,7 @@ public class CreateReadersStage extends AbstractJavaStage {
         String methodName = "read" + unionTypeName;
 
         // Skip if already created
-        if (readerClassSource.getMethod(methodName, JsonNode.class.getSimpleName()) != null) {
+        if (readerClassSource.getMethod(methodName, JsonNode.class.getSimpleName(), "ModelType") != null) {
             return;
         }
 
@@ -116,11 +116,15 @@ public class CreateReadersStage extends AbstractJavaStage {
         readerClassSource.addImport(ObjectNode.class);
         jt.addImportsTo(readerClassSource);
 
+        JavaEnumSource modelTypeEnum = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
+        readerClassSource.addImport(modelTypeEnum);
+
         MethodSource<JavaClassSource> method = readerClassSource.addMethod()
                 .setName(methodName)
                 .setReturnType(jt.toJavaTypeString())
                 .setPrivate();
         method.addParameter("JsonNode", "json");
+        method.addParameter("ModelType", "modelType");
 
         BodyBuilder body = new BodyBuilder();
         body.append("if (json == null) return null;");
@@ -146,13 +150,13 @@ public class CreateReadersStage extends AbstractJavaStage {
                 String condition;
                 if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYEXISTS) {
                     body.addContext("rulePropName", rule.getPropertyName());
-                    condition = "json.isObject() && json.has(\"${rulePropName}\")";
+                    condition = "JsonUtil.isObjectWithProperty(json, \"${rulePropName}\")";
                 } else if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYVALUE) {
                     body.addContext("rulePropName", rule.getPropertyName());
                     body.addContext("rulePropValue", rule.getPropertyValue());
                     condition = "JsonUtil.isObjectWithPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
                 } else {
-                    condition = "json.isObject()";
+                    condition = "JsonUtil.isObject(json)";
                 }
 
                 if (!first) body.append(" else ");
@@ -182,7 +186,7 @@ public class CreateReadersStage extends AbstractJavaStage {
                 first = false;
 
                 body.append("if (JsonUtil.${isMethod}(json)) {");
-                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json));");
+                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json), modelType);");
                 body.append("}");
             } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType
                     && listType.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType listEntityType) {
@@ -220,6 +224,36 @@ public class CreateReadersStage extends AbstractJavaStage {
                 body.append("    @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
                 body.append("    ${unionValueClass} unionValue = new ${unionValueClass}((List) models);");
                 body.append("    return unionValue;");
+                body.append("}");
+            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType
+                    && listType.getValueType() instanceof io.apitomy.umg.models.concept.type.PrimitiveType primType) {
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) continue;
+
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                if (javaClass == null) continue;
+
+                readerClassSource.addImport(unionValueClass);
+                readerClassSource.addImport(java.util.List.class);
+                readerClassSource.addImport(java.util.ArrayList.class);
+                readerClassSource.addImport(javaClass);
+
+                body.addContext("primType", javaClass.getSimpleName());
+                body.addContext("toMethod", "to" + javaClass.getSimpleName());
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.isArray(json)) {");
+                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
+                body.append("    List<${primType}> items = new ArrayList<>();");
+                body.append("    array.forEach(item -> {");
+                body.append("        items.add(JsonUtil.${toMethod}(item));");
+                body.append("    });");
+                body.append("    return new ${unionValueClass}(items);");
                 body.append("}");
             }
         }
@@ -292,10 +326,14 @@ public class CreateReadersStage extends AbstractJavaStage {
         JavaInterfaceSource rootCapableSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
         readerClassSource.addImport(rootCapableSource);
         readerClassSource.addImport(JsonNode.class);
-        readerClassSource.addImport(ObjectNode.class);
 
         JavaEnumSource modelTypeEnum = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
         readerClassSource.addImport(modelTypeEnum);
+
+        var namespace = specVersion.getNamespace();
+        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String readMethodName = "read" + jt.getSimpleName();
 
         MethodSource<JavaClassSource> readRootMethodSource = readerClassSource.addMethod()
                 .setName("readRoot")
@@ -304,82 +342,14 @@ public class CreateReadersStage extends AbstractJavaStage {
         readRootMethodSource.addParameter("JsonNode", "json");
         readRootMethodSource.addAnnotation(Override.class);
 
-        BodyBuilder body = new BodyBuilder();
-        var namespace = specVersion.getNamespace();
         String prefix = getPrefix(namespace);
         String modelType = prefixToModelType(prefix);
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("readMethodName", readMethodName);
         body.addContext("modelType", modelType);
 
-        boolean first = true;
-        for (var variantType : unionType.getTypes()) {
-            if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
-                var entity = entityType.getEntity();
-                if (entity == null) {
-                    entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
-                }
-                if (entity == null) continue;
-
-                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-                JavaClassSource entityImplSource = lookupJavaEntityImpl(entity);
-                readerClassSource.addImport(entitySource);
-                readerClassSource.addImport(entityImplSource);
-
-                body.addContext("entityType", entitySource.getName());
-                body.addContext("entityImplType", entityImplSource.getName());
-                body.addContext("readMethodName", readMethodName(entity));
-
-                var rule = unionType.getRuleFor(entityType.getName());
-                String condition;
-                if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYEXISTS) {
-                    body.addContext("rulePropName", rule.getPropertyName());
-                    condition = "json.isObject() && json.has(\"${rulePropName}\")";
-                } else if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYVALUE) {
-                    body.addContext("rulePropName", rule.getPropertyName());
-                    body.addContext("rulePropValue", rule.getPropertyValue());
-                    condition = "JsonUtil.isObjectWithPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
-                } else {
-                    condition = "json.isObject()";
-                }
-
-                if (!first) {
-                    body.append(" else ");
-                }
-                first = false;
-
-                body.append("if (" + condition + ") {");
-                body.append("    ${entityType} rootModel = new ${entityImplType}();");
-                body.append("    this.${readMethodName}((ObjectNode) json, rootModel);");
-                body.append("    return rootModel;");
-                body.append("}");
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType primitiveVariant) {
-                var primitiveType = primitiveVariant.getType();
-                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primitiveType.name().toLowerCase());
-                if (javaClass == null) continue;
-
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
-                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                if (unionValueClass == null) continue;
-
-                readerClassSource.addImport(unionValueClass);
-
-                body.addContext("isMethod", "is" + javaClass.getSimpleName());
-                body.addContext("toMethod", "to" + javaClass.getSimpleName());
-                body.addContext("javaType", javaClass.getSimpleName());
-                body.addContext("unionValueClass", unionValueClass.getName());
-
-                if (!first) {
-                    body.append(" else ");
-                }
-                first = false;
-
-                body.append("if (JsonUtil.${isMethod}(json)) {");
-                body.append("    ${javaType} value = JsonUtil.${toMethod}(json);");
-                body.append("    return new ${unionValueClass}(value, ModelType.${modelType});");
-                body.append("}");
-            }
-        }
-        body.append("return null;");
+        body.append("return (RootCapable) this.${readMethodName}(json, ModelType.${modelType});");
         readRootMethodSource.setBody(body.toString());
     }
 
@@ -494,30 +464,20 @@ public class CreateReadersStage extends AbstractJavaStage {
             var resolved = property.getResolvedType();
             if (resolved == null) return false;
 
-            // Only use resolved type dispatch when PropertyType doesn't recognize the
-            // type correctly (e.g., type alias properties where PropertyType is simple
-            // but resolvedType is a union). For properties where PropertyType already
-            // works (inline unions), fall through to the old code path.
-            var pt = property.getType();
-            if (pt.isUnion() || (pt.isList() && pt.getNested().iterator().next().isUnion())
-                    || (pt.isMap() && pt.getNested().iterator().next().isUnion())) {
-                return false;
-            }
-
-            // Direct union property (e.g., not: Schema where Schema is a type alias)
+            // Direct union property (both type aliases and inline unions)
             if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionProperty(body, resolved);
                 return true;
             }
 
-            // List of union (e.g., allOf: [Schema])
+            // List of union
             if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
                     && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionListProperty(body, lt);
                 return true;
             }
 
-            // Map of union (e.g., definitions: {Schema})
+            // Map of union
             if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
                     && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionMapProperty(body, mt);
@@ -543,7 +503,7 @@ public class CreateReadersStage extends AbstractJavaStage {
             body.append("{");
             body.append("    JsonNode value = JsonUtil.consumeAnyProperty(json, \"${propertyName}\");");
             body.append("    if (value != null) {");
-            body.append("        node.${setterMethodName}(this.${readMethodName}(value));");
+            body.append("        node.${setterMethodName}(this.${readMethodName}(value, null));");
             body.append("    }");
             body.append("}");
         }
@@ -569,7 +529,7 @@ public class CreateReadersStage extends AbstractJavaStage {
             body.append("    List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, \"${propertyName}\");");
             body.append("    if (array != null) {");
             body.append("        array.forEach(item -> {");
-            body.append("            ${unionJavaType} value = this.${readMethodName}(item);");
+            body.append("            ${unionJavaType} value = this.${readMethodName}(item, null);");
             body.append("            if (value != null) node.${addMethodName}(value);");
             body.append("        });");
             body.append("    }");
@@ -599,7 +559,7 @@ public class CreateReadersStage extends AbstractJavaStage {
             body.append("        JsonUtil.keys(mapObj).forEach(key -> {");
             body.append("            JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);");
             body.append("            if (value != null) {");
-            body.append("                ${unionJavaType} model = this.${readMethodName}(value);");
+            body.append("                ${unionJavaType} model = this.${readMethodName}(value, null);");
             body.append("                if (model != null) node.${addMethodName}(key, model);");
             body.append("            }");
             body.append("        });");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -159,6 +159,54 @@ public class CreateWritersStage extends AbstractJavaStage {
                     body.append("    return JsonUtil.${toJsonMethod}(union.${asMethod}());");
                     body.append("}");
                 }
+            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType) {
+                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
+
+                body.addContext("isMethod", "is" + typeName);
+                body.addContext("asMethod", "as" + typeName);
+
+                writerClassSource.addImport(ArrayNode.class);
+
+                if (listType.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType listEntityType) {
+                    var entity = listEntityType.getEntity();
+                    if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, listEntityType.getName());
+                    if (entity == null) continue;
+
+                    JavaInterfaceSource entitySource = lookupJavaEntity(entity);
+                    writerClassSource.addImport(entitySource);
+                    body.addContext("entityType", entitySource.getName());
+                    body.addContext("writeMethodName", writeMethodName(entity));
+
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
+                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("        ObjectNode itemNode = JsonUtil.objectNode();");
+                    body.append("        this.${writeMethodName}((${entityType}) item, itemNode);");
+                    body.append("        array.add(itemNode);");
+                    body.append("    }");
+                    body.append("    return array;");
+                    body.append("}");
+                } else if (listType.getValueType() instanceof io.apitomy.umg.models.concept.type.PrimitiveType primType) {
+                    Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                    if (javaClass == null) continue;
+
+                    writerClassSource.addImport(javaClass);
+                    body.addContext("primType", javaClass.getSimpleName());
+
+                    String addExpr;
+                    if (Boolean.class.equals(javaClass)) addExpr = "array.add((Boolean) item)";
+                    else if (String.class.equals(javaClass)) addExpr = "array.add((String) item)";
+                    else addExpr = "array.add(JsonUtil.numberToJsonNode((Number) item))";
+
+                    body.addContext("addExpr", addExpr);
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
+                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("        ${addExpr};");
+                    body.append("    }");
+                    body.append("    return array;");
+                    body.append("}");
+                }
             }
         }
         body.append("return null;");
@@ -191,7 +239,14 @@ public class CreateWritersStage extends AbstractJavaStage {
                                              io.apitomy.umg.models.concept.type.UnionType unionType) {
         JavaInterfaceSource rootCapableSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
         writerClassSource.addImport(rootCapableSource);
+        writerClassSource.addImport(JsonNode.class);
         writerClassSource.addImport(ObjectNode.class);
+
+        var namespace = specVersion.getNamespace();
+        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String writeMethodName = "write" + jt.getSimpleName();
+        jt.addImportsTo(writerClassSource);
 
         MethodSource<JavaClassSource> writeRootMethodSource = writerClassSource.addMethod()
                 .setName("writeRoot")
@@ -201,36 +256,14 @@ public class CreateWritersStage extends AbstractJavaStage {
         writeRootMethodSource.addAnnotation(Override.class);
 
         BodyBuilder body = new BodyBuilder();
-        var namespace = specVersion.getNamespace();
+        body.addContext("writeMethodName", writeMethodName);
+        body.addContext("unionType", jt.toJavaTypeString());
 
-        body.append("ObjectNode json = JsonUtil.objectNode();");
-
-        boolean first = true;
-        for (var variantType : unionType.getTypes()) {
-            if (!(variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType)) continue;
-
-            var entity = entityType.getEntity();
-            if (entity == null) {
-                entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
-            }
-            if (entity == null) continue;
-
-            JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-            writerClassSource.addImport(entitySource);
-
-            body.addContext("entityType", entitySource.getName());
-            body.addContext("writeMethodName", writeMethodName(entity));
-
-            if (!first) {
-                body.append(" else ");
-            }
-            first = false;
-
-            body.append("if (node instanceof ${entityType}) {");
-            body.append("    this.${writeMethodName}((${entityType}) node, json);");
-            body.append("}");
-        }
-        body.append("return json;");
+        body.append("JsonNode result = this.${writeMethodName}((${unionType}) node);");
+        body.append("if (result instanceof ObjectNode) {");
+        body.append("    return (ObjectNode) result;");
+        body.append("}");
+        body.append("return null;");
         writeRootMethodSource.setBody(body.toString());
     }
 
@@ -388,13 +421,7 @@ public class CreateWritersStage extends AbstractJavaStage {
             var resolved = property.getResolvedType();
             if (resolved == null) return false;
 
-            // Only use resolved type dispatch for type-alias-backed unions
-            var pt = property.getType();
-            if (pt.isUnion() || (pt.isList() && pt.getNested().iterator().next().isUnion())
-                    || (pt.isMap() && pt.getNested().iterator().next().isUnion())) {
-                return false;
-            }
-
+            // Direct union property (both type aliases and inline unions)
             if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionProperty(body, resolved);
                 return true;
@@ -481,12 +508,15 @@ public class CreateWritersStage extends AbstractJavaStage {
             body.addContext("writeMethodName", writeMethodName);
             body.addContext("unionJavaType", valueJt.toJavaTypeString());
 
+            writerClassSource.addImport(Collection.class);
+
             body.append("{");
             body.append("    Map<String, ${unionJavaType}> items = node.${getterMethodName}();");
             body.append("    if (items != null && !items.isEmpty()) {");
             body.append("        ObjectNode mapJson = JsonUtil.objectNode();");
-            body.append("        items.forEach((key, item) -> {");
-            body.append("            JsonNode value = this.${writeMethodName}(item);");
+            body.append("        Collection<String> keys = items.keySet();");
+            body.append("        keys.forEach(key -> {");
+            body.append("            JsonNode value = this.${writeMethodName}(items.get(key));");
             body.append("            if (value != null) JsonUtil.setAnyProperty(mapJson, key, value);");
             body.append("        });");
             body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", mapJson);");

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -7,10 +7,13 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
 import io.test.synthetic.union.SchemaOrBoolean;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,9 +149,42 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("additionalSchema");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("additionalSchema");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParent(this);
+						((NodeImpl) entity)._setParentPropertyName("additionalSchema");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParent(this);
+						entity._setParentPropertyName("additionalSchema");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -126,10 +126,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("properties");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("properties");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -159,10 +167,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		} else {
 			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("properties");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("properties");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -242,10 +258,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("definitions");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("definitions");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -275,10 +299,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		} else {
 			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("definitions");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("definitions");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -293,10 +325,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -326,10 +366,18 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		} else {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -293,8 +293,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null) {
-			((NodeImpl) value)._setParent(this);
+		if (value != null && value.isEntity()) {
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -327,8 +326,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		} else {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
-		if (value != null) {
-			((NodeImpl) value)._setParent(this);
+		if (value != null && value.isEntity()) {
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -347,9 +345,15 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("composedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("composedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
@@ -382,9 +386,15 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("composedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("composedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -3,14 +3,11 @@ package io.test.synthetic.v1.io;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
-import io.test.synthetic.NodeImpl;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
-import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
-import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
 import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
@@ -63,7 +60,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
 			if (value != null) {
-				node.setAdditionalSchema(this.readSchemaOrBoolean(value));
+				node.setAdditionalSchema(this.readSchemaOrBoolean(value, null));
 			}
 		}
 		{
@@ -161,17 +158,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
 			if (value != null) {
-				if (JsonUtil.isObjectWithProperty(value, "type")) {
-					ObjectNode object = JsonUtil.toObject(value);
-					node.setDefaultValue(node.createSchema());
-					readSchema(object, (Syn1Schema) node.getDefaultValue());
-				} else if (JsonUtil.isBoolean(value)) {
-					Boolean pValue = JsonUtil.toBoolean(value);
-					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-					node.setDefaultValue(unionValue);
-				} else {
-					node.addExtraProperty("defaultValue", value);
-				}
+				node.setDefaultValue(this.readBooleanSchemaUnion(value, null));
 			}
 		}
 		{
@@ -200,49 +187,18 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
 			if (value != null) {
-				if (JsonUtil.isObjectWithProperty(value, "type")) {
-					ObjectNode object = JsonUtil.toObject(value);
-					node.setItems(node.createSchema());
-					readSchema(object, (Syn1Schema) node.getItems());
-				} else if (JsonUtil.isArray(value)) {
-					List<JsonNode> array = JsonUtil.toList(value);
-					List<Syn1Schema> models = new ArrayList<>();
-					array.forEach(item -> {
-						ObjectNode object = JsonUtil.toObject(item);
-						Syn1Schema model = (Syn1Schema) node.createSchema();
-						((NodeImpl) model)._setParent(node);
-						this.readSchema(object, model);
-						models.add(model);
-					});
-					@SuppressWarnings({"unchecked", "rawtypes"})
-					SchemaListUnionValue unionValue = new SchemaListUnionValueImpl((List) models);
-					node.setItems(unionValue);
-				} else if (JsonUtil.isBoolean(value)) {
-					Boolean pValue = JsonUtil.toBoolean(value);
-					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-					node.setItems(unionValue);
-				} else {
-					node.addExtraProperty("items", value);
-				}
+				node.setItems(this.readBooleanSchemaSchemaListUnion(value, null));
 			}
 		}
 		{
-			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "properties");
-			if (mapObject != null) {
-				List<String> keys = JsonUtil.keys(mapObject);
-				keys.forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "properties");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						if (JsonUtil.isObject(value)) {
-							ObjectNode object = JsonUtil.toObject(value);
-							Syn1Schema model = (Syn1Schema) node.createSchema();
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+						if (model != null)
 							node.addProperty(key, model);
-							readSchema(object, model);
-						} else if (JsonUtil.isBoolean(value)) {
-							Boolean pValue = JsonUtil.toBoolean(value);
-							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-							node.addProperty(key, unionValue);
-						}
 					}
 				});
 			}
@@ -250,37 +206,22 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
 			if (array != null) {
-				array.forEach(value -> {
-					if (JsonUtil.isObject(value)) {
-						ObjectNode object = JsonUtil.toObject(value);
-						Syn1Schema model = (Syn1Schema) node.createSchema();
-						node.addAllOf(model);
-						readSchema(object, model);
-					} else if (JsonUtil.isBoolean(value)) {
-						Boolean pValue = JsonUtil.toBoolean(value);
-						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-						node.addAllOf(unionValue);
-					}
+				array.forEach(item -> {
+					BooleanSchemaUnion value = this.readBooleanSchemaUnion(item, null);
+					if (value != null)
+						node.addAllOf(value);
 				});
 			}
 		}
 		{
-			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "definitions");
-			if (mapObject != null) {
-				List<String> keys = JsonUtil.keys(mapObject);
-				keys.forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "definitions");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						if (JsonUtil.isObject(value)) {
-							ObjectNode object = JsonUtil.toObject(value);
-							Syn1Schema model = (Syn1Schema) node.createSchema();
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+						if (model != null)
 							node.addDefinition(key, model);
-							readSchema(object, model);
-						} else if (JsonUtil.isBoolean(value)) {
-							Boolean pValue = JsonUtil.toBoolean(value);
-							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-							node.addDefinition(key, unionValue);
-						}
 					}
 				});
 			}
@@ -291,7 +232,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonUtil.keys(mapObj).forEach(key -> {
 					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						SchemaOrBoolean model = this.readSchemaOrBoolean(value);
+						SchemaOrBoolean model = this.readSchemaOrBoolean(value, null);
 						if (model != null)
 							node.addNestedSchema(key, model);
 					}
@@ -302,7 +243,7 @@ public class Syn1ModelReader implements ModelReader {
 			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
 			if (array != null) {
 				array.forEach(item -> {
-					SchemaOrBoolean value = this.readSchemaOrBoolean(item);
+					SchemaOrBoolean value = this.readSchemaOrBoolean(item, null);
 					if (value != null)
 						node.addComposedSchema(value);
 				});
@@ -425,23 +366,23 @@ public class Syn1ModelReader implements ModelReader {
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
-	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json) {
+	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject() && json.has("type")) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
-	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject()) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
@@ -458,34 +399,26 @@ public class Syn1ModelReader implements ModelReader {
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
-	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject()) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
 	@Override
 	public RootCapable readRoot(JsonNode json) {
-		if (json.isObject() && json.has("type")) {
-			Syn1Schema rootModel = new Syn1SchemaImpl();
-			this.readSchema((ObjectNode) json, rootModel);
-			return rootModel;
-		} else if (JsonUtil.isBoolean(json)) {
-			Boolean value = JsonUtil.toBoolean(json);
-			return new BooleanUnionValueImpl(value, ModelType.SYN1);
-		}
-		return null;
+		return (RootCapable) this.readSchemaOrBoolean(json, ModelType.SYN1);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.SynItem;
-import io.test.synthetic.SynSchema;
 import io.test.synthetic.io.ModelWriter;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
@@ -20,6 +19,7 @@ import io.test.synthetic.v1.Syn1Operation;
 import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -123,17 +123,9 @@ public class Syn1ModelWriter implements ModelWriter {
 		}
 		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
 		{
-			BooleanSchemaUnion union = node.getDefaultValue();
-			if (union != null) {
-				if (union.isBoolean()) {
-					JsonUtil.setBooleanProperty(json, "defaultValue", union.asBoolean());
-				}
-				if (union.isSchema()) {
-					ObjectNode jsonValue = JsonUtil.objectNode();
-					this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
-					JsonUtil.setObjectProperty(json, "defaultValue", jsonValue);
-				}
-			}
+			JsonNode value = this.writeBooleanSchemaUnion(node.getDefaultValue());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "defaultValue", value);
 		}
 		JsonUtil.setStringProperty(json, "title", node.getTitle());
 		{
@@ -155,87 +147,55 @@ public class Syn1ModelWriter implements ModelWriter {
 		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
 		JsonUtil.setStringProperty(json, "type", node.getType());
 		{
-			BooleanSchemaSchemaListUnion union = node.getItems();
-			if (union != null) {
-				if (union.isBoolean()) {
-					JsonUtil.setBooleanProperty(json, "items", union.asBoolean());
-				}
-				if (union.isSchema()) {
-					ObjectNode jsonValue = JsonUtil.objectNode();
-					this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
-					JsonUtil.setObjectProperty(json, "items", jsonValue);
-				}
-				if (union.isSchemaList()) {
-					List<? extends SynSchema> models = union.asSchemaList();
-					ArrayNode array = JsonUtil.arrayNode();
-					models.forEach(model -> {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn1Schema) model, object);
-						JsonUtil.addToArray(array, object);
-					});
-					JsonUtil.setAnyProperty(json, "items", array);
-				}
-			}
+			JsonNode value = this.writeBooleanSchemaSchemaListUnion(node.getItems());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "items", value);
 		}
 		{
-			Map<String, BooleanSchemaUnion> unionMap = node.getProperties();
-			if (unionMap != null && !unionMap.isEmpty()) {
-				ObjectNode mapObject = JsonUtil.objectNode();
-				unionMap.keySet().forEach(key -> {
-					BooleanSchemaUnion union = unionMap.get(key);
-					if (union.isBoolean()) {
-						mapObject.put(key, union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn1Schema) union.asSchema(), object);
-						JsonUtil.setObjectProperty(mapObject, key, object);
-					}
+			Map<String, BooleanSchemaUnion> items = node.getProperties();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "properties", mapObject);
+				JsonUtil.setObjectProperty(json, "properties", mapJson);
 			}
 		}
 		{
-			List<BooleanSchemaUnion> unionList = node.getAllOf();
-			if (unionList != null && !unionList.isEmpty()) {
+			List<BooleanSchemaUnion> items = node.getAllOf();
+			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				unionList.forEach(union -> {
-					if (union.isBoolean()) {
-						array.add(union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn1Schema) union.asSchema(), object);
-						JsonUtil.addToArray(array, object);
-					}
+				items.forEach(item -> {
+					JsonNode value = this.writeBooleanSchemaUnion(item);
+					if (value != null)
+						array.add(value);
 				});
-				JsonUtil.setArrayProperty(json, "allOf", array);
+				JsonUtil.setAnyProperty(json, "allOf", array);
 			}
 		}
 		{
-			Map<String, BooleanSchemaUnion> unionMap = node.getDefinitions();
-			if (unionMap != null && !unionMap.isEmpty()) {
-				ObjectNode mapObject = JsonUtil.objectNode();
-				unionMap.keySet().forEach(key -> {
-					BooleanSchemaUnion union = unionMap.get(key);
-					if (union.isBoolean()) {
-						mapObject.put(key, union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn1Schema) union.asSchema(), object);
-						JsonUtil.setObjectProperty(mapObject, key, object);
-					}
+			Map<String, BooleanSchemaUnion> items = node.getDefinitions();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+				JsonUtil.setObjectProperty(json, "definitions", mapJson);
 			}
 		}
 		{
 			Map<String, SchemaOrBoolean> items = node.getNestedSchemas();
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
-				items.forEach((key, item) -> {
-					JsonNode value = this.writeSchemaOrBoolean(item);
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
 						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
@@ -385,6 +345,15 @@ public class Syn1ModelWriter implements ModelWriter {
 			this.writeSchema((Syn1Schema) union.asSchema(), jsonValue);
 			return jsonValue;
 		}
+		if (union.isSchemaList()) {
+			ArrayNode array = JsonUtil.arrayNode();
+			for (Object item : (java.util.List<?>) union.asSchemaList()) {
+				ObjectNode itemNode = JsonUtil.objectNode();
+				this.writeSchema((Syn1Schema) item, itemNode);
+				array.add(itemNode);
+			}
+			return array;
+		}
 		if (union.isBoolean()) {
 			return JsonUtil.booleanToJsonNode(union.asBoolean());
 		}
@@ -407,10 +376,10 @@ public class Syn1ModelWriter implements ModelWriter {
 
 	@Override
 	public ObjectNode writeRoot(RootCapable node) {
-		ObjectNode json = JsonUtil.objectNode();
-		if (node instanceof Syn1Schema) {
-			this.writeSchema((Syn1Schema) node, json);
+		JsonNode result = this.writeSchemaOrBoolean((SchemaOrBoolean) node);
+		if (result instanceof ObjectNode) {
+			return (ObjectNode) result;
 		}
-		return json;
+		return null;
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -7,10 +7,13 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
 import io.test.synthetic.union.SchemaOrBoolean;
+import io.test.synthetic.union.UnionValue;
+import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -207,9 +210,42 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("additionalSchema");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("additionalSchema");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			} else if (value.isEntityList()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+				for (Object entity : entityList) {
+					if (entity != null) {
+						((NodeImpl) entity)._setParent(this);
+						((NodeImpl) entity)._setParentPropertyName("additionalSchema");
+						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+					}
+				}
+			} else if (value.isEntityMap()) {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					if (entity != null) {
+						entity._setParent(this);
+						entity._setParentPropertyName("additionalSchema");
+						entity._setParentPropertyType(ParentPropertyType.map);
+						entity._setMapPropertyName(key);
+					}
+				}
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -293,8 +293,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null) {
-			((NodeImpl) value)._setParent(this);
+		if (value != null && value.isEntity()) {
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -327,8 +326,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		} else {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
-		if (value != null) {
-			((NodeImpl) value)._setParent(this);
+		if (value != null && value.isEntity()) {
 			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
 			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
 			((NodeImpl) value)._setMapPropertyName(name);
@@ -347,9 +345,15 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("composedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("composedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 
@@ -382,9 +386,15 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("composedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("composedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -126,10 +126,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("properties");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("properties");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -159,10 +167,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		} else {
 			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("properties");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("properties");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -242,10 +258,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("definitions");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("definitions");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -275,10 +299,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		} else {
 			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("definitions");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("definitions");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -293,10 +325,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 
@@ -326,10 +366,18 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		} else {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
-		if (value != null && value.isEntity()) {
-			((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+		if (value != null) {
+			if (value.isEntity()) {
+				((NodeImpl) value)._setParent(this);
+				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
+				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
+				((NodeImpl) value)._setMapPropertyName(name);
+			} else {
+				((UnionValueImpl<?>) value)._setParent(this);
+				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
+				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
+				((UnionValueImpl<?>) value)._setMapPropertyName(name);
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -3,14 +3,11 @@ package io.test.synthetic.v2.io;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.ModelType;
-import io.test.synthetic.NodeImpl;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.io.ModelReader;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
-import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
-import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
 import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
@@ -74,7 +71,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
 			if (value != null) {
-				node.setAdditionalSchema(this.readSchemaOrBoolean(value));
+				node.setAdditionalSchema(this.readSchemaOrBoolean(value, null));
 			}
 		}
 		{
@@ -176,17 +173,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
 			if (value != null) {
-				if (JsonUtil.isObjectWithProperty(value, "type")) {
-					ObjectNode object = JsonUtil.toObject(value);
-					node.setDefaultValue(node.createSchema());
-					readSchema(object, (Syn2Schema) node.getDefaultValue());
-				} else if (JsonUtil.isBoolean(value)) {
-					Boolean pValue = JsonUtil.toBoolean(value);
-					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-					node.setDefaultValue(unionValue);
-				} else {
-					node.addExtraProperty("defaultValue", value);
-				}
+				node.setDefaultValue(this.readBooleanSchemaUnion(value, null));
 			}
 		}
 		{
@@ -219,49 +206,18 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
 			if (value != null) {
-				if (JsonUtil.isObjectWithProperty(value, "type")) {
-					ObjectNode object = JsonUtil.toObject(value);
-					node.setItems(node.createSchema());
-					readSchema(object, (Syn2Schema) node.getItems());
-				} else if (JsonUtil.isArray(value)) {
-					List<JsonNode> array = JsonUtil.toList(value);
-					List<Syn2Schema> models = new ArrayList<>();
-					array.forEach(item -> {
-						ObjectNode object = JsonUtil.toObject(item);
-						Syn2Schema model = (Syn2Schema) node.createSchema();
-						((NodeImpl) model)._setParent(node);
-						this.readSchema(object, model);
-						models.add(model);
-					});
-					@SuppressWarnings({"unchecked", "rawtypes"})
-					SchemaListUnionValue unionValue = new SchemaListUnionValueImpl((List) models);
-					node.setItems(unionValue);
-				} else if (JsonUtil.isBoolean(value)) {
-					Boolean pValue = JsonUtil.toBoolean(value);
-					BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-					node.setItems(unionValue);
-				} else {
-					node.addExtraProperty("items", value);
-				}
+				node.setItems(this.readBooleanSchemaSchemaListUnion(value, null));
 			}
 		}
 		{
-			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "properties");
-			if (mapObject != null) {
-				List<String> keys = JsonUtil.keys(mapObject);
-				keys.forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "properties");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						if (JsonUtil.isObject(value)) {
-							ObjectNode object = JsonUtil.toObject(value);
-							Syn2Schema model = (Syn2Schema) node.createSchema();
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+						if (model != null)
 							node.addProperty(key, model);
-							readSchema(object, model);
-						} else if (JsonUtil.isBoolean(value)) {
-							Boolean pValue = JsonUtil.toBoolean(value);
-							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-							node.addProperty(key, unionValue);
-						}
 					}
 				});
 			}
@@ -269,37 +225,22 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
 			if (array != null) {
-				array.forEach(value -> {
-					if (JsonUtil.isObject(value)) {
-						ObjectNode object = JsonUtil.toObject(value);
-						Syn2Schema model = (Syn2Schema) node.createSchema();
-						node.addAllOf(model);
-						readSchema(object, model);
-					} else if (JsonUtil.isBoolean(value)) {
-						Boolean pValue = JsonUtil.toBoolean(value);
-						BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-						node.addAllOf(unionValue);
-					}
+				array.forEach(item -> {
+					BooleanSchemaUnion value = this.readBooleanSchemaUnion(item, null);
+					if (value != null)
+						node.addAllOf(value);
 				});
 			}
 		}
 		{
-			ObjectNode mapObject = JsonUtil.consumeObjectProperty(json, "definitions");
-			if (mapObject != null) {
-				List<String> keys = JsonUtil.keys(mapObject);
-				keys.forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObject, key);
+			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "definitions");
+			if (mapObj != null) {
+				JsonUtil.keys(mapObj).forEach(key -> {
+					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						if (JsonUtil.isObject(value)) {
-							ObjectNode object = JsonUtil.toObject(value);
-							Syn2Schema model = (Syn2Schema) node.createSchema();
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+						if (model != null)
 							node.addDefinition(key, model);
-							readSchema(object, model);
-						} else if (JsonUtil.isBoolean(value)) {
-							Boolean pValue = JsonUtil.toBoolean(value);
-							BooleanUnionValue unionValue = new BooleanUnionValueImpl(pValue);
-							node.addDefinition(key, unionValue);
-						}
 					}
 				});
 			}
@@ -310,7 +251,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonUtil.keys(mapObj).forEach(key -> {
 					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
 					if (value != null) {
-						SchemaOrBoolean model = this.readSchemaOrBoolean(value);
+						SchemaOrBoolean model = this.readSchemaOrBoolean(value, null);
 						if (model != null)
 							node.addNestedSchema(key, model);
 					}
@@ -321,7 +262,7 @@ public class Syn2ModelReader implements ModelReader {
 			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
 			if (array != null) {
 				array.forEach(item -> {
-					SchemaOrBoolean value = this.readSchemaOrBoolean(item);
+					SchemaOrBoolean value = this.readSchemaOrBoolean(item, null);
 					if (value != null)
 						node.addComposedSchema(value);
 				});
@@ -451,23 +392,23 @@ public class Syn2ModelReader implements ModelReader {
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
-	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json) {
+	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject() && json.has("type")) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
-	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject()) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
@@ -484,34 +425,26 @@ public class Syn2ModelReader implements ModelReader {
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
-	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
 		if (json == null)
 			return null;
-		if (json.isObject()) {
+		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json));
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
 		}
 		return null;
 	}
 
 	@Override
 	public RootCapable readRoot(JsonNode json) {
-		if (json.isObject() && json.has("type")) {
-			Syn2Schema rootModel = new Syn2SchemaImpl();
-			this.readSchema((ObjectNode) json, rootModel);
-			return rootModel;
-		} else if (JsonUtil.isBoolean(json)) {
-			Boolean value = JsonUtil.toBoolean(json);
-			return new BooleanUnionValueImpl(value, ModelType.SYN2);
-		}
-		return null;
+		return (RootCapable) this.readSchemaOrBoolean(json, ModelType.SYN2);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.RootCapable;
 import io.test.synthetic.SynItem;
 import io.test.synthetic.SynPathItem;
-import io.test.synthetic.SynSchema;
 import io.test.synthetic.io.ModelWriter;
 import io.test.synthetic.union.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.union.BooleanSchemaUnion;
@@ -21,6 +20,7 @@ import io.test.synthetic.v2.Syn2Operation;
 import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -137,17 +137,9 @@ public class Syn2ModelWriter implements ModelWriter {
 		}
 		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
 		{
-			BooleanSchemaUnion union = node.getDefaultValue();
-			if (union != null) {
-				if (union.isBoolean()) {
-					JsonUtil.setBooleanProperty(json, "defaultValue", union.asBoolean());
-				}
-				if (union.isSchema()) {
-					ObjectNode jsonValue = JsonUtil.objectNode();
-					this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
-					JsonUtil.setObjectProperty(json, "defaultValue", jsonValue);
-				}
-			}
+			JsonNode value = this.writeBooleanSchemaUnion(node.getDefaultValue());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "defaultValue", value);
 		}
 		JsonUtil.setStringProperty(json, "title", node.getTitle());
 		JsonUtil.setBooleanProperty(json, "deprecated", node.isDeprecated());
@@ -170,87 +162,55 @@ public class Syn2ModelWriter implements ModelWriter {
 		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
 		JsonUtil.setStringProperty(json, "type", node.getType());
 		{
-			BooleanSchemaSchemaListUnion union = node.getItems();
-			if (union != null) {
-				if (union.isBoolean()) {
-					JsonUtil.setBooleanProperty(json, "items", union.asBoolean());
-				}
-				if (union.isSchema()) {
-					ObjectNode jsonValue = JsonUtil.objectNode();
-					this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
-					JsonUtil.setObjectProperty(json, "items", jsonValue);
-				}
-				if (union.isSchemaList()) {
-					List<? extends SynSchema> models = union.asSchemaList();
-					ArrayNode array = JsonUtil.arrayNode();
-					models.forEach(model -> {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn2Schema) model, object);
-						JsonUtil.addToArray(array, object);
-					});
-					JsonUtil.setAnyProperty(json, "items", array);
-				}
-			}
+			JsonNode value = this.writeBooleanSchemaSchemaListUnion(node.getItems());
+			if (value != null)
+				JsonUtil.setAnyProperty(json, "items", value);
 		}
 		{
-			Map<String, BooleanSchemaUnion> unionMap = node.getProperties();
-			if (unionMap != null && !unionMap.isEmpty()) {
-				ObjectNode mapObject = JsonUtil.objectNode();
-				unionMap.keySet().forEach(key -> {
-					BooleanSchemaUnion union = unionMap.get(key);
-					if (union.isBoolean()) {
-						mapObject.put(key, union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn2Schema) union.asSchema(), object);
-						JsonUtil.setObjectProperty(mapObject, key, object);
-					}
+			Map<String, BooleanSchemaUnion> items = node.getProperties();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "properties", mapObject);
+				JsonUtil.setObjectProperty(json, "properties", mapJson);
 			}
 		}
 		{
-			List<BooleanSchemaUnion> unionList = node.getAllOf();
-			if (unionList != null && !unionList.isEmpty()) {
+			List<BooleanSchemaUnion> items = node.getAllOf();
+			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				unionList.forEach(union -> {
-					if (union.isBoolean()) {
-						array.add(union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn2Schema) union.asSchema(), object);
-						JsonUtil.addToArray(array, object);
-					}
+				items.forEach(item -> {
+					JsonNode value = this.writeBooleanSchemaUnion(item);
+					if (value != null)
+						array.add(value);
 				});
-				JsonUtil.setArrayProperty(json, "allOf", array);
+				JsonUtil.setAnyProperty(json, "allOf", array);
 			}
 		}
 		{
-			Map<String, BooleanSchemaUnion> unionMap = node.getDefinitions();
-			if (unionMap != null && !unionMap.isEmpty()) {
-				ObjectNode mapObject = JsonUtil.objectNode();
-				unionMap.keySet().forEach(key -> {
-					BooleanSchemaUnion union = unionMap.get(key);
-					if (union.isBoolean()) {
-						mapObject.put(key, union.asBoolean());
-					}
-					if (union.isSchema()) {
-						ObjectNode object = JsonUtil.objectNode();
-						this.writeSchema((Syn2Schema) union.asSchema(), object);
-						JsonUtil.setObjectProperty(mapObject, key, object);
-					}
+			Map<String, BooleanSchemaUnion> items = node.getDefinitions();
+			if (items != null && !items.isEmpty()) {
+				ObjectNode mapJson = JsonUtil.objectNode();
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
+					if (value != null)
+						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "definitions", mapObject);
+				JsonUtil.setObjectProperty(json, "definitions", mapJson);
 			}
 		}
 		{
 			Map<String, SchemaOrBoolean> items = node.getNestedSchemas();
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
-				items.forEach((key, item) -> {
-					JsonNode value = this.writeSchemaOrBoolean(item);
+				Collection<String> keys = items.keySet();
+				keys.forEach(key -> {
+					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
 						JsonUtil.setAnyProperty(mapJson, key, value);
 				});
@@ -407,6 +367,15 @@ public class Syn2ModelWriter implements ModelWriter {
 			this.writeSchema((Syn2Schema) union.asSchema(), jsonValue);
 			return jsonValue;
 		}
+		if (union.isSchemaList()) {
+			ArrayNode array = JsonUtil.arrayNode();
+			for (Object item : (java.util.List<?>) union.asSchemaList()) {
+				ObjectNode itemNode = JsonUtil.objectNode();
+				this.writeSchema((Syn2Schema) item, itemNode);
+				array.add(itemNode);
+			}
+			return array;
+		}
 		if (union.isBoolean()) {
 			return JsonUtil.booleanToJsonNode(union.asBoolean());
 		}
@@ -429,10 +398,10 @@ public class Syn2ModelWriter implements ModelWriter {
 
 	@Override
 	public ObjectNode writeRoot(RootCapable node) {
-		ObjectNode json = JsonUtil.objectNode();
-		if (node instanceof Syn2Schema) {
-			this.writeSchema((Syn2Schema) node, json);
+		JsonNode result = this.writeSchemaOrBoolean((SchemaOrBoolean) node);
+		if (result instanceof ObjectNode) {
+			return (ObjectNode) result;
 		}
-		return json;
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary

- Setter, add, remove, clear, and insert method generation in `CreateImplMethodsStage` now checks `resolvedType` (the Type hierarchy) before falling back to `PropertyType`
- This fixes type alias properties (e.g., `SchemaOrBoolean = boolean|Schema`) being misidentified as entities instead of unions by the legacy `PropertyType` system
- Star/regex properties still use `PropertyType` (they don't have `resolvedType`)

## Context

The JSON Schema spec rewrite uses type aliases like `Schema = boolean|JSchema`. When a property is typed as `Schema`, `PropertyType` sees it as a simple entity name (not a union), causing:
- `CreateInterfaceMethodsStage`: "Could not resolve entity type: Schema" warnings
- `CreateImplMethodsStage`: entity setter generated instead of union setter, leading to `ClassCastException` at runtime

This PR fixes the impl stage. The interface stage already works via `AbstractCreateMethodsStage.createGetter/createSetter` which check `resolvedType` first.

## Test plan

- [x] Generator tests pass (SyntheticSnapshotTest, FullGeneratorTest)
- [x] All 1129 data-models tests pass
- [x] Synthetic spec `SchemaOrBoolean` type alias properties generate correct union setter code