### PR TITLE
fix(ref): fix root() traversal and enable $ref resolution tests

### DIFF
--- a/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityTest.java
@@ -3,7 +3,7 @@ package io.apitomy.datamodels.jsonschema.compat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -97,7 +97,6 @@ public class JsonSchemaCompatibilityTest {
         Assertions.assertTrue(JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated));
     }
 
-    @Disabled("$ref/$id anchor resolution not yet implemented — see #1042")
     @Test
     public void testAnchorRefResolution() {
         var schema = """

--- a/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
+++ b/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
@@ -3007,7 +3007,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "id": "References: $ref",
       "compatibility": "both",
       "original": {
@@ -3066,7 +3066,7 @@
       "_disabledReason": "$ref/$id resolution not yet implemented \u2014 see #1042"
     },
     {
-      "enabled": false,
+      "enabled": true,
       "id": "References: $ref compatibility",
       "compatibility": "backward",
       "original": {
@@ -3121,7 +3121,7 @@
       "_disabledReason": "$ref/$id resolution not yet implemented \u2014 see #1042"
     },
     {
-      "enabled": false,
+      "enabled": true,
       "id": "References: $id",
       "compatibility": "both",
       "original": {
@@ -3181,7 +3181,7 @@
       "_disabledReason": "$ref/$id resolution not yet implemented \u2014 see #1042"
     },
     {
-      "enabled": false,
+      "enabled": true,
       "id": "References: $id compatibility",
       "compatibility": "backward",
       "original": {
@@ -3238,7 +3238,7 @@
       "_disabledReason": "$ref/$id resolution not yet implemented \u2014 see #1042"
     },
     {
-      "enabled": false,
+      "enabled": true,
       "id": "References: recursive",
       "compatibility": "both",
       "original": {

--- a/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/NodeImpl.java
@@ -29,10 +29,13 @@ public abstract class NodeImpl implements Node {
 
     @Override
     public RootCapable root() {
+        if (this._parent != null) {
+            return this._parent.root();
+        }
         if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
             return (RootCapable) this;
         }
-        return this._parent != null ? this._parent.root() : null;
+        return null;
     }
 
     @Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/NodeImpl.java
@@ -28,10 +28,13 @@ public abstract class NodeImpl implements Node {
 
 	@Override
 	public RootCapable root() {
+		if (this._parent != null) {
+			return this._parent.root();
+		}
 		if (this instanceof RootCapable && ((RootCapable) this).isRoot()) {
 			return (RootCapable) this;
 		}
-		return this._parent != null ? this._parent.root() : null;
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

- Fix `NodeImpl.root()` to check `_parent` before `isRoot()` — child nodes no longer incorrectly return themselves as root
- Enable all 6 previously disabled $ref/$id compatibility test cases (C25 in #1042)

## Root Cause

`NodeImpl.root()` checked `isRoot()` (returns true when `_modelType != null`) before checking `_parent`. The reader sets `_modelType` on ALL entities (not just the root), so every FullSchema in the tree returned itself as root. This broke `$ref` resolution — the resolver couldn't find the document root from child nodes to search for `#/definitions/...` or `#anchor` targets.

## Test plan

- [x] All 1129 tests pass (0 skipped — was 1 skipped before)
- [x] JsonSchemaCompatibilityTest: 6/6 pass (5 re-enabled from fixture data + 1 re-enabled Java test)
- [x] SyntheticSnapshotTest pass (expected output updated)
- [x] No regressions in IO, clone, validation, command, transform, dereference tests