### PR TITLE
refactor(generator): migrate AbstractStage helpers to resolvedType (C30b)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
@@ -37,14 +37,25 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isEntityList(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isListType()
+                    && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isEntityType();
+        }
         return property.getType().isList() && property.getType().getNested().iterator().next().isEntityType();
     }
 
     protected boolean isEntityMap(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isMapType()
+                    && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isEntityType();
+        }
         return property.getType().isMap() && property.getType().getNested().iterator().next().isEntityType();
     }
 
     protected boolean isEntity(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isEntityType();
+        }
         return property.getType().isEntityType();
     }
 
@@ -56,14 +67,25 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isPrimitive(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isPrimitiveType();
+        }
         return property.getType().isPrimitiveType();
     }
 
     protected boolean isPrimitiveList(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isListType()
+                    && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isPrimitiveType();
+        }
         return property.getType().isList() && property.getType().getNested().iterator().next().isPrimitiveType();
     }
 
     protected boolean isPrimitiveMap(PropertyModel property) {
+        if (property.getResolvedType() != null) {
+            return property.getResolvedType().isMapType()
+                    && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isPrimitiveType();
+        }
         return property.getType().isMap() && property.getType().getNested().iterator().next().isPrimitiveType();
     }
 


### PR DESCRIPTION
## Summary

All property type helpers in `AbstractStage` now check `resolvedType` first before falling back to `PropertyType`:
- `isEntity`, `isEntityList`, `isEntityMap`
- `isPrimitive`, `isPrimitiveList`, `isPrimitiveMap`

Previously only `isUnion`/`isUnionList`/`isUnionMap` had this pattern (PR #1107).

## Context

C30b in #1042 — incremental PropertyType removal. Since `resolvedType` is always set by `CreatePropertyAndTypeModelsStage` (confirmed: the old claim that star/regex properties lacked it was outdated), the PropertyType fallback is defensive only and can be removed in a future step (C30e).

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generator tests pass