### PR TITLE
refactor(generator): extract method classes from CreateImplMethodsStage (C32)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -2,23 +2,28 @@ package io.apitomy.umg.pipe.java;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.MethodHolderSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.java.JavaIndex;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.CollectionType;
-import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.ClearMethod;
+import io.apitomy.umg.pipe.java.method.FactoryMethod;
+import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.ImplMethodContext;
+import io.apitomy.umg.pipe.java.method.InsertMethod;
+import io.apitomy.umg.pipe.java.method.RemoveMethod;
+import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Creates methods on all entity implementation classes.  This follows the same algorithm
@@ -28,6 +33,68 @@ import io.apitomy.umg.pipe.java.method.BodyBuilder;
  * @author eric.wittmann@gmail.com
  */
 public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
+
+    private final ImplMethodContext ctx = new ImplMethodContext() {
+        @Override
+        public String getFieldName(PropertyModel property) {
+            return CreateImplMethodsStage.this.getFieldName(property);
+        }
+
+        @Override
+        public String getNodeEntityClassFQN() {
+            return CreateImplMethodsStage.this.getNodeEntityClassFQN();
+        }
+
+        @Override
+        public String getParentPropertyTypeEnumFQN() {
+            return CreateImplMethodsStage.this.getParentPropertyTypeEnumFQN();
+        }
+
+        @Override
+        public String getUnionValueInterfaceFQN() {
+            return CreateImplMethodsStage.this.getUnionValueInterfaceFQN();
+        }
+
+        @Override
+        public String getUnionTypeFQN(String name) {
+            return CreateImplMethodsStage.this.getUnionTypeFQN(name);
+        }
+
+        @Override
+        public String getDataModelUtilFQCN() {
+            return CreateImplMethodsStage.this.getDataModelUtilFQCN();
+        }
+
+        @Override
+        public String getJavaEntityClassFQN(EntityModel entity) {
+            return CreateImplMethodsStage.this.getJavaEntityClassFQN(entity);
+        }
+
+        @Override
+        public JavaClassSource lookupJavaEntityImpl(String fqn) {
+            return CreateImplMethodsStage.this.lookupJavaEntityImpl(fqn);
+        }
+
+        @Override
+        public JavaClassSource lookupJavaEntityImpl(EntityModel entity) {
+            return CreateImplMethodsStage.this.lookupJavaEntityImpl(entity);
+        }
+
+        @Override
+        public ConceptIndex getConceptIndex() {
+            return CreateImplMethodsStage.this.getState().getConceptIndex();
+        }
+
+        @Override
+        public JavaIndex getJavaIndex() {
+            return CreateImplMethodsStage.this.getState().getJavaIndex();
+        }
+
+        @Override
+        public void error(String message) {
+            CreateImplMethodsStage.this.error(message);
+        }
+    };
 
     @Override
     protected void doProcess() {
@@ -193,396 +260,43 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
 
     @Override
     protected void createGetterBody(PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-        body.append("return ${fieldName};");
-        method.setBody(body.toString());
+        new GetterMethod(property, ctx).writeTo(method);
     }
 
     @Override
     protected void createSetterBody(JavaSource<?> javaEntity, PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        String propertyName = property.getName();
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-        body.addContext("propertyName", propertyName);
-        body.append("this.${fieldName} = value;");
-        Type resolvedType = property.getResolvedType();
-        boolean isEntityType = resolvedType.isEntityType();
-        boolean isUnionType = resolvedType.isUnionType();
-        if (isEntityType) {
-            JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-            javaEntity.addImport(parentPropertyTypeSource);
-            JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-            javaEntity.addImport(nodeImplSource);
-
-            body.append("if (value != null) {");
-            body.append("    ((NodeImpl) value)._setParent(this);");
-            body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-            body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
-            body.append("}");
-        } else if (isUnionType) {
-            JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-            javaEntity.addImport(parentPropertyTypeSource);
-            JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-            javaEntity.addImport(nodeImplSource);
-            JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
-            javaEntity.addImport(unionValueSource);
-            JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
-            javaEntity.addImport(unionValueImplSource);
-
-            javaEntity.addImport(Collection.class);
-            javaEntity.addImport(List.class);
-            javaEntity.addImport(Map.class);
-
-            body.append("if (value != null) {");
-            body.append("    if (value.isEntity()) {");
-            body.append("        ((NodeImpl) value)._setParent(this);");
-            body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-            body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
-            body.append("    } else if (value.isEntityList()) {");
-            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-            body.append("        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();");
-            body.append("        for (Object entity : entityList) {");
-            body.append("            if (entity != null) {");
-            body.append("                ((NodeImpl) entity)._setParent(this);");
-            body.append("                ((NodeImpl) entity)._setParentPropertyName(\"${propertyName}\");");
-            body.append("                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);");
-            body.append("            }");
-            body.append("        }");
-            body.append("    } else if (value.isEntityMap()) {");
-            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-            body.append("        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();");
-            body.append("        Collection<String> keys = entityMap.keySet();");
-            body.append("        for (String key : keys) {");
-            body.append("            NodeImpl entity = (NodeImpl) entityMap.get(key);");
-            body.append("            if (entity != null) {");
-            body.append("                entity._setParent(this);");
-            body.append("                entity._setParentPropertyName(\"${propertyName}\");");
-            body.append("                entity._setParentPropertyType(ParentPropertyType.map);");
-            body.append("                entity._setMapPropertyName(key);");
-            body.append("            }");
-            body.append("        }");
-            body.append("    } else {");
-            body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-            body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-            body.append("    }");
-            body.append("}");
-        }
-        method.setBody(body.toString());
+        SetterMethod setter = new SetterMethod(javaEntity, property, ctx);
+        setter.addImportsTo(javaEntity);
+        setter.writeTo(method);
     }
 
     @Override
     protected void createFactoryMethodBody(JavaSource<?> javaEntity, String entityName, MethodSource<?> method) {
-        String entityFQN = javaEntity.getPackage() + "." + entityName;
-        EntityModel entityModel = getState().getConceptIndex().lookupEntity(entityFQN);
-        String implFQN = getJavaEntityClassFQN(entityModel);
-
-        JavaClassSource entityImpl = lookupJavaEntityImpl(implFQN);
-        if (entityImpl == null) {
-            error("Could not resolve entity type (impl): " + implFQN);
-            return;
-        }
-        javaEntity.addImport(entityImpl);
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("implClass", entityImpl.getName());
-        body.append("${implClass} node = new ${implClass}();");
-        body.append("node._setParent(this);");
-        body.append("return node;");
-        method.setBody(body.toString());
+        new FactoryMethod(javaEntity, entityName, ctx).writeTo(method);
     }
 
     @Override
     protected void createAddMethodBody(JavaSource<?> javaEntity, PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        String propertyName = property.getName();
-
-        Type resolvedType = property.getResolvedType();
-        Type resolvedValueType = resolvedType.isCollectionType()
-                ? ((CollectionType) resolvedType).getValueType()
-                : null;
-        boolean isEntityValue = resolvedValueType != null && resolvedValueType.isEntityType();
-        boolean isUnionValue = resolvedValueType != null && resolvedValueType.isUnionType();
-        boolean isPrimitiveValue = resolvedValueType != null && resolvedValueType.isPrimitiveType();
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-        body.addContext("propertyName", propertyName);
-
-        if (isEntityValue || isPrimitiveValue || isUnionValue) {
-            if (resolvedType.isMapType()) {
-                javaEntity.addImport(LinkedHashMap.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new LinkedHashMap<>();");
-                body.append("}");
-                body.append("this.${fieldName}.put(name, value);");
-                if (isEntityValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    ((NodeImpl) value)._setParent(this);");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
-                    body.append("}");
-                } else if (isUnionValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-                    JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
-                    javaEntity.addImport(unionValueSource);
-                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
-                    javaEntity.addImport(unionValueImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    if (value.isEntity()) {");
-                    body.append("        ((NodeImpl) value)._setParent(this);");
-                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
-                    body.append("    } else {");
-                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
-                    body.append("    }");
-                    body.append("}");
-                }
-            } else {
-                javaEntity.addImport(ArrayList.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new ArrayList<>();");
-                body.append("}");
-                body.append("this.${fieldName}.add(value);");
-                if (isEntityValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    ((NodeImpl) value)._setParent(this);");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("}");
-                } else if (isUnionValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-                    JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
-                    javaEntity.addImport(unionValueSource);
-
-                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
-                    javaEntity.addImport(unionValueImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    if (value.isEntity()) {");
-                    body.append("        ((NodeImpl) value)._setParent(this);");
-                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("    } else {");
-                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("    }");
-                    body.append("}");
-                }
-            }
-        }
-
-        method.setBody(body.toString());
+        AddMethod add = new AddMethod(javaEntity, property, ctx);
+        add.addImportsTo(javaEntity);
+        add.writeTo(method);
     }
 
     @Override
     protected void createClearMethodBody(PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        Type resolvedType = property.getResolvedType();
-        Type resolvedValueType = resolvedType.isCollectionType()
-                ? ((CollectionType) resolvedType).getValueType()
-                : null;
-        boolean needsDetach = resolvedValueType != null
-                && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType());
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-        if (needsDetach) {
-            String valuesExpr = resolvedType.isMapType()
-                    ? "this." + fieldName + ".values()" : "this." + fieldName;
-            body.addContext("valuesExpr", valuesExpr);
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    ${valuesExpr}.forEach(item -> {");
-            body.append("        if (item != null) item.detach();");
-            body.append("    });");
-            body.append("    this.${fieldName}.clear();");
-            body.append("}");
-        } else {
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    this.${fieldName}.clear();");
-            body.append("}");
-        }
-        method.setBody(body.toString());
+        new ClearMethod(property, ctx).writeTo(method);
     }
 
     @Override
     protected void createRemoveMethodBody(PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-
-        Type resolvedType = property.getResolvedType();
-        Type resolvedValueType = resolvedType.isCollectionType()
-                ? ((CollectionType) resolvedType).getValueType()
-                : null;
-        boolean needsDetach = resolvedValueType != null
-                && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType());
-        if (resolvedType.isListType()) {
-            body.append("if (this.${fieldName} != null) {");
-            if (needsDetach) {
-                body.append("    if (value != null && this.${fieldName}.remove(value)) {");
-                body.append("        value.detach();");
-                body.append("    }");
-            } else {
-                body.append("    this.${fieldName}.remove(value);");
-            }
-            body.append("}");
-        } else {
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    this.${fieldName}.remove(name);");
-            body.append("}");
-        }
-
-        method.setBody(body.toString());
+        new RemoveMethod(property, ctx).writeTo(method);
     }
 
     @Override
     protected void createInsertMethodBody(JavaSource<?> javaEntity, PropertyModel property, MethodSource<?> method) {
-        String fieldName = getFieldName(property);
-        String propertyName = property.getName();
-
-        Type resolvedType = property.getResolvedType();
-        Type resolvedValueType = resolvedType.isCollectionType()
-                ? ((CollectionType) resolvedType).getValueType()
-                : null;
-        boolean isEntityValue = resolvedValueType != null && resolvedValueType.isEntityType();
-        boolean isUnionValue = resolvedValueType != null && resolvedValueType.isUnionType();
-        boolean isPrimitiveValue = resolvedValueType != null && resolvedValueType.isPrimitiveType();
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("fieldName", fieldName);
-        body.addContext("propertyName", propertyName);
-
-        if (isEntityValue || isPrimitiveValue || isUnionValue) {
-            if (resolvedType.isMapType()) {
-                JavaClassSource dataModelUtilSource = getState().getJavaIndex().lookupClass(getDataModelUtilFQCN());
-                javaEntity.addImport(dataModelUtilSource);
-                javaEntity.addImport(LinkedHashMap.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new LinkedHashMap<>();");
-                body.append("    this.${fieldName}.put(name, value);");
-                body.append("} else {");
-                body.append("    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);");
-                body.append("}");
-
-                if (isEntityValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    ((NodeImpl) value)._setParent(this);");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
-                    body.append("}");
-                } else if (isUnionValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-                    JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
-                    javaEntity.addImport(unionValueSource);
-                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
-                    javaEntity.addImport(unionValueImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    if (value.isEntity()) {");
-                    body.append("        ((NodeImpl) value)._setParent(this);");
-                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
-                    body.append("    } else {");
-                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);");
-                    body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
-                    body.append("    }");
-                    body.append("}");
-                }
-            } else {
-                JavaClassSource dataModelUtilSource = getState().getJavaIndex().lookupClass(getDataModelUtilFQCN());
-                javaEntity.addImport(dataModelUtilSource);
-                javaEntity.addImport(ArrayList.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new ArrayList<>();");
-                body.append("    this.${fieldName}.add(value);");
-                body.append("} else {");
-                body.append("    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);");
-                body.append("}");
-                if (isEntityValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    ((NodeImpl) value)._setParent(this);");
-                    body.append("    ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("}");
-                } else if (isUnionValue) {
-                    JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                    javaEntity.addImport(parentPropertyTypeSource);
-                    JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                    javaEntity.addImport(nodeImplSource);
-                    JavaInterfaceSource unionValueSource = getState().getJavaIndex().lookupInterface(getUnionValueInterfaceFQN());
-                    javaEntity.addImport(unionValueSource);
-
-                    JavaClassSource unionValueImplSource = getState().getJavaIndex().lookupClass(getUnionTypeFQN("UnionValueImpl"));
-                    javaEntity.addImport(unionValueImplSource);
-
-                    body.append("if (value != null) {");
-                    body.append("    if (value.isEntity()) {");
-                    body.append("        ((NodeImpl) value)._setParent(this);");
-                    body.append("        ((NodeImpl) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("    } else {");
-                    body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(\"${propertyName}\");");
-                    body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);");
-                    body.append("    }");
-                    body.append("}");
-                }
-            }
-        }
-
-        method.setBody(body.toString());
+        InsertMethod insert = new InsertMethod(javaEntity, property, ctx);
+        insert.addImportsTo(javaEntity);
+        insert.writeTo(method);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
@@ -1,0 +1,92 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates an "add" method body: initialize collection if null, add value, then
+ * attach parent for entity/union types. Handles both list and map variants.
+ */
+public class AddMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final JavaSource<?> javaEntity;
+    private final ImplMethodContext ctx;
+    private final ParentAttachmentBlock parentBlock;
+
+    public AddMethod(JavaSource<?> javaEntity, PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.javaEntity = javaEntity;
+        this.ctx = ctx;
+
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+
+        if (resolvedValueType != null && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType())) {
+            ParentAttachmentBlock.ParentPropertyKind kind = resolvedType.isMapType()
+                    ? ParentAttachmentBlock.ParentPropertyKind.MAP
+                    : ParentAttachmentBlock.ParentPropertyKind.ARRAY;
+            this.parentBlock = new ParentAttachmentBlock(resolvedValueType, property.getName(), kind, ctx);
+        } else {
+            this.parentBlock = null;
+        }
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        String propertyName = property.getName();
+
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+        boolean isEntityValue = resolvedValueType != null && resolvedValueType.isEntityType();
+        boolean isUnionValue = resolvedValueType != null && resolvedValueType.isUnionType();
+        boolean isPrimitiveValue = resolvedValueType != null && resolvedValueType.isPrimitiveType();
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+        body.addContext("propertyName", propertyName);
+
+        if (isEntityValue || isPrimitiveValue || isUnionValue) {
+            if (resolvedType.isMapType()) {
+                javaEntity.addImport(LinkedHashMap.class);
+
+                body.append("if (this.${fieldName} == null) {");
+                body.append("    this.${fieldName} = new LinkedHashMap<>();");
+                body.append("}");
+                body.append("this.${fieldName}.put(name, value);");
+            } else {
+                javaEntity.addImport(ArrayList.class);
+
+                body.append("if (this.${fieldName} == null) {");
+                body.append("    this.${fieldName} = new ArrayList<>();");
+                body.append("}");
+                body.append("this.${fieldName}.add(value);");
+            }
+
+            if (parentBlock != null) {
+                parentBlock.appendTo(body);
+            }
+        }
+
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        if (parentBlock != null) {
+            parentBlock.addImportsTo(source);
+        }
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CanAddImports.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CanAddImports.java
@@ -1,0 +1,12 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+/**
+ * Interface for objects that can contribute import statements to a Java source file.
+ */
+public interface CanAddImports {
+
+    void addImportsTo(JavaSource<?> source);
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
@@ -1,0 +1,59 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates a "clear" method body: clear collection plus detach all items if entity/union.
+ */
+public class ClearMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final ImplMethodContext ctx;
+
+    public ClearMethod(PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.ctx = ctx;
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+        boolean needsDetach = resolvedValueType != null
+                && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType());
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+
+        if (needsDetach) {
+            String valuesExpr = resolvedType.isMapType()
+                    ? "this." + fieldName + ".values()" : "this." + fieldName;
+            body.addContext("valuesExpr", valuesExpr);
+            body.append("if (this.${fieldName} != null) {");
+            body.append("    ${valuesExpr}.forEach(item -> {");
+            body.append("        if (item != null) item.detach();");
+            body.append("    });");
+            body.append("    this.${fieldName}.clear();");
+            body.append("}");
+        } else {
+            body.append("if (this.${fieldName} != null) {");
+            body.append("    this.${fieldName}.clear();");
+            body.append("}");
+        }
+
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // No imports needed
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeBlock.java
@@ -1,0 +1,20 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+/**
+ * Abstract base for reusable code fragments that can be appended to a {@link BodyBuilder}.
+ */
+public abstract class CodeBlock implements CanAddImports {
+
+    /**
+     * Appends this code block's statements to the given body builder.
+     */
+    abstract void appendTo(BodyBuilder body);
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Default: no imports needed
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/FactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/FactoryMethod.java
@@ -1,0 +1,51 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+
+/**
+ * Generates a factory method body: create new entity impl instance and set parent.
+ */
+public class FactoryMethod implements CanAddImports {
+
+    private final JavaSource<?> javaEntity;
+    private final String entityName;
+    private final ImplMethodContext ctx;
+
+    private JavaClassSource entityImpl;
+
+    public FactoryMethod(JavaSource<?> javaEntity, String entityName, ImplMethodContext ctx) {
+        this.javaEntity = javaEntity;
+        this.entityName = entityName;
+        this.ctx = ctx;
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String entityFQN = javaEntity.getPackage() + "." + entityName;
+        EntityModel entityModel = ctx.getConceptIndex().lookupEntity(entityFQN);
+        String implFQN = ctx.getJavaEntityClassFQN(entityModel);
+
+        entityImpl = ctx.lookupJavaEntityImpl(implFQN);
+        if (entityImpl == null) {
+            ctx.error("Could not resolve entity type (impl): " + implFQN);
+            return;
+        }
+        javaEntity.addImport(entityImpl);
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("implClass", entityImpl.getName());
+        body.append("${implClass} node = new ${implClass}();");
+        body.append("node._setParent(this);");
+        body.append("return node;");
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo since we need to resolve the impl first
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/GetterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/GetterMethod.java
@@ -1,0 +1,34 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+
+/**
+ * Generates a getter method body: {@code return ${fieldName};}
+ */
+public class GetterMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final ImplMethodContext ctx;
+
+    public GetterMethod(PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.ctx = ctx;
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+        body.append("return ${fieldName};");
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // No imports needed
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ImplMethodContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ImplMethodContext.java
@@ -1,0 +1,40 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.index.java.JavaIndex;
+import io.apitomy.umg.index.concept.ConceptIndex;
+
+/**
+ * Provides the stage-level lookups that method classes need for resolving FQNs and
+ * looking up Java entities. This decouples method classes from the stage itself.
+ */
+public interface ImplMethodContext {
+
+    String getFieldName(PropertyModel property);
+
+    String getNodeEntityClassFQN();
+
+    String getParentPropertyTypeEnumFQN();
+
+    String getUnionValueInterfaceFQN();
+
+    String getUnionTypeFQN(String name);
+
+    String getDataModelUtilFQCN();
+
+    String getJavaEntityClassFQN(EntityModel entity);
+
+    JavaClassSource lookupJavaEntityImpl(String fqn);
+
+    JavaClassSource lookupJavaEntityImpl(EntityModel entity);
+
+    ConceptIndex getConceptIndex();
+
+    JavaIndex getJavaIndex();
+
+    void error(String message);
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
@@ -1,0 +1,101 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates an "insert" method body: initialize collection if null, insert at index
+ * using DataModelUtil, then attach parent for entity/union types.
+ */
+public class InsertMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final JavaSource<?> javaEntity;
+    private final ImplMethodContext ctx;
+    private final ParentAttachmentBlock parentBlock;
+
+    public InsertMethod(JavaSource<?> javaEntity, PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.javaEntity = javaEntity;
+        this.ctx = ctx;
+
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+
+        if (resolvedValueType != null && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType())) {
+            ParentAttachmentBlock.ParentPropertyKind kind = resolvedType.isMapType()
+                    ? ParentAttachmentBlock.ParentPropertyKind.MAP
+                    : ParentAttachmentBlock.ParentPropertyKind.ARRAY;
+            this.parentBlock = new ParentAttachmentBlock(resolvedValueType, property.getName(), kind, ctx);
+        } else {
+            this.parentBlock = null;
+        }
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        String propertyName = property.getName();
+
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+        boolean isEntityValue = resolvedValueType != null && resolvedValueType.isEntityType();
+        boolean isUnionValue = resolvedValueType != null && resolvedValueType.isUnionType();
+        boolean isPrimitiveValue = resolvedValueType != null && resolvedValueType.isPrimitiveType();
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+        body.addContext("propertyName", propertyName);
+
+        if (isEntityValue || isPrimitiveValue || isUnionValue) {
+            if (resolvedType.isMapType()) {
+                JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+                javaEntity.addImport(dataModelUtilSource);
+                javaEntity.addImport(LinkedHashMap.class);
+
+                body.append("if (this.${fieldName} == null) {");
+                body.append("    this.${fieldName} = new LinkedHashMap<>();");
+                body.append("    this.${fieldName}.put(name, value);");
+                body.append("} else {");
+                body.append("    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);");
+                body.append("}");
+            } else {
+                JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+                javaEntity.addImport(dataModelUtilSource);
+                javaEntity.addImport(ArrayList.class);
+
+                body.append("if (this.${fieldName} == null) {");
+                body.append("    this.${fieldName} = new ArrayList<>();");
+                body.append("    this.${fieldName}.add(value);");
+                body.append("} else {");
+                body.append("    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);");
+                body.append("}");
+            }
+
+            if (parentBlock != null) {
+                parentBlock.appendTo(body);
+            }
+        }
+
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        if (parentBlock != null) {
+            parentBlock.addImportsTo(source);
+        }
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -1,0 +1,173 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates parent tracking code for entity/union types. The generated code varies based
+ * on the type and the parent-property-type (standard, array, map).
+ */
+public class ParentAttachmentBlock extends CodeBlock {
+
+    public enum ParentPropertyKind {
+        STANDARD, ARRAY, MAP
+    }
+
+    private final Type valueType;
+    private final String propertyName;
+    private final ParentPropertyKind kind;
+    private final ImplMethodContext ctx;
+
+    /**
+     * @param valueType the resolved type of the value being attached
+     * @param propertyName the property name for _setParentPropertyName, or null for mapped-node methods
+     * @param kind determines the ParentPropertyType enum value (standard/array/map)
+     * @param ctx stage context for FQN lookups
+     */
+    public ParentAttachmentBlock(Type valueType, String propertyName, ParentPropertyKind kind,
+            ImplMethodContext ctx) {
+        this.valueType = valueType;
+        this.propertyName = propertyName;
+        this.kind = kind;
+        this.ctx = ctx;
+    }
+
+    @Override
+    void appendTo(BodyBuilder body) {
+        if (valueType.isEntityType()) {
+            appendEntityAttachment(body);
+        } else if (valueType.isUnionType()) {
+            if (kind == ParentPropertyKind.STANDARD) {
+                appendUnionStandardAttachment(body);
+            } else {
+                appendUnionCollectionAttachment(body);
+            }
+        }
+        // PrimitiveType: no parent tracking needed
+    }
+
+    private void appendEntityAttachment(BodyBuilder body) {
+        String parentPropertyType = kindToString();
+        String quotedName = propertyName != null ? "\"" + propertyName + "\"" : "null";
+        body.append("if (value != null) {");
+        body.append("    ((NodeImpl) value)._setParent(this);");
+        body.append("    ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
+        if (kind == ParentPropertyKind.MAP) {
+            body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
+        }
+        body.append("}");
+    }
+
+    /**
+     * Union attachment for setter (standard) - has full isEntity/isEntityList/isEntityMap/else dispatch.
+     */
+    private void appendUnionStandardAttachment(BodyBuilder body) {
+        String quotedName = "\"" + propertyName + "\"";
+        body.append("if (value != null) {");
+        body.append("    if (value.isEntity()) {");
+        body.append("        ((NodeImpl) value)._setParent(this);");
+        body.append("        ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
+        body.append("    } else if (value.isEntityList()) {");
+        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
+        body.append("        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();");
+        body.append("        for (Object entity : entityList) {");
+        body.append("            if (entity != null) {");
+        body.append("                ((NodeImpl) entity)._setParent(this);");
+        body.append("                ((NodeImpl) entity)._setParentPropertyName(" + quotedName + ");");
+        body.append("                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);");
+        body.append("            }");
+        body.append("        }");
+        body.append("    } else if (value.isEntityMap()) {");
+        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
+        body.append("        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();");
+        body.append("        Collection<String> keys = entityMap.keySet();");
+        body.append("        for (String key : keys) {");
+        body.append("            NodeImpl entity = (NodeImpl) entityMap.get(key);");
+        body.append("            if (entity != null) {");
+        body.append("                entity._setParent(this);");
+        body.append("                entity._setParentPropertyName(" + quotedName + ");");
+        body.append("                entity._setParentPropertyType(ParentPropertyType.map);");
+        body.append("                entity._setMapPropertyName(key);");
+        body.append("            }");
+        body.append("        }");
+        body.append("    } else {");
+        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
+        body.append("    }");
+        body.append("}");
+    }
+
+    /**
+     * Union attachment for array/map collection methods - simpler isEntity/else dispatch.
+     */
+    private void appendUnionCollectionAttachment(BodyBuilder body) {
+        String parentPropertyType = kindToString();
+        String quotedName = "\"" + propertyName + "\"";
+        body.append("if (value != null) {");
+        body.append("    if (value.isEntity()) {");
+        body.append("        ((NodeImpl) value)._setParent(this);");
+        body.append("        ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
+        if (kind == ParentPropertyKind.MAP) {
+            body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
+        }
+        body.append("    } else {");
+        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
+        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
+        if (kind == ParentPropertyKind.MAP) {
+            body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
+        }
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        if (valueType.isEntityType()) {
+            JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
+            source.addImport(parentPropertyTypeSource);
+            JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
+            source.addImport(nodeImplSource);
+        } else if (valueType.isUnionType()) {
+            JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
+            source.addImport(parentPropertyTypeSource);
+            JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
+            source.addImport(nodeImplSource);
+            JavaInterfaceSource unionValueSource = ctx.getJavaIndex().lookupInterface(ctx.getUnionValueInterfaceFQN());
+            source.addImport(unionValueSource);
+            JavaClassSource unionValueImplSource = ctx.getJavaIndex().lookupClass(ctx.getUnionTypeFQN("UnionValueImpl"));
+            source.addImport(unionValueImplSource);
+
+            if (kind == ParentPropertyKind.STANDARD) {
+                source.addImport(Collection.class);
+                source.addImport(List.class);
+                source.addImport(Map.class);
+            }
+        }
+    }
+
+    private String kindToString() {
+        return switch (kind) {
+            case STANDARD -> "standard";
+            case ARRAY -> "array";
+            case MAP -> "map";
+        };
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/RemoveMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/RemoveMethod.java
@@ -1,0 +1,59 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates a "remove" method body: remove from list or map, plus detach if entity/union.
+ */
+public class RemoveMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final ImplMethodContext ctx;
+
+    public RemoveMethod(PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.ctx = ctx;
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+
+        Type resolvedType = property.getResolvedType();
+        Type resolvedValueType = resolvedType.isCollectionType()
+                ? ((CollectionType) resolvedType).getValueType()
+                : null;
+        boolean needsDetach = resolvedValueType != null
+                && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType());
+
+        if (resolvedType.isListType()) {
+            body.append("if (this.${fieldName} != null) {");
+            if (needsDetach) {
+                body.append("    if (value != null && this.${fieldName}.remove(value)) {");
+                body.append("        value.detach();");
+                body.append("    }");
+            } else {
+                body.append("    this.${fieldName}.remove(value);");
+            }
+            body.append("}");
+        } else {
+            body.append("if (this.${fieldName} != null) {");
+            body.append("    this.${fieldName}.remove(name);");
+            body.append("}");
+        }
+
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // No imports needed
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/SetterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/SetterMethod.java
@@ -1,0 +1,58 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Generates a setter method body: {@code this.${fieldName} = value;} plus parent
+ * tracking for entity/union types.
+ */
+public class SetterMethod implements CanAddImports {
+
+    private final PropertyModel property;
+    private final JavaSource<?> javaEntity;
+    private final ImplMethodContext ctx;
+    private final ParentAttachmentBlock parentBlock;
+
+    public SetterMethod(JavaSource<?> javaEntity, PropertyModel property, ImplMethodContext ctx) {
+        this.property = property;
+        this.javaEntity = javaEntity;
+        this.ctx = ctx;
+
+        Type resolvedType = property.getResolvedType();
+        if (resolvedType.isEntityType() || resolvedType.isUnionType()) {
+            this.parentBlock = new ParentAttachmentBlock(
+                    resolvedType, property.getName(),
+                    ParentAttachmentBlock.ParentPropertyKind.STANDARD, ctx);
+        } else {
+            this.parentBlock = null;
+        }
+    }
+
+    public void writeTo(MethodSource<?> method) {
+        String fieldName = ctx.getFieldName(property);
+        String propertyName = property.getName();
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("fieldName", fieldName);
+        body.addContext("propertyName", propertyName);
+        body.append("this.${fieldName} = value;");
+
+        if (parentBlock != null) {
+            parentBlock.appendTo(body);
+        }
+
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        if (parentBlock != null) {
+            parentBlock.addImportsTo(source);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Model each generated method type as a self-contained class, using `CanAddImports`/`CodeBlock` abstractions. `CreateImplMethodsStage` becomes an orchestrator (593 → 307 lines).

**New abstractions:**
- `CanAddImports` — interface for objects that contribute imports
- `CodeBlock` — reusable code fragment base with import support
- `ImplMethodContext` — decouples method classes from stage internals
- `ParentAttachmentBlock` — type-based parent tracking dispatch (entity/union/primitive)

**Method classes** (each self-contained — signature, body, imports):
`GetterMethod`, `SetterMethod`, `FactoryMethod`, `AddMethod`, `InsertMethod`, `RemoveMethod`, `ClearMethod`

## Context

C32/G8 in #1042 and #1041. Establishes the pattern for C32b (apply same refactoring to reader/writer/cloner stages).

Key design: a single `ParentAttachmentBlock` that takes a `Type` and dispatches internally, rather than callers checking `isEntityType()`/`isUnionType()` and calling different helpers.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output identical (pure internal refactoring)