### PR TITLE
feat(generator): add resolvedType dispatch to CreateClonersStage

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -148,6 +148,8 @@ public class CreateClonersStage extends AbstractJavaStage {
                 handleStarProperty(body);
             } else if (isRegexProperty(property)) {
                 handleRegexProperty(body);
+            } else if (handleViaResolvedType(body)) {
+                // Handled by resolved type dispatch
             } else if (isEntity(property)) {
                 handleEntityProperty(body);
             } else if (isPrimitive(property)) {
@@ -166,6 +168,31 @@ public class CreateClonersStage extends AbstractJavaStage {
                 warn("Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
                 warn("       property type: " + property.getType());
             }
+        }
+
+        private boolean handleViaResolvedType(BodyBuilder body) {
+            PropertyModel property = propertyWithOrigin.getProperty();
+            var resolved = property.getResolvedType();
+            if (resolved == null) return false;
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleUnionProperty(body);
+                return true;
+            }
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
+                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleUnionListProperty(body);
+                return true;
+            }
+
+            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
+                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                handleUnionMapProperty(body);
+                return true;
+            }
+
+            return false;
         }
 
         private void handlePrimitiveProperty(BodyBuilder body) {
@@ -425,12 +452,35 @@ public class CreateClonersStage extends AbstractJavaStage {
             }
         }
 
+        private PropertyType getEffectiveUnionType(PropertyModel property) {
+            if (property.getType().isUnion()) {
+                return property.getType();
+            }
+            var resolved = property.getResolvedType();
+            if (resolved != null && resolved.getRawType() != null) {
+                return PropertyType.parse(resolved.getRawType().asRawType());
+            }
+            return property.getType();
+        }
+
+        private String getUnionJavaTypeName(PropertyModel property, UnionPropertyType ut) {
+            var resolved = property.getResolvedType();
+            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType unionType
+                    && unionType.getAliasName() != null) {
+                var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+                var jt = getJavaTypeFactory().createJavaType(resolved, nsModel);
+                jt.addImportsTo(clonerClassSource);
+                return jt.getSimpleName();
+            }
+            return ut.toJavaTypeString();
+        }
+
         private void handleUnionProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            UnionPropertyType ut = new UnionPropertyType(property.getType());
+            UnionPropertyType ut = new UnionPropertyType(getEffectiveUnionType(property));
 
-            body.addContext("unionJavaType", ut.toJavaTypeString());
+            body.addContext("unionJavaType", getUnionJavaTypeName(property, ut));
             body.addContext("getterMethodName", getterMethodName(property));
             body.addContext("setterMethodName", setterMethodName(property));
 
