### PR TITLE
refactor(generator): route reader/writer/cloner through resolvedType dispatch (C30d)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -150,23 +150,8 @@ public class CreateClonersStage extends AbstractJavaStage {
                 handleRegexProperty(body);
             } else if (handleViaResolvedType(body)) {
                 // Handled by resolved type dispatch
-            } else if (isEntity(property)) {
-                handleEntityProperty(body);
-            } else if (isPrimitive(property)) {
-                handlePrimitiveProperty(body);
-            } else if (isUnionList(property)) {
-                handleUnionListProperty(body);
-            } else if (isUnionMap(property)) {
-                handleUnionMapProperty(body);
-            } else if (property.getType().isList()) {
-                handleListProperty(body);
-            } else if (property.getType().isMap()) {
-                handleMapProperty(body);
-            } else if (property.getType().isUnion()) {
-                handleUnionProperty(body);
             } else {
                 warn("Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getType());
             }
         }
 
@@ -189,6 +174,23 @@ public class CreateClonersStage extends AbstractJavaStage {
             if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
                     && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleUnionMapProperty(body);
+                return true;
+            }
+
+            if (resolved.isEntityType()) {
+                handleEntityProperty(body);
+                return true;
+            }
+            if (resolved.isPrimitiveType()) {
+                handlePrimitiveProperty(body);
+                return true;
+            }
+            if (resolved.isListType()) {
+                handleListProperty(body);
+                return true;
+            }
+            if (resolved.isMapType()) {
+                handleMapProperty(body);
                 return true;
             }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -442,24 +442,9 @@ public class CreateReadersStage extends AbstractJavaStage {
             } else if (property.getName().startsWith("/")) {
                 handleRegexProperty(body);
             } else if (handleViaResolvedType(body)) {
-                // Handled by resolved type dispatch — union reader methods etc.
-            } else if (property.getType().isEntityType()) {
-                handleEntityProperty(body);
-            } else if (property.getType().isPrimitiveType()) {
-                handlePrimitiveTypeProperty(body);
-            } else if (isUnionList(propertyWithOrigin.getProperty())) {
-                handleUnionListProperty(body);
-            } else if (isUnionMap(propertyWithOrigin.getProperty())) {
-                handleUnionMapProperty(body);
-            } else if (property.getType().isList()) {
-                handleListProperty(body);
-            } else if (property.getType().isMap()) {
-                handleMapProperty(body);
-            } else if (property.getType().isUnion()) {
-                handleUnionProperty(body);
+                // Handled by resolved type dispatch
             } else {
                 warn("Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getType());
             }
         }
 
@@ -485,6 +470,30 @@ public class CreateReadersStage extends AbstractJavaStage {
             if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
                     && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionMapProperty(body, mt);
+                return true;
+            }
+
+            // Entity
+            if (resolved.isEntityType()) {
+                handleEntityProperty(body);
+                return true;
+            }
+
+            // Primitive
+            if (resolved.isPrimitiveType()) {
+                handlePrimitiveTypeProperty(body);
+                return true;
+            }
+
+            // List (entity or primitive)
+            if (resolved.isListType()) {
+                handleListProperty(body);
+                return true;
+            }
+
+            // Map (entity or primitive)
+            if (resolved.isMapType()) {
+                handleMapProperty(body);
                 return true;
             }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -396,23 +396,8 @@ public class CreateWritersStage extends AbstractJavaStage {
                 handleRegexProperty(body);
             } else if (handleViaResolvedType(body)) {
                 // Handled by resolved type dispatch
-            } else if (isEntity(property)) {
-                handleEntityProperty(body);
-            } else if (isPrimitive(property)) {
-                handlePrimitiveTypeProperty(body);
-            } else if (isUnionList(propertyWithOrigin.getProperty())) {
-                handleUnionListProperty(body);
-            } else if (isUnionMap(propertyWithOrigin.getProperty())) {
-                handleUnionMapProperty(body);
-            } else if (property.getType().isList()) {
-                handleListProperty(body);
-            } else if (property.getType().isMap()) {
-                handleMapProperty(body);
-            } else if (property.getType().isUnion()) {
-                handleUnionProperty(body);
             } else {
                 warn("Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getType());
             }
         }
 
@@ -436,6 +421,23 @@ public class CreateWritersStage extends AbstractJavaStage {
             if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
                     && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
                 handleResolvedUnionMapProperty(body, mt);
+                return true;
+            }
+
+            if (resolved.isEntityType()) {
+                handleEntityProperty(body);
+                return true;
+            }
+            if (resolved.isPrimitiveType()) {
+                handlePrimitiveTypeProperty(body);
+                return true;
+            }
+            if (resolved.isListType()) {
+                handleListProperty(body);
+                return true;
+            }
+            if (resolved.isMapType()) {
+                handleMapProperty(body);
                 return true;
             }
 


### PR DESCRIPTION
## Summary

All three property handler stages now route ALL property types through `handleViaResolvedType`:
- `CreateReadersStage`: entity, primitive, list, map added to resolved dispatch
- `CreateWritersStage`: same
- `CreateClonersStage`: same

PropertyType-based fallback branches removed from `writeTo()` in all three stages.

## Context

C30d in #1042 — the largest part of PropertyType removal. The individual handler methods still use PropertyType internally (they're called from the resolvedType dispatcher now), but the entry-point dispatch is fully resolvedType-based. This means no property goes through PropertyType checks to determine WHICH handler to call.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generator tests pass