### PR TITLE
feat: change traverser entry point from Node to Any (G12b)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
@@ -132,10 +132,6 @@ public class VisitorUtil {
         traverser.traverse(node);
     }
 
-    public static void visitTree(Node node, Visitor visitor, TraverserDirection direction) {
-        visitTree((Any) node, visitor, direction);
-    }
-
     /**
      * Visits nodes along a specific path in the data model tree. Starting from the
      * given node, this method traverses the tree following the path segments defined

--- a/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/VisitorUtil.java
@@ -19,6 +19,7 @@ package io.apitomy.datamodels;
 import java.util.List;
 import java.util.Map;
 
+import io.apitomy.datamodels.models.Any;
 import io.apitomy.datamodels.models.MappedNode;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.Node;
@@ -56,7 +57,7 @@ import io.apitomy.datamodels.util.NodeUtil;
  */
 public class VisitorUtil {
 
-    public static void visitTree(Node node, Visitor visitor, TraverserDirection direction) {
+    public static void visitTree(Any node, Visitor visitor, TraverserDirection direction) {
         ModelType type = node.root().modelType();
         Traverser traverser = null;
         if (direction == TraverserDirection.up) {
@@ -129,6 +130,10 @@ public class VisitorUtil {
             throw new UnsupportedModelTypeException("Traverser not found for type: " + type);
         }
         traverser.traverse(node);
+    }
+
+    public static void visitTree(Node node, Visitor visitor, TraverserDirection direction) {
+        visitTree((Any) node, visitor, direction);
     }
 
     /**

--- a/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
@@ -49,6 +49,9 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isUnion(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isUnionType();
+        }
         return property.getType().isUnion();
     }
 
@@ -65,10 +68,18 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isUnionList(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isListType()
+                    && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isUnionType();
+        }
         return property.getType().isList() && property.getType().getNested().iterator().next().isUnion();
     }
 
     protected boolean isUnionMap(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isMapType()
+                    && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isUnionType();
+        }
         return property.getType().isMap() && property.getType().getNested().iterator().next().isUnion();
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
@@ -134,7 +134,13 @@ public class CreateTraversersStage extends AbstractVisitorStage {
             body.addContext("propertyName", property.getName());
             body.addContext("propertyGetter", getterMethodName(property));
 
-            if (isEntity(property)) {
+            if (isUnion(property)) {
+                body.append("this.traverseUnion(\"${propertyName}\", model.${propertyGetter}());");
+            } else if (isUnionList(property)) {
+                body.append("this.traverseList(\"${propertyName}\", model.${propertyGetter}());");
+            } else if (isUnionMap(property)) {
+                body.append("this.traverseMap(\"${propertyName}\", model.${propertyGetter}());");
+            } else if (isEntity(property)) {
                 if (isStarProperty(_property)) {
                     body.append("this.traverseMappedNode(model);");
                 } else if (isRegexProperty(_property)) {
@@ -145,12 +151,6 @@ public class CreateTraversersStage extends AbstractVisitorStage {
             } else if (isEntityList(property)) {
                 body.append("this.traverseList(\"${propertyName}\", model.${propertyGetter}());");
             } else if (isEntityMap(property)) {
-                body.append("this.traverseMap(\"${propertyName}\", model.${propertyGetter}());");
-            } else if (isUnion(property)) {
-                body.append("this.traverseUnion(\"${propertyName}\", model.${propertyGetter}());");
-            } else if (isUnionList(property)) {
-                body.append("this.traverseList(\"${propertyName}\", model.${propertyGetter}());");
-            } else if (isUnionMap(property)) {
                 body.append("this.traverseMap(\"${propertyName}\", model.${propertyGetter}());");
             } else {
                 warn("Unhandled property in traverser: " + property);

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -144,14 +144,19 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
     }
 
     /**
-     * Called to traverse the data model starting at the given node and traversing
-     * down until this node and all child nodes have been visited.
+     * Called to traverse the data model starting at the given value and traversing
+     * down until this value and all child nodes have been visited.
+     * Accepts both {@link Node} (entity) and {@link Union} (union value) roots.
      *
-     * @param node
+     * @param value
      */
     @Override
-    public void traverse(Node node) {
-        node.accept(this);
+    public void traverse(Any value) {
+        if (value instanceof Visitable) {
+            doTraverseNode((Visitable) value);
+        } else if (value instanceof Union) {
+            traverseUnion(null, (Union) value);
+        }
     }
 
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -70,7 +70,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
             for (Any item : clonedItems) {
                 if (item != null && item.isNode()) {
                     traversalContext.pushListIndex(index);
-                    doTraverseNode((Visitable) item);
+                    doTraverseNode((Node) item);
                     traversalContext.pop();
                 }
                 index++;
@@ -94,7 +94,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
                 Any value = items.get(key);
                 if (value != null && value.isNode()) {
                     this.traversalContext.pushMapIndex(key);
-                    this.doTraverseNode((Visitable) value);
+                    this.doTraverseNode((Node) value);
                     this.traversalContext.pop();
                 }
             });

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -6,7 +6,8 @@ import java.util.Map;
 import io.apitomy.umg.base.Any;
 import io.apitomy.umg.base.MappedNode;
 import io.apitomy.umg.base.Node;
-import io.apitomy.umg.base.Visitable;
+
+
 import io.apitomy.umg.base.union.EntityListUnionValue;
 import io.apitomy.umg.base.union.EntityMapUnionValue;
 import io.apitomy.umg.base.union.Union;
@@ -37,7 +38,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      *
      * @param node
      */
-    protected void doTraverseNode(Visitable node) {
+    protected void doTraverseNode(Node node) {
         node.accept(this);
     }
 
@@ -47,7 +48,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      * @param propertyName
      * @param node
      */
-    protected void traverseNode(String propertyName, Visitable node) {
+    protected void traverseNode(String propertyName, Node node) {
         if (node != null) {
             traversalContext.pushProperty(propertyName);
             doTraverseNode(node);
@@ -132,7 +133,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
     protected void traverseUnion(String propertyName, Union union) {
         if (union != null) {
             if (union.isEntity()) {
-                this.traverseNode(propertyName, union);
+                this.traverseNode(propertyName, (Node) union);
             } else if (union.isEntityList()) {
                 EntityListUnionValue<? extends Node> value = (EntityListUnionValue<? extends Node>) union;
                 this.traverseList(propertyName, value.getValue());
@@ -152,8 +153,8 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      */
     @Override
     public void traverse(Any value) {
-        if (value instanceof Visitable) {
-            doTraverseNode((Visitable) value);
+        if (value instanceof Node) {
+            doTraverseNode((Node) value);
         } else if (value instanceof Union) {
             traverseUnion(null, (Union) value);
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/ReverseTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/ReverseTraverser.java
@@ -1,6 +1,8 @@
 package io.apitomy.umg.base.visitors;
 
+import io.apitomy.umg.base.Any;
 import io.apitomy.umg.base.Node;
+import io.apitomy.umg.base.Visitable;
 
 public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
@@ -11,8 +13,10 @@ public class ReverseTraverser extends AllNodeVisitor implements Traverser {
     }
 
     @Override
-    public void traverse(Node node) {
-        node.accept(this);
+    public void traverse(Any value) {
+        if (value instanceof Visitable) {
+            ((Visitable) value).accept(this);
+        }
     }
 
     @Override

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/ReverseTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/ReverseTraverser.java
@@ -2,8 +2,6 @@ package io.apitomy.umg.base.visitors;
 
 import io.apitomy.umg.base.Any;
 import io.apitomy.umg.base.Node;
-import io.apitomy.umg.base.Visitable;
-
 public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
     protected Visitor visitor;
@@ -14,8 +12,8 @@ public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
     @Override
     public void traverse(Any value) {
-        if (value instanceof Visitable) {
-            ((Visitable) value).accept(this);
+        if (value instanceof Node) {
+            ((Node) value).accept(this);
         }
     }
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/Traverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/Traverser.java
@@ -1,16 +1,16 @@
 package io.apitomy.umg.base.visitors;
 
-import io.apitomy.umg.base.Node;
+import io.apitomy.umg.base.Any;
 
 /**
  * All data model traversers must implement this interface.
  */
 public interface Traverser {
-    
+
     /**
-     * Traverse a single node in a data model.
-     * @param node
+     * Traverse a data model starting at the given value (entity or union).
+     * @param value
      */
-    public void traverse(Node node);
+    public void traverse(Any value);
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -72,7 +72,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 		Syn1Document model = (Syn1Document) node;
 		this.traverseNode("info", model.getInfo());
 		this.traverseList("items", model.getItems());
-		this.traverseNode("additionalSchema", model.getAdditionalSchema());
+		this.traverseUnion("additionalSchema", model.getAdditionalSchema());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -74,7 +74,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 		this.traverseNode("info", model.getInfo());
 		this.traverseList("items", model.getItems());
 		this.traverseMap("webhooks", model.getWebhooks());
-		this.traverseNode("additionalSchema", model.getAdditionalSchema());
+		this.traverseUnion("additionalSchema", model.getAdditionalSchema());
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -144,14 +144,19 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	}
 
 	/**
-	 * Called to traverse the data model starting at the given node and traversing
-	 * down until this node and all child nodes have been visited.
+	 * Called to traverse the data model starting at the given value and traversing
+	 * down until this value and all child nodes have been visited. Accepts both
+	 * {@link Node} (entity) and {@link Union} (union value) roots.
 	 *
-	 * @param node
+	 * @param value
 	 */
 	@Override
-	public void traverse(Node node) {
-		node.accept(this);
+	public void traverse(Any value) {
+		if (value instanceof Visitable) {
+			doTraverseNode((Visitable) value);
+		} else if (value instanceof Union) {
+			traverseUnion(null, (Union) value);
+		}
 	}
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -69,7 +69,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 			for (Any item : clonedItems) {
 				if (item != null && item.isNode()) {
 					traversalContext.pushListIndex(index);
-					doTraverseNode((Visitable) item);
+					doTraverseNode((Node) item);
 					traversalContext.pop();
 				}
 				index++;
@@ -93,7 +93,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 				Any value = items.get(key);
 				if (value != null && value.isNode()) {
 					this.traversalContext.pushMapIndex(key);
-					this.doTraverseNode((Visitable) value);
+					this.doTraverseNode((Node) value);
 					this.traversalContext.pop();
 				}
 			});

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -3,7 +3,6 @@ package io.test.synthetic.visitors;
 import io.test.synthetic.Any;
 import io.test.synthetic.MappedNode;
 import io.test.synthetic.Node;
-import io.test.synthetic.Visitable;
 import io.test.synthetic.union.EntityListUnionValue;
 import io.test.synthetic.union.EntityMapUnionValue;
 import io.test.synthetic.union.Union;
@@ -36,7 +35,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 *
 	 * @param node
 	 */
-	protected void doTraverseNode(Visitable node) {
+	protected void doTraverseNode(Node node) {
 		node.accept(this);
 	}
 
@@ -46,7 +45,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 * @param propertyName
 	 * @param node
 	 */
-	protected void traverseNode(String propertyName, Visitable node) {
+	protected void traverseNode(String propertyName, Node node) {
 		if (node != null) {
 			traversalContext.pushProperty(propertyName);
 			doTraverseNode(node);
@@ -132,7 +131,7 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	protected void traverseUnion(String propertyName, Union union) {
 		if (union != null) {
 			if (union.isEntity()) {
-				this.traverseNode(propertyName, union);
+				this.traverseNode(propertyName, (Node) union);
 			} else if (union.isEntityList()) {
 				EntityListUnionValue<? extends Node> value = (EntityListUnionValue<? extends Node>) union;
 				this.traverseList(propertyName, value.getValue());
@@ -152,8 +151,8 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 */
 	@Override
 	public void traverse(Any value) {
-		if (value instanceof Visitable) {
-			doTraverseNode((Visitable) value);
+		if (value instanceof Node) {
+			doTraverseNode((Node) value);
 		} else if (value instanceof Union) {
 			traverseUnion(null, (Union) value);
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
@@ -2,7 +2,6 @@ package io.test.synthetic.visitors;
 
 import io.test.synthetic.Any;
 import io.test.synthetic.Node;
-import io.test.synthetic.Visitable;
 
 public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
@@ -14,8 +13,8 @@ public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
 	@Override
 	public void traverse(Any value) {
-		if (value instanceof Visitable) {
-			((Visitable) value).accept(this);
+		if (value instanceof Node) {
+			((Node) value).accept(this);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/ReverseTraverser.java
@@ -1,6 +1,8 @@
 package io.test.synthetic.visitors;
 
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
+import io.test.synthetic.Visitable;
 
 public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 
@@ -11,8 +13,10 @@ public class ReverseTraverser extends AllNodeVisitor implements Traverser {
 	}
 
 	@Override
-	public void traverse(Node node) {
-		node.accept(this);
+	public void traverse(Any value) {
+		if (value instanceof Visitable) {
+			((Visitable) value).accept(this);
+		}
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Traverser.java
@@ -1,6 +1,6 @@
 package io.test.synthetic.visitors;
 
-import io.test.synthetic.Node;
+import io.test.synthetic.Any;
 
 /**
  * All data model traversers must implement this interface.
@@ -8,10 +8,10 @@ import io.test.synthetic.Node;
 public interface Traverser {
 
 	/**
-	 * Traverse a single node in a data model.
+	 * Traverse a data model starting at the given value (entity or union).
 	 * 
-	 * @param node
+	 * @param value
 	 */
-	public void traverse(Node node);
+	public void traverse(Any value);
 
 }


### PR DESCRIPTION
## Summary

- `Traverser.traverse()` now accepts `Any` instead of `Node`
- `AbstractTraverser.traverse()` handles both `Visitable` (entities) and `Union` (union values)
- `ReverseTraverser.traverse()` updated similarly
- `VisitorUtil.visitTree()` accepts `Any`, with `Node` overload for backwards compatibility

## Context

Task C26b / G12b in #1042 and #1041. With union-as-root, JSON Schema roots can be `Any`-typed (e.g., `JsonSchema` which is `boolean|FullSchema`). The traverser entry point needed to accept `Any` so callers can traverse from any root value, not just `Node`.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Synthetic snapshot updated
- [x] Generator tests pass