@@ -481,13 +531,16 @@ public class CreateClonersStage extends AbstractJavaStage {
                     EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
                     if (nestedTypeEntity != null) {
                         JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        if (entityJavaSource != null) {
+                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
+                        if (entityJavaSource != null && entityImplSource != null) {
                             clonerClassSource.addImport(entityJavaSource);
+                            clonerClassSource.addImport(entityImplSource);
                             body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("createMethodName", createMethodName(nestedTypeEntity));
+                            body.addContext("entityImplType", entityImplSource.getName());
                             body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("            target.${setterMethodName}(target.${createMethodName}());");
-                            body.append("            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), (${entityType}) target.${getterMethodName}());");
+                            body.append("            ${entityType} tgtEntity = new ${entityImplType}();");
+                            body.append("            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtEntity);");
+                            body.append("            target.${setterMethodName}(tgtEntity);");
                         }
                     }
                 } else if (jt.isEntityList()) {
@@ -540,13 +593,26 @@ public class CreateClonersStage extends AbstractJavaStage {
         private void handleUnionListProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            PropertyType unionType = property.getType().getNested().iterator().next();
+            PropertyType unionType;
+            var resolved = property.getResolvedType();
+            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
+                    && lt.getValueType().getRawType() != null) {
+                unionType = PropertyType.parse(lt.getValueType().getRawType().asRawType());
+            } else {
+                unionType = property.getType().getNested().iterator().next();
+            }
             UnionPropertyType ut = new UnionPropertyType(unionType);
 
             clonerClassSource.addImport(List.class);
             ut.addImportsTo(clonerClassSource);
 
-            body.addContext("unionJavaType", ut.toJavaTypeString());
+            String unionJavaType = ut.toJavaTypeString();
+            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt2
+                    && lt2.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType vut
+                    && vut.getAliasName() != null) {
+                unionJavaType = vut.getAliasName();
+            }
+            body.addContext("unionJavaType", unionJavaType);
             body.addContext("getterMethodName", getterMethodName(property));
             body.addContext("addMethodName", addMethodName(singularize(property.getName())));
 
@@ -583,12 +649,14 @@ public class CreateClonersStage extends AbstractJavaStage {
                     EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
                     if (nestedTypeEntity != null) {
                         JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        if (entityJavaSource != null) {
+                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
+                        if (entityJavaSource != null && entityImplSource != null) {
                             clonerClassSource.addImport(entityJavaSource);
+                            clonerClassSource.addImport(entityImplSource);
                             body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("createMethodName", createMethodName(nestedTypeEntity));
+                            body.addContext("entityImplType", entityImplSource.getName());
                             body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("                ${entityType} tgtItem = (${entityType}) target.${createMethodName}();");
+                            body.append("                ${entityType} tgtItem = new ${entityImplType}();");
                             body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
                             body.append("                target.${addMethodName}(tgtItem);");
                         }
@@ -608,13 +676,26 @@ public class CreateClonersStage extends AbstractJavaStage {
         private void handleUnionMapProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            PropertyType unionType = property.getType().getNested().iterator().next();
+            PropertyType unionType;
+            var resolved = property.getResolvedType();
+            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
+                    && mt.getValueType().getRawType() != null) {
+                unionType = PropertyType.parse(mt.getValueType().getRawType().asRawType());
+            } else {
+                unionType = property.getType().getNested().iterator().next();
+            }
             UnionPropertyType ut = new UnionPropertyType(unionType);
 
             clonerClassSource.addImport(Map.class);
             ut.addImportsTo(clonerClassSource);
 
-            body.addContext("unionJavaType", ut.toJavaTypeString());
+            String unionJavaType = ut.toJavaTypeString();
+            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt2
+                    && mt2.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType vut
+                    && vut.getAliasName() != null) {
+                unionJavaType = vut.getAliasName();
+            }
+            body.addContext("unionJavaType", unionJavaType);
             body.addContext("getterMethodName", getterMethodName(property));
             body.addContext("addMethodName", addMethodName(singularize(property.getName())));
 
@@ -652,12 +733,14 @@ public class CreateClonersStage extends AbstractJavaStage {
                     EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
                     if (nestedTypeEntity != null) {
                         JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        if (entityJavaSource != null) {
+                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
+                        if (entityJavaSource != null && entityImplSource != null) {
                             clonerClassSource.addImport(entityJavaSource);
+                            clonerClassSource.addImport(entityImplSource);
                             body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("createMethodName", createMethodName(nestedTypeEntity));
+                            body.addContext("entityImplType", entityImplSource.getName());
                             body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("                ${entityType} tgtItem = (${entityType}) target.${createMethodName}();");
+                            body.append("                ${entityType} tgtItem = new ${entityImplType}();");
                             body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
                             body.append("                target.${addMethodName}(key, tgtItem);");
                         }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelCloner.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelCloner.java
@@ -8,6 +8,7 @@ import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
 import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.v1.Syn1Contact;
 import io.test.synthetic.v1.Syn1Document;
@@ -17,6 +18,7 @@ import io.test.synthetic.v1.Syn1Operation;
 import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.v1.Syn1SchemaImpl;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +54,19 @@ public class Syn1ModelCloner {
 			Map<String, String> srcMap = source.getMetadata();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				target.setMetadata(new LinkedHashMap<>(srcMap));
+			}
+		}
+		{
+			SchemaOrBoolean srcUnion = source.getAdditionalSchema();
+			if (srcUnion != null) {
+				if (srcUnion.isBoolean()) {
+					target.setAdditionalSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
+				}
+				if (srcUnion.isSchema()) {
+					Syn1Schema tgtEntity = new Syn1SchemaImpl();
+					this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtEntity);
+					target.setAdditionalSchema(tgtEntity);
+				}
 			}
 		}
 		{
@@ -151,8 +166,9 @@ public class Syn1ModelCloner {
 					target.setDefaultValue(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 				}
 				if (srcUnion.isSchema()) {
-					target.setDefaultValue(target.createSchema());
-					this.cloneSchema((Syn1Schema) srcUnion.asSchema(), (Syn1Schema) target.getDefaultValue());
+					Syn1Schema tgtEntity = new Syn1SchemaImpl();
+					this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtEntity);
+					target.setDefaultValue(tgtEntity);
 				}
 			}
 		}
@@ -189,8 +205,9 @@ public class Syn1ModelCloner {
 					target.setItems(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 				}
 				if (srcUnion.isSchema()) {
-					target.setItems(target.createSchema());
-					this.cloneSchema((Syn1Schema) srcUnion.asSchema(), (Syn1Schema) target.getItems());
+					Syn1Schema tgtEntity = new Syn1SchemaImpl();
+					this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtEntity);
+					target.setItems(tgtEntity);
 				}
 				if (srcUnion.isSchemaList()) {
 					List<Syn1Schema> clonedList = new ArrayList<>();
@@ -214,7 +231,7 @@ public class Syn1ModelCloner {
 						target.addProperty(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn1Schema tgtItem = (Syn1Schema) target.createSchema();
+						Syn1Schema tgtItem = new Syn1SchemaImpl();
 						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
 						target.addProperty(key, tgtItem);
 					}
@@ -229,7 +246,7 @@ public class Syn1ModelCloner {
 						target.addAllOf(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn1Schema tgtItem = (Syn1Schema) target.createSchema();
+						Syn1Schema tgtItem = new Syn1SchemaImpl();
 						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
 						target.addAllOf(tgtItem);
 					}
@@ -245,9 +262,40 @@ public class Syn1ModelCloner {
 						target.addDefinition(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn1Schema tgtItem = (Syn1Schema) target.createSchema();
+						Syn1Schema tgtItem = new Syn1SchemaImpl();
 						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
 						target.addDefinition(key, tgtItem);
+					}
+				});
+			}
+		}
+		{
+			Map<String, SchemaOrBoolean> srcMap = source.getNestedSchemas();
+			if (srcMap != null && !srcMap.isEmpty()) {
+				srcMap.keySet().forEach(key -> {
+					SchemaOrBoolean srcUnion = srcMap.get(key);
+					if (srcUnion.isBoolean()) {
+						target.addNestedSchema(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
+					}
+					if (srcUnion.isSchema()) {
+						Syn1Schema tgtItem = new Syn1SchemaImpl();
+						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
+						target.addNestedSchema(key, tgtItem);
+					}
+				});
+			}
+		}
+		{
+			List<SchemaOrBoolean> srcList = source.getComposedSchemas();
+			if (srcList != null && !srcList.isEmpty()) {
+				srcList.forEach(srcUnion -> {
+					if (srcUnion.isBoolean()) {
+						target.addComposedSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
+					}
+					if (srcUnion.isSchema()) {
+						Syn1Schema tgtItem = new Syn1SchemaImpl();
+						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
+						target.addComposedSchema(tgtItem);
 					}
 				});
 			}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelCloner.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelCloner.java
@@ -9,6 +9,7 @@ import io.test.synthetic.union.BooleanUnionValue;
 import io.test.synthetic.union.BooleanUnionValueImpl;
 import io.test.synthetic.union.SchemaListUnionValue;
 import io.test.synthetic.union.SchemaListUnionValueImpl;
+import io.test.synthetic.union.SchemaOrBoolean;
 import io.test.synthetic.util.JsonUtil;
 import io.test.synthetic.v2.Syn2Contact;
 import io.test.synthetic.v2.Syn2Document;
@@ -18,6 +19,7 @@ import io.test.synthetic.v2.Syn2Operation;
 import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.v2.Syn2SchemaImpl;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -63,6 +65,19 @@ public class Syn2ModelCloner {
 					this.clonePathItem((Syn2PathItem) srcMap.get(name), tgtItem);
 					target.addWebhook(name, tgtItem);
 				});
+			}
+		}
+		{
+			SchemaOrBoolean srcUnion = source.getAdditionalSchema();
+			if (srcUnion != null) {
+				if (srcUnion.isBoolean()) {
+					target.setAdditionalSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
+				}
+				if (srcUnion.isSchema()) {
+					Syn2Schema tgtEntity = new Syn2SchemaImpl();
+					this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtEntity);
+					target.setAdditionalSchema(tgtEntity);
+				}
 			}
 		}
 		{
@@ -163,8 +178,9 @@ public class Syn2ModelCloner {
 					target.setDefaultValue(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 				}
 				if (srcUnion.isSchema()) {
-					target.setDefaultValue(target.createSchema());
-					this.cloneSchema((Syn2Schema) srcUnion.asSchema(), (Syn2Schema) target.getDefaultValue());
+					Syn2Schema tgtEntity = new Syn2SchemaImpl();
+					this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtEntity);
+					target.setDefaultValue(tgtEntity);
 				}
 			}
 		}
