### PR TITLE
feat(generator): add union collection support to traverser (G12a)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/AnchorFragmentResolver.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/AnchorFragmentResolver.java
@@ -20,8 +20,8 @@ import java.util.Set;
  * Scans the document tree for {@code $anchor} (2019-09+) or {@code $id}/{@code id} with
  * a fragment value (draft-4 through draft-7).
  * <p>
- * Manually walks the schema tree since the generated traverser
- * does not visit sub-schemas inside map/list properties like definitions.
+ * Walks the schema tree manually (rather than using the generated traverser)
+ * because anchor search needs to return a found node, not fire visitor callbacks.
  */
 public class AnchorFragmentResolver implements FragmentResolver {
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
@@ -118,7 +118,8 @@ public class CreateTraversersStage extends AbstractVisitorStage {
         body.append("node.accept(this.visitor);");
 
         Collection<PropertyModel> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel).stream().map(property -> property.getProperty()).filter(property -> {
-            return isEntity(property) || isEntityList(property) || isEntityMap(property) || isUnion(property);
+            return isEntity(property) || isEntityList(property) || isEntityMap(property)
+                    || isUnion(property) || isUnionList(property) || isUnionMap(property);
         }).collect(Collectors.toList());
 
         if (!allProperties.isEmpty()) {
@@ -147,6 +148,10 @@ public class CreateTraversersStage extends AbstractVisitorStage {
                 body.append("this.traverseMap(\"${propertyName}\", model.${propertyGetter}());");
             } else if (isUnion(property)) {
                 body.append("this.traverseUnion(\"${propertyName}\", model.${propertyGetter}());");
+            } else if (isUnionList(property)) {
+                body.append("this.traverseList(\"${propertyName}\", model.${propertyGetter}());");
+            } else if (isUnionMap(property)) {
+                body.append("this.traverseMap(\"${propertyName}\", model.${propertyGetter}());");
             } else {
                 warn("Unhandled property in traverser: " + property);
             }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -43,6 +43,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 		node.accept(this.visitor);
 		Syn1Schema model = (Syn1Schema) node;
 		this.traverseUnion("items", model.getItems());
+		this.traverseMap("properties", model.getProperties());
+		this.traverseList("allOf", model.getAllOf());
+		this.traverseMap("definitions", model.getDefinitions());
 		this.traverseMap("nestedSchemas", model.getNestedSchemas());
 		this.traverseList("composedSchemas", model.getComposedSchemas());
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -43,6 +43,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 		node.accept(this.visitor);
 		Syn2Schema model = (Syn2Schema) node;
 		this.traverseUnion("items", model.getItems());
+		this.traverseMap("properties", model.getProperties());
+		this.traverseList("allOf", model.getAllOf());
+		this.traverseMap("definitions", model.getDefinitions());
 		this.traverseMap("nestedSchemas", model.getNestedSchemas());
 		this.traverseList("composedSchemas", model.getComposedSchemas());
 	}


### PR DESCRIPTION
## Summary

- Add `isUnionList` and `isUnionMap` to `CreateTraversersStage` property filter and generation
- Previously, some union collections were traversed via PropertyType fallback (treating type alias names as entities), but entity-typed union collections like `properties: {Schema}`, `allOf: [Schema]`, `definitions: {Schema}` were missed
- Now all union list/map properties generate `traverseList`/`traverseMap` calls
- Update stale comment in `AnchorFragmentResolver`

## Context

Task C26 / G12a in #1042 and #1041. The generated traverser needs to visit map/list properties containing union types (e.g., `definitions`, `properties`, `allOf`/`anyOf`/`oneOf`). The base `traverseList`/`traverseMap` methods already handle union values correctly via `isNode()` check — entity variants are traversed, primitives are skipped.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Synthetic snapshot updated — 3 new traversal calls added per version (properties, allOf, definitions)
- [x] Generator tests pass (FullGeneratorTest, SyntheticSnapshotTest)