@@ -202,8 +218,9 @@ public class Syn2ModelCloner {
 					target.setItems(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 				}
 				if (srcUnion.isSchema()) {
-					target.setItems(target.createSchema());
-					this.cloneSchema((Syn2Schema) srcUnion.asSchema(), (Syn2Schema) target.getItems());
+					Syn2Schema tgtEntity = new Syn2SchemaImpl();
+					this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtEntity);
+					target.setItems(tgtEntity);
 				}
 				if (srcUnion.isSchemaList()) {
 					List<Syn2Schema> clonedList = new ArrayList<>();
@@ -227,7 +244,7 @@ public class Syn2ModelCloner {
 						target.addProperty(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn2Schema tgtItem = (Syn2Schema) target.createSchema();
+						Syn2Schema tgtItem = new Syn2SchemaImpl();
 						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
 						target.addProperty(key, tgtItem);
 					}
@@ -242,7 +259,7 @@ public class Syn2ModelCloner {
 						target.addAllOf(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn2Schema tgtItem = (Syn2Schema) target.createSchema();
+						Syn2Schema tgtItem = new Syn2SchemaImpl();
 						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
 						target.addAllOf(tgtItem);
 					}
@@ -258,9 +275,40 @@ public class Syn2ModelCloner {
 						target.addDefinition(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
 					if (srcUnion.isSchema()) {
-						Syn2Schema tgtItem = (Syn2Schema) target.createSchema();
+						Syn2Schema tgtItem = new Syn2SchemaImpl();
 						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
 						target.addDefinition(key, tgtItem);
+					}
+				});
+			}
+		}
+		{
+			Map<String, SchemaOrBoolean> srcMap = source.getNestedSchemas();
+			if (srcMap != null && !srcMap.isEmpty()) {
+				srcMap.keySet().forEach(key -> {
+					SchemaOrBoolean srcUnion = srcMap.get(key);
+					if (srcUnion.isBoolean()) {
+						target.addNestedSchema(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
+					}
+					if (srcUnion.isSchema()) {
+						Syn2Schema tgtItem = new Syn2SchemaImpl();
+						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
+						target.addNestedSchema(key, tgtItem);
+					}
+				});
+			}
+		}
+		{
+			List<SchemaOrBoolean> srcList = source.getComposedSchemas();
+			if (srcList != null && !srcList.isEmpty()) {
+				srcList.forEach(srcUnion -> {
+					if (srcUnion.isBoolean()) {
+						target.addComposedSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
+					}
+					if (srcUnion.isSchema()) {
+						Syn2Schema tgtItem = new Syn2SchemaImpl();
+						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
+						target.addComposedSchema(tgtItem);
 					}
 				});
 			}


### PR DESCRIPTION
## Summary

- `CreateClonersStage` now checks `resolvedType` before falling back to `PropertyType` for union detection
- Type alias properties (e.g., `nestedSchemas: {SchemaOrBoolean}`) are now correctly cloned — previously silently skipped because `PropertyType` didn't recognize the alias as a union
- Union handlers extract the underlying union structure from the resolved type's raw type string

## Context

Same pattern as PRs #1093 (CreateImplMethodsStage, CreateReadersStage, CreateWritersStage). Without this fix, the JSON Schema spec rewrite produces 56 CloneTest failures because the cloner doesn't clone properties typed with union type aliases.

## Test plan

- [x] Generator tests pass (SyntheticSnapshotTest, FullGeneratorTest)
- [x] All 1129 data-models tests pass
- [x] Synthetic expected output now includes clone code for `nestedSchemas` (map of type alias) and `composedSchemas` (list of type alias)