### PR TITLE
refactor(generator): extract reader/writer/cloner code blocks (C32b)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
@@ -78,7 +78,7 @@ public abstract class AbstractStage implements Stage {
                 && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isUnionType();
     }
 
-    protected String singularize(String name) {
+    public String singularize(String name) {
         return inflector.singularize(name);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
@@ -26,7 +26,7 @@ public abstract class AbstractJavaStage extends AbstractStage {
 
     private JavaTypeFactory javaTypeFactory;
 
-    protected JavaTypeFactory getJavaTypeFactory() {
+    public JavaTypeFactory getJavaTypeFactory() {
         if (javaTypeFactory == null) {
             javaTypeFactory = new JavaTypeFactory(
                     getState().getConceptIndex(),
@@ -135,7 +135,7 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return prefix == null ? "" : prefix;
     }
 
-    protected String getJavaEntityInterfaceFQN(EntityModel entity) {
+    public String getJavaEntityInterfaceFQN(EntityModel entity) {
         return getJavaEntityInterfacePackage(entity) + "." + getJavaEntityInterfaceName(entity);
     }
 
@@ -143,7 +143,7 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getJavaTraitInterfacePackage(trait) + "." + getJavaTraitInterfaceName(trait);
     }
 
-    protected String getJavaEntityClassFQN(EntityModel entity) {
+    public String getJavaEntityClassFQN(EntityModel entity) {
         return getJavaEntityClassPackage(entity) + "." + getJavaEntityClassName(entity);
     }
 
@@ -190,7 +190,7 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getState().getConfig().getRootNamespace() + ".MappedNode";
     }
 
-    protected String getNodeEntityClassFQN() {
+    public String getNodeEntityClassFQN() {
         return getState().getConfig().getRootNamespace() + ".NodeImpl";
     }
 
@@ -238,27 +238,27 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getUnionTypesPackageName() + ".UnionValue";
     }
 
-    protected String createMethodName(EntityModel entityModel) {
+    public String createMethodName(EntityModel entityModel) {
         return createMethodName(entityModel.getName());
     }
 
-    protected String createMethodName(PropertyModel propertyModel) {
+    public String createMethodName(PropertyModel propertyModel) {
         return createMethodName(propertyModel.getName());
     }
 
-    protected String createMethodName(String entityName) {
+    public String createMethodName(String entityName) {
         return "create" + StringUtils.capitalize(entityName);
     }
 
-    protected String addMethodName(EntityModel entityModel) {
+    public String addMethodName(EntityModel entityModel) {
         return addMethodName(entityModel.getName());
     }
 
-    protected String addMethodName(PropertyModel propertyModel) {
+    public String addMethodName(PropertyModel propertyModel) {
         return addMethodName(propertyModel.getName());
     }
 
-    protected String addMethodName(String name) {
+    public String addMethodName(String name) {
         return "add" + StringUtils.capitalize(name);
     }
 
@@ -298,15 +298,15 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return "remove" + StringUtils.capitalize(name);
     }
 
-    protected String readMethodName(EntityModel entityModel) {
+    public String readMethodName(EntityModel entityModel) {
         return readMethodName(entityModel.getName());
     }
 
-    protected String readMethodName(String entityName) {
+    public String readMethodName(String entityName) {
         return "read" + StringUtils.capitalize(entityName);
     }
 
-    protected String getterMethodName(PropertyModel propertyModel) {
+    public String getterMethodName(PropertyModel propertyModel) {
         String name = propertyModel.getName();
         if (name.startsWith("/")) {
             name = propertyModel.getCollection();
@@ -314,16 +314,16 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getterMethodName(name, propertyModel.getResolvedType());
     }
 
-    protected String getterMethodName(String propertyName, Type type) {
+    public String getterMethodName(String propertyName, Type type) {
         boolean isBool = type.isPrimitiveType() && type.getName().equals("boolean");
         return (isBool ? "is" : "get") + StringUtils.capitalize(propertyName);
     }
 
-    protected String setterMethodName(PropertyModel propertyModel) {
+    public String setterMethodName(PropertyModel propertyModel) {
         return "set" + StringUtils.capitalize(propertyModel.getName());
     }
 
-    protected Class<?> primitiveTypeToClass(Type type) {
+    public Class<?> primitiveTypeToClass(Type type) {
         if (!type.isPrimitiveType()) {
             throw new UnsupportedOperationException("Property type not primitive: " + type);
         }
@@ -334,56 +334,56 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return rval;
     }
 
-    protected JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, PropertyModel property) {
+    public JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, PropertyModel property) {
         var entityType = (io.apitomy.umg.models.concept.type.EntityType) property.getResolvedType();
         return resolveJavaEntity(namespace.fullName(), entityType.getName());
     }
 
-    protected JavaInterfaceSource resolveJavaEntityType(String namespace, PropertyModel property) {
+    public JavaInterfaceSource resolveJavaEntityType(String namespace, PropertyModel property) {
         var entityType = (io.apitomy.umg.models.concept.type.EntityType) property.getResolvedType();
         return resolveJavaEntity(namespace, entityType.getName());
     }
 
-    protected JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, Type type) {
+    public JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, Type type) {
         return resolveJavaEntity(namespace.fullName(), type.getName());
     }
 
-    protected JavaInterfaceSource resolveJavaEntityType(String namespace, Type type) {
+    public JavaInterfaceSource resolveJavaEntityType(String namespace, Type type) {
         return resolveJavaEntity(namespace, type.getName());
     }
 
-    protected JavaInterfaceSource resolveJavaEntity(EntityModel entityModel) {
+    public JavaInterfaceSource resolveJavaEntity(EntityModel entityModel) {
         return resolveJavaEntity(entityModel.getNamespace().fullName(), entityModel.getName());
     }
 
-    protected JavaClassSource resolveJavaEntityImpl(EntityModel entityModel) {
+    public JavaClassSource resolveJavaEntityImpl(EntityModel entityModel) {
         return resolveJavaEntityImpl(entityModel.getNamespace().fullName(), entityModel.getName());
     }
 
-    protected JavaInterfaceSource resolveJavaEntity(String namespace, String entityName) {
+    public JavaInterfaceSource resolveJavaEntity(String namespace, String entityName) {
         String _package = namespace;
         String prefix = getPrefix(namespace);
         String fqn = _package + "." + prefix + entityName;
         return lookupJavaEntity(fqn);
     }
 
-    protected JavaClassSource resolveJavaEntityImpl(String namespace, String entityName) {
+    public JavaClassSource resolveJavaEntityImpl(String namespace, String entityName) {
         String _package = namespace;
         String prefix = getPrefix(namespace);
         String fqn = _package + "." + prefix + entityName + "Impl";
         return lookupJavaEntityImpl(fqn);
     }
 
-    protected JavaInterfaceSource resolveCommonJavaEntity(EntityModel entityModel) {
+    public JavaInterfaceSource resolveCommonJavaEntity(EntityModel entityModel) {
         return resolveCommonJavaEntity(entityModel.getNamespace().fullName(), entityModel.getName());
     }
 
-    protected JavaInterfaceSource resolveCommonJavaEntity(NamespaceModel namespace, String entityName) {
+    public JavaInterfaceSource resolveCommonJavaEntity(NamespaceModel namespace, String entityName) {
         EntityModel commonEntity = getState().getConceptIndex().lookupCommonEntity(namespace.fullName(), entityName);
         return lookupJavaEntity(commonEntity);
     }
 
-    protected JavaInterfaceSource resolveCommonJavaEntity(String namespace, String entityName) {
+    public JavaInterfaceSource resolveCommonJavaEntity(String namespace, String entityName) {
         EntityModel commonEntity = getState().getConceptIndex().lookupCommonEntity(namespace, entityName);
         return lookupJavaEntity(commonEntity);
     }
@@ -409,11 +409,11 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getState().getJavaIndex().lookupInterface(getJavaTraitInterfaceFQN(trait));
     }
 
-    protected JavaClassSource lookupJavaEntityImpl(EntityModel entity) {
+    public JavaClassSource lookupJavaEntityImpl(EntityModel entity) {
         return lookupJavaEntityImpl(getJavaEntityClassFQN(entity));
     }
 
-    protected JavaClassSource lookupJavaEntityImpl(String fullyQualifiedName) {
+    public JavaClassSource lookupJavaEntityImpl(String fullyQualifiedName) {
         return getState().getJavaIndex().lookupClass(fullyQualifiedName);
     }
 
@@ -434,11 +434,11 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getState().getConfig().getRootNamespace() + ".union";
     }
 
-    protected String getUnionTypeFQN(String name) {
+    public String getUnionTypeFQN(String name) {
         return getUnionTypesPackageName() + "." + name;
     }
 
-    protected String getUnionTypeFQN(String name, String namespace) {
+    public String getUnionTypeFQN(String name, String namespace) {
         String pkg = namespace != null ? namespace : getUnionTypesPackageName();
         return pkg + "." + name;
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -23,15 +23,26 @@ import io.apitomy.umg.models.concept.type.Type;
 
 import java.util.Comparator;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.cloner.CloneEntityPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneMapPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.ClonePrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneUnionPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneUnionListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneUnionMapPropertyBlock;
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.java.JavaIndex;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
  * Creates the deep-copy cloner classes. There is a bespoke cloner for each specification
  * version. Each cloner can clone any node in the tree by walking the source node and
- * copying property values directly into a new target node — avoiding JSON serialization.
+ * copying property values directly into a new target node -- avoiding JSON serialization.
  */
-public class CreateClonersStage extends AbstractJavaStage {
+public class CreateClonersStage extends AbstractJavaStage implements CodeGenContext {
 
     @Override
     protected void doProcess() {
@@ -133,9 +144,26 @@ public class CreateClonersStage extends AbstractJavaStage {
         return "clone" + entityModel.getName();
     }
 
-    @Data
+    // --- CodeGenContext implementation (only methods not inherited from AbstractJavaStage) ---
+
+    @Override
+    public ConceptIndex getConceptIndex() {
+        return getState().getConceptIndex();
+    }
+
+    @Override
+    public JavaIndex getJavaIndex() {
+        return getState().getJavaIndex();
+    }
+
+    @Override
+    public void warn(String message) {
+        super.warn(message);
+    }
+
     @AllArgsConstructor
     private class CreateCloneProperty {
+
         PropertyModelWithOrigin propertyWithOrigin;
         EntityModel entityModel;
         JavaInterfaceSource javaEntity;
@@ -201,35 +229,11 @@ public class CreateClonersStage extends AbstractJavaStage {
         }
 
         private void handlePrimitiveProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("setterMethodName", setterMethodName(property));
-            body.append("target.${setterMethodName}(source.${getterMethodName}());");
+            new ClonePrimitivePropertyBlock(propertyWithOrigin, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-            EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(propertyTypeEntityName);
-            if (propertyTypeEntity == null) {
-                warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                return;
-            }
-            JavaInterfaceSource propertyTypeJavaEntity = resolveJavaEntityType(entityModel.getNamespace(), property);
-            clonerClassSource.addImport(propertyTypeJavaEntity);
-
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("setterMethodName", setterMethodName(property));
-            body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-            body.addContext("cloneMethodName", cloneMethodName(propertyTypeEntity));
-            body.addContext("entityType", propertyTypeJavaEntity.getName());
-
-            body.append("{");
-            body.append("    if (source.${getterMethodName}() != null) {");
-            body.append("        target.${setterMethodName}(target.${createMethodName}());");
-            body.append("        this.${cloneMethodName}((${entityType}) source.${getterMethodName}(), (${entityType}) target.${getterMethodName}());");
-            body.append("    }");
-            body.append("}");
+            new CloneEntityPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -343,416 +347,23 @@ public class CreateClonersStage extends AbstractJavaStage {
         }
 
         private void handleListProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-
-            body.addContext("getterMethodName", getterMethodName(property));
-
-            if (listValueType.isPrimitiveType()) {
-                clonerClassSource.addImport(List.class);
-                clonerClassSource.addImport(ArrayList.class);
-                body.addContext("setterMethodName", setterMethodName(property));
-                body.addContext("valueType", determineValueType(listValueType));
-
-                body.append("{");
-                body.append("    List<${valueType}> srcList = source.${getterMethodName}();");
-                body.append("    if (srcList != null) {");
-                body.append("        target.${setterMethodName}(new ArrayList<>(srcList));");
-                body.append("    }");
-                body.append("}");
-            } else if (listValueType.isEntityType()) {
-                String entityTypeName = listValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityTypeModel));
-                if (entityTypeJavaModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(entityTypeModel);
-                clonerClassSource.addImport(entityTypeJavaModel);
-                clonerClassSource.addImport(commonEntityTypeJavaModel);
-                clonerClassSource.addImport(List.class);
-
-                body.addContext("entityJavaType", entityTypeJavaModel.getName());
-                body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-                body.addContext("createMethodName", createMethodName(entityTypeModel));
-                body.addContext("cloneMethodName", cloneMethodName(entityTypeModel));
-                body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-                body.append("{");
-                body.append("    List<? extends ${commonEntityType}> srcList = source.${getterMethodName}();");
-                body.append("    if (srcList != null && !srcList.isEmpty()) {");
-                body.append("        srcList.forEach(srcItem -> {");
-                body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-                body.append("            this.${cloneMethodName}((${entityJavaType}) srcItem, tgtItem);");
-                body.append("            target.${addMethodName}(tgtItem);");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("LIST Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            }
+            new CloneListPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-
-            body.addContext("getterMethodName", getterMethodName(property));
-
-            if (mapValueType.isPrimitiveType()) {
-                clonerClassSource.addImport(Map.class);
-                clonerClassSource.addImport(LinkedHashMap.class);
-                body.addContext("setterMethodName", setterMethodName(property));
-                body.addContext("valueType", determineValueType(mapValueType));
-
-                body.append("{");
-                body.append("    Map<String, ${valueType}> srcMap = source.${getterMethodName}();");
-                body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-                body.append("        target.${setterMethodName}(new LinkedHashMap<>(srcMap));");
-                body.append("    }");
-                body.append("}");
-            } else if (mapValueType.isEntityType()) {
-                String entityTypeName = mapValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityTypeModel));
-                if (entityTypeJavaModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(entityTypeModel);
-
-                clonerClassSource.addImport(Map.class);
-                clonerClassSource.addImport(entityTypeJavaModel);
-                clonerClassSource.addImport(commonEntityTypeJavaModel);
-
-                body.addContext("entityJavaType", entityTypeJavaModel.getName());
-                body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-                body.addContext("createMethodName", "create" + entityTypeName);
-                body.addContext("cloneMethodName", "clone" + entityTypeName);
-                body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-                body.append("{");
-                body.append("    Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();");
-                body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-                body.append("        srcMap.keySet().forEach(name -> {");
-                body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-                body.append("            this.${cloneMethodName}((${entityJavaType}) srcMap.get(name), tgtItem);");
-                body.append("            target.${addMethodName}(name, tgtItem);");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("MAP Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            }
-        }
-
-        private io.apitomy.umg.models.concept.type.UnionType getEffectiveUnionType(PropertyModel property) {
-            Type resolved = property.getResolvedType();
-            if (resolved.isUnionType()) {
-                return (io.apitomy.umg.models.concept.type.UnionType) resolved;
-            }
-            if (resolved.isCollectionType()) {
-                Type valueType = ((io.apitomy.umg.models.concept.type.CollectionType) resolved).getValueType();
-                if (valueType.isUnionType()) {
-                    return (io.apitomy.umg.models.concept.type.UnionType) valueType;
-                }
-            }
-            throw new IllegalStateException("Could not extract union type from: " + resolved);
-        }
-
-        private String getUnionJavaTypeName(PropertyModel property, io.apitomy.umg.models.concept.type.UnionType unionType) {
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
-            jt.addImportsTo(clonerClassSource);
-            return jt.getSimpleName();
+            new CloneMapPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleUnionProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = getEffectiveUnionType(property);
-
-            body.addContext("unionJavaType", getUnionJavaTypeName(property, effectiveUnionType));
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("setterMethodName", setterMethodName(property));
-
-            body.append("{");
-            body.append("    ${unionJavaType} srcUnion = source.${getterMethodName}();");
-            body.append("    if (srcUnion != null) {");
-
-            // Sort types alphabetically to match the old UnionPropertyType behavior
-            List<Type> sortedTypes = effectiveUnionType.getTypes().stream()
-                    .sorted(UnionVariantComparator.INSTANCE)
-                    .collect(java.util.stream.Collectors.toList());
-            sortedTypes.forEach(nestedType -> {
-                String typeName = getTypeName(nestedType);
-                String isMethodName = "is" + typeName;
-                String asMethodName = "as" + typeName;
-
-                body.addContext("isMethodName", isMethodName);
-                body.addContext("asMethodName", asMethodName);
-
-                body.append("        if (srcUnion.${isMethodName}()) {");
-
-                if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                    String unionValueInterfaceFQN = getUnionTypeFQN(typeName + "UnionValue");
-                    String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                    JavaInterfaceSource unionValueInterface = getState().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                    JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                    if (unionValueInterface != null && unionValueClass != null) {
-                        clonerClassSource.addImport(unionValueInterface);
-                        clonerClassSource.addImport(unionValueClass);
-                        body.addContext("unionValueInterfaceName", unionValueInterface.getName());
-                        body.addContext("unionValueClassName", unionValueClass.getName());
-                        body.append("            target.${setterMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
-                    }
-                } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isPrimitiveType()) {
-                    String unionValueName = getTypeName(nestedType);
-                    String unionValueInterfaceFQN = getUnionTypeFQN(unionValueName + "UnionValue");
-                    String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                    JavaInterfaceSource unionValueInterface = getState().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                    JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                    if (unionValueInterface != null && unionValueClass != null) {
-                        clonerClassSource.addImport(unionValueInterface);
-                        clonerClassSource.addImport(unionValueClass);
-                        clonerClassSource.addImport(ArrayList.class);
-                        body.addContext("unionValueInterfaceName", unionValueInterface.getName());
-                        body.addContext("unionValueClassName", unionValueClass.getName());
-                        body.append("            target.${setterMethodName}(new ${unionValueClassName}(new ArrayList<>(srcUnion.${asMethodName}())));");
-                    }
-                } else if (nestedType.isEntityType()) {
-                    NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
-                    String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                    EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
-                    if (nestedTypeEntity != null) {
-                        JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
-                        if (entityJavaSource != null && entityImplSource != null) {
-                            clonerClassSource.addImport(entityJavaSource);
-                            clonerClassSource.addImport(entityImplSource);
-                            body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("entityImplType", entityImplSource.getName());
-                            body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("            ${entityType} tgtEntity = new ${entityImplType}();");
-                            body.append("            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtEntity);");
-                            body.append("            target.${setterMethodName}(tgtEntity);");
-                        }
-                    }
-                } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isEntityType()) {
-                    Type listItemType = ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType();
-                    String listItemEntityName = entityModel.getNamespace().fullName() + "." + listItemType.getName();
-                    EntityModel listItemEntity = getState().getConceptIndex().lookupEntity(listItemEntityName);
-                    if (listItemEntity != null) {
-                        JavaInterfaceSource listItemEntitySource = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(listItemEntity));
-                        if (listItemEntitySource != null) {
-                            String unionValueName = getTypeName(nestedType);
-                            String unionValueInterfaceFQN = getUnionTypeFQN(unionValueName + "UnionValue");
-                            String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                            JavaInterfaceSource unionValueInterface = getState().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                            JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                            if (unionValueInterface == null) {
-                                unionValueInterface = getState().getJavaIndex().findInterfaceBySimpleName(unionValueName + "UnionValue");
-                            }
-                            if (unionValueClass == null) {
-                                unionValueClass = getState().getJavaIndex().findClassBySimpleName(unionValueName + "UnionValueImpl");
-                            }
-                            if (unionValueInterface != null && unionValueClass != null) {
-                                clonerClassSource.addImport(listItemEntitySource);
-                                clonerClassSource.addImport(unionValueInterface);
-                                clonerClassSource.addImport(unionValueClass);
-                                clonerClassSource.addImport(List.class);
-                                clonerClassSource.addImport(ArrayList.class);
-                                body.addContext("listItemType", listItemEntitySource.getName());
-                                body.addContext("createMethodName", createMethodName(listItemEntity));
-                                body.addContext("cloneMethodName", cloneMethodName(listItemEntity));
-                                body.addContext("unionValueClassName", unionValueClass.getName());
-                                body.append("            List<${listItemType}> clonedList = new ArrayList<>();");
-                                body.append("            srcUnion.${asMethodName}().forEach(srcItem -> {");
-                                body.append("                ${listItemType} tgtItem = (${listItemType}) target.${createMethodName}();");
-                                body.append("                this.${cloneMethodName}((${listItemType}) srcItem, tgtItem);");
-                                body.append("                clonedList.add(tgtItem);");
-                                body.append("            });");
-                                body.append("            @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
-                                body.append("            ${unionValueClassName} unionValue = new ${unionValueClassName}((List) clonedList);");
-                                body.append("            target.${setterMethodName}(unionValue);");
-                            }
-                        }
-                    }
-                } else {
-                    warn("UNION property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
-                }
-
-                body.append("        }");
-            });
-
-            body.append("    }");
-            body.append("}");
-
-            var unionJavaType = getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
-            unionJavaType.addImportsTo(clonerClassSource);
+            new CloneUnionPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleUnionListProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-
-            clonerClassSource.addImport(List.class);
-
-            var unionJavaType = getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
-            unionJavaType.addImportsTo(clonerClassSource);
-            body.addContext("unionJavaType", unionJavaType.getSimpleName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-            body.append("{");
-            body.append("    List<${unionJavaType}> srcList = source.${getterMethodName}();");
-            body.append("    if (srcList != null && !srcList.isEmpty()) {");
-            body.append("        srcList.forEach(srcUnion -> {");
-
-            effectiveUnionType.getTypes().stream()
-                    .sorted(UnionVariantComparator.INSTANCE)
-                    .forEach(nestedType -> {
-                String typeName = getTypeName(nestedType);
-                String isMethodName = "is" + typeName;
-                String asMethodName = "as" + typeName;
-
-                body.addContext("isMethodName", isMethodName);
-                body.addContext("asMethodName", asMethodName);
-
-                body.append("            if (srcUnion.${isMethodName}()) {");
-
-                if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                    String unionValueInterfaceFQN = getUnionTypeFQN(typeName + "UnionValue");
-                    String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                    JavaInterfaceSource unionValueInterface = getState().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                    JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                    if (unionValueInterface != null && unionValueClass != null) {
-                        clonerClassSource.addImport(unionValueInterface);
-                        clonerClassSource.addImport(unionValueClass);
-                        body.addContext("unionValueClassName", unionValueClass.getName());
-                        body.append("                target.${addMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
-                    }
-                } else if (nestedType.isEntityType()) {
-                    NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
-                    String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                    EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
-                    if (nestedTypeEntity != null) {
-                        JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
-                        if (entityJavaSource != null && entityImplSource != null) {
-                            clonerClassSource.addImport(entityJavaSource);
-                            clonerClassSource.addImport(entityImplSource);
-                            body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("entityImplType", entityImplSource.getName());
-                            body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("                ${entityType} tgtItem = new ${entityImplType}();");
-                            body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
-                            body.append("                target.${addMethodName}(tgtItem);");
-                        }
-                    }
-                } else {
-                    warn("UNION LIST property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
-                }
-
-                body.append("            }");
-            });
-
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            new CloneUnionListPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private void handleUnionMapProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
-            io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-
-            clonerClassSource.addImport(Map.class);
-
-            var unionJavaType = getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
-            unionJavaType.addImportsTo(clonerClassSource);
-            body.addContext("unionJavaType", unionJavaType.getSimpleName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-            body.append("{");
-            body.append("    Map<String, ${unionJavaType}> srcMap = source.${getterMethodName}();");
-            body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-            body.append("        srcMap.keySet().forEach(key -> {");
-            body.append("            ${unionJavaType} srcUnion = srcMap.get(key);");
-
-            effectiveUnionType.getTypes().stream()
-                    .sorted(UnionVariantComparator.INSTANCE)
-                    .forEach(nestedType -> {
-                String typeName = getTypeName(nestedType);
-                String isMethodName = "is" + typeName;
-                String asMethodName = "as" + typeName;
-
-                body.addContext("isMethodName", isMethodName);
-                body.addContext("asMethodName", asMethodName);
-
-                body.append("            if (srcUnion.${isMethodName}()) {");
-
-                if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                    String unionValueInterfaceFQN = getUnionTypeFQN(typeName + "UnionValue");
-                    String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                    JavaInterfaceSource unionValueInterface = getState().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                    JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                    if (unionValueInterface != null && unionValueClass != null) {
-                        clonerClassSource.addImport(unionValueInterface);
-                        clonerClassSource.addImport(unionValueClass);
-                        body.addContext("unionValueClassName", unionValueClass.getName());
-                        body.append("                target.${addMethodName}(key, new ${unionValueClassName}(srcUnion.${asMethodName}()));");
-                    }
-                } else if (nestedType.isEntityType()) {
-                    NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
-                    String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                    EntityModel nestedTypeEntity = getState().getConceptIndex().lookupEntity(nestedTypeEntityName);
-                    if (nestedTypeEntity != null) {
-                        JavaInterfaceSource entityJavaSource = resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                        JavaClassSource entityImplSource = lookupJavaEntityImpl(getJavaEntityClassFQN(nestedTypeEntity));
-                        if (entityJavaSource != null && entityImplSource != null) {
-                            clonerClassSource.addImport(entityJavaSource);
-                            clonerClassSource.addImport(entityImplSource);
-                            body.addContext("entityType", entityJavaSource.getName());
-                            body.addContext("entityImplType", entityImplSource.getName());
-                            body.addContext("cloneMethodName", cloneMethodName(nestedTypeEntity));
-                            body.append("                ${entityType} tgtItem = new ${entityImplType}();");
-                            body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
-                            body.append("                target.${addMethodName}(key, tgtItem);");
-                        }
-                    }
-                } else if (nestedType.isListType()) {
-                    String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
-                    JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                    if (unionValueClass != null) {
-                        clonerClassSource.addImport(unionValueClass);
-                        clonerClassSource.addImport(java.util.ArrayList.class);
-                        body.addContext("unionValueClassName", unionValueClass.getName());
-                        body.append("                target.${addMethodName}(key, new ${unionValueClassName}(new java.util.ArrayList<>(srcUnion.${asMethodName}())));");
-                    }
-                } else {
-                    warn("UNION MAP property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
-                }
-
-                body.append("            }");
-            });
-
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            new CloneUnionMapPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
         private String determineValueType(Type type) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -27,6 +27,16 @@ import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadMapPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadPrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadUnionPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadUnionListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadUnionMapPropertyBlock;
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.java.JavaIndex;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -36,7 +46,7 @@ import lombok.Data;
  *
  * @author eric.wittmann@gmail.com
  */
-public class CreateReadersStage extends AbstractJavaStage {
+public class CreateReadersStage extends AbstractJavaStage implements CodeGenContext {
 
     @Override
     protected void doProcess() {
@@ -423,6 +433,23 @@ public class CreateReadersStage extends AbstractJavaStage {
         body.append("ReaderUtil.readExtraProperties(json, node);");
     }
 
+    // --- CodeGenContext implementation (only methods not inherited from AbstractJavaStage) ---
+
+    @Override
+    public ConceptIndex getConceptIndex() {
+        return getState().getConceptIndex();
+    }
+
+    @Override
+    public JavaIndex getJavaIndex() {
+        return getState().getJavaIndex();
+    }
+
+    @Override
+    public void warn(String message) {
+        super.warn(message);
+    }
+
     @Data
     @AllArgsConstructor
     private class CreateReadPropertySnippet {
@@ -502,83 +529,17 @@ public class CreateReadersStage extends AbstractJavaStage {
         }
 
         private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var jt = getJavaTypeFactory().createJavaType(resolved, nsModel);
-            String readMethodName = "read" + jt.getSimpleName();
-
-            readerClassSource.addImport(JsonNode.class);
-            jt.addImportsTo(readerClassSource);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("setterMethodName", setterMethodName(property));
-            body.addContext("readMethodName", readMethodName);
-
-            body.append("{");
-            body.append("    JsonNode value = JsonUtil.consumeAnyProperty(json, \"${propertyName}\");");
-            body.append("    if (value != null) {");
-            body.append("        node.${setterMethodName}(this.${readMethodName}(value, null));");
-            body.append("    }");
-            body.append("}");
+            new ReadUnionPropertyBlock(propertyWithOrigin, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleResolvedUnionListProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.ListType listType) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var valueJt = getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
-            String readMethodName = "read" + valueJt.getSimpleName();
-
-            readerClassSource.addImport(JsonNode.class);
-            readerClassSource.addImport(java.util.List.class);
-            readerClassSource.addImport(java.util.ArrayList.class);
-            valueJt.addImportsTo(readerClassSource);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-            body.addContext("readMethodName", readMethodName);
-            body.addContext("unionJavaType", valueJt.toJavaTypeString());
-
-            body.append("{");
-            body.append("    List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, \"${propertyName}\");");
-            body.append("    if (array != null) {");
-            body.append("        array.forEach(item -> {");
-            body.append("            ${unionJavaType} value = this.${readMethodName}(item, null);");
-            body.append("            if (value != null) node.${addMethodName}(value);");
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            new ReadUnionListPropertyBlock(propertyWithOrigin, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleResolvedUnionMapProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.MapType mapType) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var valueJt = getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
-            String readMethodName = "read" + valueJt.getSimpleName();
-
-            readerClassSource.addImport(JsonNode.class);
-            readerClassSource.addImport(ObjectNode.class);
-            readerClassSource.addImport(java.util.List.class);
-            valueJt.addImportsTo(readerClassSource);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-            body.addContext("readMethodName", readMethodName);
-            body.addContext("unionJavaType", valueJt.toJavaTypeString());
-
-            body.append("{");
-            body.append("    ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-            body.append("    if (mapObj != null) {");
-            body.append("        JsonUtil.keys(mapObj).forEach(key -> {");
-            body.append("            JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);");
-            body.append("            if (value != null) {");
-            body.append("                ${unionJavaType} model = this.${readMethodName}(value, null);");
-            body.append("                if (model != null) node.${addMethodName}(key, model);");
-            body.append("            }");
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            new ReadUnionMapPropertyBlock(propertyWithOrigin, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -699,152 +660,19 @@ public class CreateReadersStage extends AbstractJavaStage {
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-            EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(propertyTypeEntityName);
-            if (propertyTypeEntity == null) {
-                warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-                return;
-            }
-            JavaInterfaceSource propertyTypeJavaEntity = resolveJavaEntityType(entityModel.getNamespace(), property);
-            readerClassSource.addImport(propertyTypeJavaEntity);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("setterMethodName", setterMethodName(property));
-            body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("readMethodName", readMethodName(propertyTypeEntity));
-            body.addContext("propertyEntityType", propertyTypeJavaEntity.getName());
-
-            body.append("{");
-            body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-            body.append("    if (object != null) {");
-            body.append("        node.${setterMethodName}(node.${createMethodName}());");
-            body.append("        ${readMethodName}(object, (${propertyEntityType}) node.${getterMethodName}());");
-            body.append("    }");
-            body.append("}");
+            new ReadEntityPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("valueType", determineValueType(property.getResolvedType()));
-            body.addContext("consumeProperty", determineConsumePropertyVariant(property.getResolvedType()));
-            body.addContext("propertyName", property.getName());
-            body.addContext("setterMethodName", setterMethodName(property));
-
-            body.append("{");
-            body.append("    ${valueType} value = JsonUtil.${consumeProperty}(json, \"${propertyName}\");");
-            body.append("    node.${setterMethodName}(value);");
-            body.append("}");
+            new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleListProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("propertyName", property.getName());
-            body.addContext("setterMethodName", setterMethodName(property));
-
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                body.addContext("consumeMethodName", determineConsumePropertyVariant(property.getResolvedType()));
-                body.addContext("propertyValueJavaType", determineValueType(property.getResolvedType()));
-                readerClassSource.addImport(List.class);
-
-                body.append("{");
-                body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
-                body.append("    node.${setterMethodName}(value);");
-                body.append("}");
-            } else if (listValueType.isEntityType()) {
-                String entityTypeName = listValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityTypeModel));
-                if (entityTypeJavaModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                readerClassSource.addImport(entityTypeJavaModel);
-                readerClassSource.addImport(List.class);
-
-                body.addContext("listValueJavaType", entityTypeJavaModel.getName());
-                body.addContext("createMethodName", createMethodName(entityTypeModel));
-                body.addContext("readMethodName", readMethodName(entityTypeModel));
-                body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-                body.append("{");
-                body.append("    List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, \"${propertyName}\");");
-                body.append("    if (objects != null) {");
-                body.append("        objects.forEach(object -> {");
-                body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
-                body.append("            node.${addMethodName}(model);");
-                body.append("            this.${readMethodName}(object, model);");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            new ReadListPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("propertyName", property.getName());
-            body.addContext("setterMethodName", setterMethodName(property));
-
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                body.addContext("consumeMethodName", determineConsumePropertyVariant(property.getResolvedType()));
-                body.addContext("propertyValueJavaType", determineValueType(property.getResolvedType()));
-                readerClassSource.addImport(Map.class);
-
-                body.append("{");
-                body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
-                body.append("    node.${setterMethodName}(value);");
-                body.append("}");
-            } else if (mapValueType.isEntityType()) {
-                String entityTypeName = mapValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityTypeModel));
-                if (entityTypeJavaModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                readerClassSource.addImport(entityTypeJavaModel);
-
-                body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
-                body.addContext("createMethodName", "create" + entityTypeName);
-                body.addContext("readMethodName", "read" + entityTypeName);
-                body.addContext("addMethodName", addMethodName(singularize(property.getName())));
-
-                body.append("{");
-                body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-                body.append("    JsonUtil.keys(object).forEach(name -> {");
-                body.append("        ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);");
-                body.append("        if (mapValue != null) {");
-                body.append("            ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
-                body.append("            node.${addMethodName}(name, model);");
-                body.append("            this.${readMethodName}(mapValue, model);");
-                body.append("        }");
-                body.append("    });");
-                body.append("}");
-            } else {
-                warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            new ReadMapPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
 
         private void handleUnionProperty(BodyBuilder body) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -21,6 +21,16 @@ import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.writer.WriteEntityPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteMapPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WritePrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteUnionPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteUnionListPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteUnionMapPropertyBlock;
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.java.JavaIndex;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -30,7 +40,7 @@ import lombok.Data;
  *
  * @author eric.wittmann@gmail.com
  */
-public class CreateWritersStage extends AbstractJavaStage {
+public class CreateWritersStage extends AbstractJavaStage implements CodeGenContext {
 
     @Override
     protected void doProcess() {
@@ -375,6 +385,23 @@ public class CreateWritersStage extends AbstractJavaStage {
         return "write" + StringUtils.capitalize(entityName);
     }
 
+    // --- CodeGenContext implementation (only methods not inherited from AbstractJavaStage) ---
+
+    @Override
+    public ConceptIndex getConceptIndex() {
+        return getState().getConceptIndex();
+    }
+
+    @Override
+    public JavaIndex getJavaIndex() {
+        return getState().getJavaIndex();
+    }
+
+    @Override
+    public void warn(String message) {
+        super.warn(message);
+    }
+
     @Data
     @AllArgsConstructor
     private class CreateWriteProperty {
@@ -445,85 +472,17 @@ public class CreateWritersStage extends AbstractJavaStage {
         }
 
         private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var jt = getJavaTypeFactory().createJavaType(resolved, nsModel);
-            String writeMethodName = "write" + jt.getSimpleName();
-
-            jt.addImportsTo(writerClassSource);
-            writerClassSource.addImport(JsonNode.class);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("writeMethodName", writeMethodName);
-
-            body.append("{");
-            body.append("    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());");
-            body.append("    if (value != null) JsonUtil.setAnyProperty(json, \"${propertyName}\", value);");
-            body.append("}");
+            new WriteUnionPropertyBlock(propertyWithOrigin, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleResolvedUnionListProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.ListType listType) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var valueJt = getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
-            String writeMethodName = "write" + valueJt.getSimpleName();
-
-            valueJt.addImportsTo(writerClassSource);
-            writerClassSource.addImport(JsonNode.class);
-            writerClassSource.addImport(ArrayNode.class);
-            writerClassSource.addImport(List.class);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("writeMethodName", writeMethodName);
-            body.addContext("unionJavaType", valueJt.toJavaTypeString());
-
-            body.append("{");
-            body.append("    List<${unionJavaType}> items = node.${getterMethodName}();");
-            body.append("    if (items != null && !items.isEmpty()) {");
-            body.append("        ArrayNode array = JsonUtil.arrayNode();");
-            body.append("        items.forEach(item -> {");
-            body.append("            JsonNode value = this.${writeMethodName}(item);");
-            body.append("            if (value != null) array.add(value);");
-            body.append("        });");
-            body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
-            body.append("    }");
-            body.append("}");
+            new WriteUnionListPropertyBlock(propertyWithOrigin, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleResolvedUnionMapProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.MapType mapType) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-            var valueJt = getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
-            String writeMethodName = "write" + valueJt.getSimpleName();
-
-            valueJt.addImportsTo(writerClassSource);
-            writerClassSource.addImport(JsonNode.class);
-            writerClassSource.addImport(ObjectNode.class);
-            writerClassSource.addImport(Map.class);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("writeMethodName", writeMethodName);
-            body.addContext("unionJavaType", valueJt.toJavaTypeString());
-
-            writerClassSource.addImport(Collection.class);
-
-            body.append("{");
-            body.append("    Map<String, ${unionJavaType}> items = node.${getterMethodName}();");
-            body.append("    if (items != null && !items.isEmpty()) {");
-            body.append("        ObjectNode mapJson = JsonUtil.objectNode();");
-            body.append("        Collection<String> keys = items.keySet();");
-            body.append("        keys.forEach(key -> {");
-            body.append("            JsonNode value = this.${writeMethodName}(items.get(key));");
-            body.append("            if (value != null) JsonUtil.setAnyProperty(mapJson, key, value);");
-            body.append("        });");
-            body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", mapJson);");
-            body.append("    }");
-            body.append("}");
+            new WriteUnionMapPropertyBlock(propertyWithOrigin, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -636,147 +595,19 @@ public class CreateWritersStage extends AbstractJavaStage {
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-            EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(propertyTypeEntityName);
-            if (propertyTypeEntity == null) {
-                warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-                return;
-            }
-            JavaInterfaceSource propertyTypeJavaEntity = resolveJavaEntityType(entityModel.getNamespace(), property);
-            writerClassSource.addImport(propertyTypeJavaEntity);
-
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-            body.addContext("writeMethodName", writeMethodName(propertyTypeEntity));
-            body.addContext("propertyTypeJavaEntity", propertyTypeJavaEntity.getName());
-
-            body.append("{");
-            body.append("    if (node.${getterMethodName}() != null) {");
-            body.append("        ObjectNode object = JsonUtil.objectNode();");
-            body.append("        this.${writeMethodName}((${propertyTypeJavaEntity}) node.${getterMethodName}(), object);");
-            body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
-            body.append("    }");
-            body.append("}");
+            new WriteEntityPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-
-            body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+            new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleListProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
-
-                body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
-            } else if (listValueType.isEntityType()) {
-                String entityTypeName = listValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = resolveJavaEntity(entityTypeModel);
-                if (entityTypeJavaModel == null) {
-                    warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(entityTypeModel);
-
-                writerClassSource.addImport(entityTypeJavaModel);
-                writerClassSource.addImport(commonEntityTypeJavaModel);
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(ArrayNode.class);
-
-                body.addContext("propertyName", property.getName());
-                body.addContext("listValueJavaType", entityTypeJavaModel.getName());
-                body.addContext("writeMethodName", writeMethodName(entityTypeModel));
-                body.addContext("listValueCommonJavaType", commonEntityTypeJavaModel.getName());
-
-                body.append("{");
-                body.append("    List<? extends ${listValueCommonJavaType}> models = node.${getterMethodName}();");
-                body.append("    if (models != null && !models.isEmpty()) {");
-                body.append("        ArrayNode array = JsonUtil.arrayNode();");
-                body.append("        models.forEach(model -> {");
-                body.append("            ObjectNode object = JsonUtil.objectNode();");
-                body.append("            this.${writeMethodName}((${listValueJavaType}) model, object);");
-                body.append("            JsonUtil.addToArray(array, object);");
-                body.append("        });");
-                body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            new WriteListPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            body.addContext("propertyName", property.getName());
-            body.addContext("getterMethodName", getterMethodName(property));
-
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
-                writerClassSource.addImport(List.class);
-
-                body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
-            } else if (mapValueType.isEntityType()) {
-                String entityTypeName = mapValueType.getName();
-                String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-                EntityModel entityTypeModel = getState().getConceptIndex().lookupEntity(fqEntityName);
-                if (entityTypeModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityTypeModel));
-                if (entityTypeJavaModel == null) {
-                    warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(entityTypeModel);
-
-                writerClassSource.addImport(Map.class);
-                writerClassSource.addImport(entityTypeJavaModel);
-                writerClassSource.addImport(commonEntityTypeJavaModel);
-
-                body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
-                body.addContext("writeMethodName", "write" + entityTypeName);
-                body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
-
-                body.append("{");
-                body.append("    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();");
-                body.append("    if (models != null && !models.isEmpty()) {");
-                body.append("        ObjectNode object = JsonUtil.objectNode();");
-                body.append("        models.keySet().forEach(jsonName -> {");
-                body.append("            ObjectNode jsonValue = JsonUtil.objectNode();");
-                body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);");
-                body.append("            JsonUtil.setObjectProperty(object, jsonName, jsonValue);");
-                body.append("        });");
-                body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            new WriteMapPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
         private void handleUnionProperty(BodyBuilder body) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeBlock.java
@@ -10,7 +10,7 @@ public abstract class CodeBlock implements CanAddImports {
     /**
      * Appends this code block's statements to the given body builder.
      */
-    abstract void appendTo(BodyBuilder body);
+    public abstract void appendTo(BodyBuilder body);
 
     @Override
     public void addImportsTo(JavaSource<?> source) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -1,0 +1,60 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
+import io.apitomy.umg.index.concept.ConceptIndex;
+import io.apitomy.umg.index.java.JavaIndex;
+
+/**
+ * Provides stage-level lookups that extracted code block classes need
+ * for resolving FQNs, looking up Java entities, and computing method names.
+ * This decouples code blocks from the concrete stage classes.
+ */
+public interface CodeGenContext {
+
+    ConceptIndex getConceptIndex();
+
+    JavaIndex getJavaIndex();
+
+    JavaTypeFactory getJavaTypeFactory();
+
+    String getJavaEntityInterfaceFQN(EntityModel entity);
+
+    String getJavaEntityClassFQN(EntityModel entity);
+
+    String getNodeEntityClassFQN();
+
+    String getUnionTypeFQN(String name);
+
+    JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, PropertyModel property);
+
+    JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, Type type);
+
+    JavaInterfaceSource resolveJavaEntity(EntityModel entity);
+
+    JavaInterfaceSource resolveCommonJavaEntity(EntityModel entity);
+
+    JavaClassSource lookupJavaEntityImpl(String fqn);
+
+    Class<?> primitiveTypeToClass(Type type);
+
+    String getterMethodName(PropertyModel property);
+
+    String setterMethodName(PropertyModel property);
+
+    String createMethodName(EntityModel entity);
+
+    String addMethodName(String singularName);
+
+    String singularize(String name);
+
+    String readMethodName(EntityModel entity);
+
+    void warn(String message);
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -41,7 +41,7 @@ public class ParentAttachmentBlock extends CodeBlock {
     }
 
     @Override
-    void appendTo(BodyBuilder body) {
+    public void appendTo(BodyBuilder body) {
         if (valueType.isEntityType()) {
             appendEntityAttachment(body);
         } else if (valueType.isUnionType()) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
@@ -1,0 +1,70 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone an entity-typed property: creates the target entity,
+ * then recursively clones from source to target.
+ */
+public class CloneEntityPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    // resolved during appendTo
+    private JavaInterfaceSource propertyTypeJavaEntity;
+
+    public CloneEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
+        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
+        if (propertyTypeEntity == null) {
+            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+            return;
+        }
+        propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
+        clonerClassSource.addImport(propertyTypeJavaEntity);
+
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.addContext("createMethodName", ctx.createMethodName(propertyTypeEntity));
+        body.addContext("cloneMethodName", cloneMethodName(propertyTypeEntity));
+        body.addContext("entityType", propertyTypeJavaEntity.getName());
+
+        body.append("{");
+        body.append("    if (source.${getterMethodName}() != null) {");
+        body.append("        target.${setterMethodName}(target.${createMethodName}());");
+        body.append("        this.${cloneMethodName}((${entityType}) source.${getterMethodName}(), (${entityType}) target.${getterMethodName}());");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+
+    static String cloneMethodName(EntityModel entityModel) {
+        return "clone" + entityModel.getName();
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -1,0 +1,129 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a list property (primitive list or entity list).
+ */
+public class CloneListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    public CloneListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+
+        if (listValueType.isPrimitiveType()) {
+            clonerClassSource.addImport(List.class);
+            clonerClassSource.addImport(ArrayList.class);
+            body.addContext("setterMethodName", ctx.setterMethodName(property));
+            body.addContext("valueType", determineValueType(listValueType));
+
+            body.append("{");
+            body.append("    List<${valueType}> srcList = source.${getterMethodName}();");
+            body.append("    if (srcList != null) {");
+            body.append("        target.${setterMethodName}(new ArrayList<>(srcList));");
+            body.append("    }");
+            body.append("}");
+        } else if (listValueType.isEntityType()) {
+            String entityTypeName = listValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
+            if (entityTypeJavaModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
+                return;
+            }
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+            clonerClassSource.addImport(entityTypeJavaModel);
+            clonerClassSource.addImport(commonEntityTypeJavaModel);
+            clonerClassSource.addImport(List.class);
+
+            body.addContext("entityJavaType", entityTypeJavaModel.getName());
+            body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
+            body.addContext("createMethodName", ctx.createMethodName(entityTypeModel));
+            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(entityTypeModel));
+            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+            body.append("{");
+            body.append("    List<? extends ${commonEntityType}> srcList = source.${getterMethodName}();");
+            body.append("    if (srcList != null && !srcList.isEmpty()) {");
+            body.append("        srcList.forEach(srcItem -> {");
+            body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
+            body.append("            this.${cloneMethodName}((${entityJavaType}) srcItem, tgtItem);");
+            body.append("            target.${addMethodName}(tgtItem);");
+            body.append("        });");
+            body.append("    }");
+            body.append("}");
+        } else {
+            ctx.warn("LIST Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
+        }
+    }
+
+    private String determineValueType(Type type) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (_class != null) {
+                clonerClassSource.addImport(_class);
+                return _class.getSimpleName();
+            }
+        }
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (_class != null) {
+                    clonerClassSource.addImport(_class);
+                    return "List<" + _class.getSimpleName() + ">";
+                }
+            }
+        }
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (_class != null) {
+                    clonerClassSource.addImport(_class);
+                    return "Map<String, " + _class.getSimpleName() + ">";
+                }
+            }
+        }
+        return "Object";
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -1,0 +1,111 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a map property (primitive map or entity map).
+ */
+public class CloneMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    public CloneMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+
+        if (mapValueType.isPrimitiveType()) {
+            clonerClassSource.addImport(Map.class);
+            clonerClassSource.addImport(LinkedHashMap.class);
+            body.addContext("setterMethodName", ctx.setterMethodName(property));
+            body.addContext("valueType", determineValueType(mapValueType));
+
+            body.append("{");
+            body.append("    Map<String, ${valueType}> srcMap = source.${getterMethodName}();");
+            body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
+            body.append("        target.${setterMethodName}(new LinkedHashMap<>(srcMap));");
+            body.append("    }");
+            body.append("}");
+        } else if (mapValueType.isEntityType()) {
+            String entityTypeName = mapValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
+            if (entityTypeJavaModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
+                return;
+            }
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+
+            clonerClassSource.addImport(Map.class);
+            clonerClassSource.addImport(entityTypeJavaModel);
+            clonerClassSource.addImport(commonEntityTypeJavaModel);
+
+            body.addContext("entityJavaType", entityTypeJavaModel.getName());
+            body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
+            body.addContext("createMethodName", "create" + entityTypeName);
+            body.addContext("cloneMethodName", "clone" + entityTypeName);
+            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+            body.append("{");
+            body.append("    Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();");
+            body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
+            body.append("        srcMap.keySet().forEach(name -> {");
+            body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
+            body.append("            this.${cloneMethodName}((${entityJavaType}) srcMap.get(name), tgtItem);");
+            body.append("            target.${addMethodName}(name, tgtItem);");
+            body.append("        });");
+            body.append("    }");
+            body.append("}");
+        } else {
+            ctx.warn("MAP Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
+        }
+    }
+
+    private String determineValueType(Type type) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (_class != null) {
+                clonerClassSource.addImport(_class);
+                return _class.getSimpleName();
+            }
+        }
+        return "Object";
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
@@ -1,0 +1,37 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a primitive property from source to target:
+ * {@code target.setX(source.getX());}
+ */
+public class ClonePrimitivePropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final CodeGenContext ctx;
+
+    public ClonePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.append("target.${setterMethodName}(source.${getterMethodName}());");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // No imports needed
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -1,0 +1,115 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import io.apitomy.umg.pipe.java.AbstractJavaStage;
+
+import java.util.List;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionVariantComparator;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a list of union values.
+ */
+public class CloneUnionListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    public CloneUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+
+        clonerClassSource.addImport(List.class);
+
+        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        unionJavaType.addImportsTo(clonerClassSource);
+        body.addContext("unionJavaType", unionJavaType.getSimpleName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+        body.append("{");
+        body.append("    List<${unionJavaType}> srcList = source.${getterMethodName}();");
+        body.append("    if (srcList != null && !srcList.isEmpty()) {");
+        body.append("        srcList.forEach(srcUnion -> {");
+
+        effectiveUnionType.getTypes().stream()
+                .sorted(UnionVariantComparator.INSTANCE)
+                .forEach(nestedType -> {
+            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String isMethodName = "is" + typeName;
+            String asMethodName = "as" + typeName;
+
+            body.addContext("isMethodName", isMethodName);
+            body.addContext("asMethodName", asMethodName);
+
+            body.append("            if (srcUnion.${isMethodName}()) {");
+
+            if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
+                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
+                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueInterface != null && unionValueClass != null) {
+                    clonerClassSource.addImport(unionValueInterface);
+                    clonerClassSource.addImport(unionValueClass);
+                    body.addContext("unionValueClassName", unionValueClass.getName());
+                    body.append("                target.${addMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
+                }
+            } else if (nestedType.isEntityType()) {
+                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
+                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                if (nestedTypeEntity != null) {
+                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    if (entityJavaSource != null && entityImplSource != null) {
+                        clonerClassSource.addImport(entityJavaSource);
+                        clonerClassSource.addImport(entityImplSource);
+                        body.addContext("entityType", entityJavaSource.getName());
+                        body.addContext("entityImplType", entityImplSource.getName());
+                        body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(nestedTypeEntity));
+                        body.append("                ${entityType} tgtItem = new ${entityImplType}();");
+                        body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
+                        body.append("                target.${addMethodName}(tgtItem);");
+                    }
+                }
+            } else {
+                ctx.warn("UNION LIST property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+            }
+
+            body.append("            }");
+        });
+
+        body.append("        });");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -1,0 +1,125 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import io.apitomy.umg.pipe.java.AbstractJavaStage;
+
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionVariantComparator;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a map of union values.
+ */
+public class CloneUnionMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    public CloneUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+
+        clonerClassSource.addImport(Map.class);
+
+        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        unionJavaType.addImportsTo(clonerClassSource);
+        body.addContext("unionJavaType", unionJavaType.getSimpleName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+        body.append("{");
+        body.append("    Map<String, ${unionJavaType}> srcMap = source.${getterMethodName}();");
+        body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
+        body.append("        srcMap.keySet().forEach(key -> {");
+        body.append("            ${unionJavaType} srcUnion = srcMap.get(key);");
+
+        effectiveUnionType.getTypes().stream()
+                .sorted(UnionVariantComparator.INSTANCE)
+                .forEach(nestedType -> {
+            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String isMethodName = "is" + typeName;
+            String asMethodName = "as" + typeName;
+
+            body.addContext("isMethodName", isMethodName);
+            body.addContext("asMethodName", asMethodName);
+
+            body.append("            if (srcUnion.${isMethodName}()) {");
+
+            if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
+                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
+                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueInterface != null && unionValueClass != null) {
+                    clonerClassSource.addImport(unionValueInterface);
+                    clonerClassSource.addImport(unionValueClass);
+                    body.addContext("unionValueClassName", unionValueClass.getName());
+                    body.append("                target.${addMethodName}(key, new ${unionValueClassName}(srcUnion.${asMethodName}()));");
+                }
+            } else if (nestedType.isEntityType()) {
+                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
+                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                if (nestedTypeEntity != null) {
+                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    if (entityJavaSource != null && entityImplSource != null) {
+                        clonerClassSource.addImport(entityJavaSource);
+                        clonerClassSource.addImport(entityImplSource);
+                        body.addContext("entityType", entityJavaSource.getName());
+                        body.addContext("entityImplType", entityImplSource.getName());
+                        body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(nestedTypeEntity));
+                        body.append("                ${entityType} tgtItem = new ${entityImplType}();");
+                        body.append("                this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtItem);");
+                        body.append("                target.${addMethodName}(key, tgtItem);");
+                    }
+                }
+            } else if (nestedType.isListType()) {
+                String unionValueClassFQN = ctx.getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass != null) {
+                    clonerClassSource.addImport(unionValueClass);
+                    clonerClassSource.addImport(java.util.ArrayList.class);
+                    body.addContext("unionValueClassName", unionValueClass.getName());
+                    body.append("                target.${addMethodName}(key, new ${unionValueClassName}(new java.util.ArrayList<>(srcUnion.${asMethodName}())));");
+                }
+            } else {
+                ctx.warn("UNION MAP property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+            }
+
+            body.append("            }");
+        });
+
+        body.append("        });");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -1,0 +1,192 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import io.apitomy.umg.pipe.java.AbstractJavaStage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionVariantComparator;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to clone a union-typed property by dispatching on each variant type.
+ */
+public class CloneUnionPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource clonerClassSource;
+    private final CodeGenContext ctx;
+
+    public CloneUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource clonerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.clonerClassSource = clonerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = getEffectiveUnionType(property);
+
+        body.addContext("unionJavaType", getUnionJavaTypeName(property, effectiveUnionType));
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+
+        body.append("{");
+        body.append("    ${unionJavaType} srcUnion = source.${getterMethodName}();");
+        body.append("    if (srcUnion != null) {");
+
+        // Sort types alphabetically to match the old UnionPropertyType behavior
+        List<Type> sortedTypes = effectiveUnionType.getTypes().stream()
+                .sorted(UnionVariantComparator.INSTANCE)
+                .collect(Collectors.toList());
+        sortedTypes.forEach(nestedType -> {
+            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String isMethodName = "is" + typeName;
+            String asMethodName = "as" + typeName;
+
+            body.addContext("isMethodName", isMethodName);
+            body.addContext("asMethodName", asMethodName);
+
+            body.append("        if (srcUnion.${isMethodName}()) {");
+
+            if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
+                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
+                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueInterface != null && unionValueClass != null) {
+                    clonerClassSource.addImport(unionValueInterface);
+                    clonerClassSource.addImport(unionValueClass);
+                    body.addContext("unionValueInterfaceName", unionValueInterface.getName());
+                    body.addContext("unionValueClassName", unionValueClass.getName());
+                    body.append("            target.${setterMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
+                }
+            } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isPrimitiveType()) {
+                String unionValueName = AbstractJavaStage.getTypeName(nestedType);
+                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(unionValueName + "UnionValue");
+                String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
+                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueInterface != null && unionValueClass != null) {
+                    clonerClassSource.addImport(unionValueInterface);
+                    clonerClassSource.addImport(unionValueClass);
+                    clonerClassSource.addImport(ArrayList.class);
+                    body.addContext("unionValueInterfaceName", unionValueInterface.getName());
+                    body.addContext("unionValueClassName", unionValueClass.getName());
+                    body.append("            target.${setterMethodName}(new ${unionValueClassName}(new ArrayList<>(srcUnion.${asMethodName}())));");
+                }
+            } else if (nestedType.isEntityType()) {
+                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
+                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                if (nestedTypeEntity != null) {
+                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    if (entityJavaSource != null && entityImplSource != null) {
+                        clonerClassSource.addImport(entityJavaSource);
+                        clonerClassSource.addImport(entityImplSource);
+                        body.addContext("entityType", entityJavaSource.getName());
+                        body.addContext("entityImplType", entityImplSource.getName());
+                        body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(nestedTypeEntity));
+                        body.append("            ${entityType} tgtEntity = new ${entityImplType}();");
+                        body.append("            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtEntity);");
+                        body.append("            target.${setterMethodName}(tgtEntity);");
+                    }
+                }
+            } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isEntityType()) {
+                Type listItemType = ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType();
+                String listItemEntityName = entityModel.getNamespace().fullName() + "." + listItemType.getName();
+                EntityModel listItemEntity = ctx.getConceptIndex().lookupEntity(listItemEntityName);
+                if (listItemEntity != null) {
+                    JavaInterfaceSource listItemEntitySource = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(listItemEntity));
+                    if (listItemEntitySource != null) {
+                        String unionValueName = AbstractJavaStage.getTypeName(nestedType);
+                        String unionValueInterfaceFQN = ctx.getUnionTypeFQN(unionValueName + "UnionValue");
+                        String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
+                        JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                        JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                        if (unionValueInterface == null) {
+                            unionValueInterface = ctx.getJavaIndex().findInterfaceBySimpleName(unionValueName + "UnionValue");
+                        }
+                        if (unionValueClass == null) {
+                            unionValueClass = ctx.getJavaIndex().findClassBySimpleName(unionValueName + "UnionValueImpl");
+                        }
+                        if (unionValueInterface != null && unionValueClass != null) {
+                            clonerClassSource.addImport(listItemEntitySource);
+                            clonerClassSource.addImport(unionValueInterface);
+                            clonerClassSource.addImport(unionValueClass);
+                            clonerClassSource.addImport(List.class);
+                            clonerClassSource.addImport(ArrayList.class);
+                            body.addContext("listItemType", listItemEntitySource.getName());
+                            body.addContext("createMethodName", ctx.createMethodName(listItemEntity));
+                            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(listItemEntity));
+                            body.addContext("unionValueClassName", unionValueClass.getName());
+                            body.append("            List<${listItemType}> clonedList = new ArrayList<>();");
+                            body.append("            srcUnion.${asMethodName}().forEach(srcItem -> {");
+                            body.append("                ${listItemType} tgtItem = (${listItemType}) target.${createMethodName}();");
+                            body.append("                this.${cloneMethodName}((${listItemType}) srcItem, tgtItem);");
+                            body.append("                clonedList.add(tgtItem);");
+                            body.append("            });");
+                            body.append("            @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
+                            body.append("            ${unionValueClassName} unionValue = new ${unionValueClassName}((List) clonedList);");
+                            body.append("            target.${setterMethodName}(unionValue);");
+                        }
+                    }
+                }
+            } else {
+                ctx.warn("UNION property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+            }
+
+            body.append("        }");
+        });
+
+        body.append("    }");
+        body.append("}");
+
+        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        unionJavaType.addImportsTo(clonerClassSource);
+    }
+
+    private io.apitomy.umg.models.concept.type.UnionType getEffectiveUnionType(PropertyModel property) {
+        Type resolved = property.getResolvedType();
+        if (resolved.isUnionType()) {
+            return (io.apitomy.umg.models.concept.type.UnionType) resolved;
+        }
+        if (resolved.isCollectionType()) {
+            Type valueType = ((io.apitomy.umg.models.concept.type.CollectionType) resolved).getValueType();
+            if (valueType.isUnionType()) {
+                return (io.apitomy.umg.models.concept.type.UnionType) valueType;
+            }
+        }
+        throw new IllegalStateException("Could not extract union type from: " + resolved);
+    }
+
+    private String getUnionJavaTypeName(PropertyModel property, io.apitomy.umg.models.concept.type.UnionType unionType) {
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        jt.addImportsTo(clonerClassSource);
+        return jt.getSimpleName();
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -1,0 +1,65 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read an entity-typed property from JSON.
+ */
+public class ReadEntityPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
+        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
+        if (propertyTypeEntity == null) {
+            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+            return;
+        }
+        JavaInterfaceSource propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
+        readerClassSource.addImport(propertyTypeJavaEntity);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.addContext("createMethodName", ctx.createMethodName(propertyTypeEntity));
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("readMethodName", ctx.readMethodName(propertyTypeEntity));
+        body.addContext("propertyEntityType", propertyTypeJavaEntity.getName());
+
+        body.append("{");
+        body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
+        body.append("    if (object != null) {");
+        body.append("        node.${setterMethodName}(node.${createMethodName}());");
+        body.append("        ${readMethodName}(object, (${propertyEntityType}) node.${getterMethodName}());");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -1,0 +1,96 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a list property from JSON (primitive list or entity list).
+ */
+public class ReadListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("propertyName", property.getName());
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+
+        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        if (listValueType.isPrimitiveType()) {
+            ReadPrimitivePropertyBlock helper = new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, ctx);
+            body.addContext("consumeMethodName", helper.determineConsumePropertyVariant(property.getResolvedType()));
+            body.addContext("propertyValueJavaType", helper.determineValueType(property.getResolvedType()));
+            readerClassSource.addImport(List.class);
+
+            body.append("{");
+            body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
+            body.append("    node.${setterMethodName}(value);");
+            body.append("}");
+        } else if (listValueType.isEntityType()) {
+            String entityTypeName = listValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
+            if (entityTypeJavaModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+                return;
+            }
+            readerClassSource.addImport(entityTypeJavaModel);
+            readerClassSource.addImport(List.class);
+
+            body.addContext("listValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("createMethodName", ctx.createMethodName(entityTypeModel));
+            body.addContext("readMethodName", ctx.readMethodName(entityTypeModel));
+            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+            body.append("{");
+            body.append("    List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, \"${propertyName}\");");
+            body.append("    if (objects != null) {");
+            body.append("        objects.forEach(object -> {");
+            body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
+            body.append("            node.${addMethodName}(model);");
+            body.append("            this.${readMethodName}(object, model);");
+            body.append("        });");
+            body.append("    }");
+            body.append("}");
+        } else {
+            ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+        }
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -1,0 +1,95 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a map property from JSON (primitive map or entity map).
+ */
+public class ReadMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("propertyName", property.getName());
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+
+        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        if (mapValueType.isPrimitiveType()) {
+            ReadPrimitivePropertyBlock helper = new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, ctx);
+            body.addContext("consumeMethodName", helper.determineConsumePropertyVariant(property.getResolvedType()));
+            body.addContext("propertyValueJavaType", helper.determineValueType(property.getResolvedType()));
+            readerClassSource.addImport(Map.class);
+
+            body.append("{");
+            body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
+            body.append("    node.${setterMethodName}(value);");
+            body.append("}");
+        } else if (mapValueType.isEntityType()) {
+            String entityTypeName = mapValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
+            if (entityTypeJavaModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+                return;
+            }
+            readerClassSource.addImport(entityTypeJavaModel);
+
+            body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("createMethodName", "create" + entityTypeName);
+            body.addContext("readMethodName", "read" + entityTypeName);
+            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+
+            body.append("{");
+            body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
+            body.append("    JsonUtil.keys(object).forEach(name -> {");
+            body.append("        ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);");
+            body.append("        if (mapValue != null) {");
+            body.append("            ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
+            body.append("            node.${addMethodName}(name, model);");
+            body.append("            this.${readMethodName}(mapValue, model);");
+            body.append("        }");
+            body.append("    });");
+            body.append("}");
+        } else {
+            ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+        }
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -1,0 +1,147 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a primitive-typed property from JSON.
+ */
+public class ReadPrimitivePropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadPrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("valueType", determineValueType(property.getResolvedType()));
+        body.addContext("consumeProperty", determineConsumePropertyVariant(property.getResolvedType()));
+        body.addContext("propertyName", property.getName());
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+
+        body.append("{");
+        body.append("    ${valueType} value = JsonUtil.${consumeProperty}(json, \"${propertyName}\");");
+        body.append("    node.${setterMethodName}(value);");
+        body.append("}");
+    }
+
+    /**
+     * Determines the Java data type of the given property.
+     */
+    String determineValueType(Type type) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (_class != null) {
+                readerClassSource.addImport(_class);
+                return _class.getSimpleName();
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (_class != null) {
+                    readerClassSource.addImport(_class);
+                    return "List<" + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (_class != null) {
+                    readerClassSource.addImport(_class);
+                    return "Map<String, " + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        PropertyModel property = propertyWithOrigin.getProperty();
+        ctx.warn("Unable to determine value type for: " + property);
+        return "Object";
+    }
+
+    /**
+     * Determines the JsonUtil consume method variant to use for the given type.
+     */
+    String determineConsumePropertyVariant(Type type) {
+        if (type.isEntityType()) {
+            return "consumeObjectProperty";
+        }
+
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (ObjectNode.class.equals(_class)) {
+                readerClassSource.addImport(_class);
+                return "consumeObjectProperty";
+            } else if (JsonNode.class.equals(_class)) {
+                readerClassSource.addImport(_class);
+                return "consumeAnyProperty";
+            } else {
+                return "consume" + _class.getSimpleName() + "Property";
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    readerClassSource.addImport(_class);
+                    return "consumeObjectArrayProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    readerClassSource.addImport(_class);
+                    return "consumeAnyArrayProperty";
+                } else {
+                    return "consume" + _class.getSimpleName() + "ArrayProperty";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    readerClassSource.addImport(_class);
+                    return "consumeObjectMapProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    readerClassSource.addImport(_class);
+                    return "consumeAnyMapProperty";
+                } else {
+                    return "consume" + _class.getSimpleName() + "MapProperty";
+                }
+            }
+        }
+
+        PropertyModel property = propertyWithOrigin.getProperty();
+        ctx.warn("Unable to determine value type for: " + property);
+        return "consumeProperty";
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -1,0 +1,67 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a list of union values from JSON using the type-based reader method.
+ */
+public class ReadUnionListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        io.apitomy.umg.models.concept.type.ListType listType =
+                (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var valueJt = ctx.getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+        String readMethodName = "read" + valueJt.getSimpleName();
+
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(ArrayList.class);
+        valueJt.addImportsTo(readerClassSource);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+        body.addContext("readMethodName", readMethodName);
+        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+        body.append("{");
+        body.append("    List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, \"${propertyName}\");");
+        body.append("    if (array != null) {");
+        body.append("        array.forEach(item -> {");
+        body.append("            ${unionJavaType} value = this.${readMethodName}(item, null);");
+        body.append("            if (value != null) node.${addMethodName}(value);");
+        body.append("        });");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -1,0 +1,70 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a map of union values from JSON using the type-based reader method.
+ */
+public class ReadUnionMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        io.apitomy.umg.models.concept.type.MapType mapType =
+                (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var valueJt = ctx.getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+        String readMethodName = "read" + valueJt.getSimpleName();
+
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(ObjectNode.class);
+        readerClassSource.addImport(List.class);
+        valueJt.addImportsTo(readerClassSource);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+        body.addContext("readMethodName", readMethodName);
+        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+        body.append("{");
+        body.append("    ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
+        body.append("    if (mapObj != null) {");
+        body.append("        JsonUtil.keys(mapObj).forEach(key -> {");
+        body.append("            JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);");
+        body.append("            if (value != null) {");
+        body.append("                ${unionJavaType} model = this.${readMethodName}(value, null);");
+        body.append("                if (model != null) node.${addMethodName}(key, model);");
+        body.append("            }");
+        body.append("        });");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -1,0 +1,58 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to read a union-typed property from JSON using the type-based reader method.
+ */
+public class ReadUnionPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource readerClassSource;
+    private final CodeGenContext ctx;
+
+    public ReadUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource readerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.readerClassSource = readerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        Type resolved = property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var jt = ctx.getJavaTypeFactory().createJavaType(resolved, nsModel);
+        String readMethodName = "read" + jt.getSimpleName();
+
+        readerClassSource.addImport(JsonNode.class);
+        jt.addImportsTo(readerClassSource);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.addContext("readMethodName", readMethodName);
+
+        body.append("{");
+        body.append("    JsonNode value = JsonUtil.consumeAnyProperty(json, \"${propertyName}\");");
+        body.append("    if (value != null) {");
+        body.append("        node.${setterMethodName}(this.${readMethodName}(value, null));");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -1,0 +1,72 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write an entity-typed property to JSON.
+ */
+public class WriteEntityPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
+        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
+        if (propertyTypeEntity == null) {
+            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+            return;
+        }
+        JavaInterfaceSource propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
+        writerClassSource.addImport(propertyTypeJavaEntity);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("writeMethodName", writeMethodName(propertyTypeEntity));
+        body.addContext("propertyTypeJavaEntity", propertyTypeJavaEntity.getName());
+
+        body.append("{");
+        body.append("    if (node.${getterMethodName}() != null) {");
+        body.append("        ObjectNode object = JsonUtil.objectNode();");
+        body.append("        this.${writeMethodName}((${propertyTypeJavaEntity}) node.${getterMethodName}(), object);");
+        body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
+        body.append("    }");
+        body.append("}");
+    }
+
+    static String writeMethodName(EntityModel entityModel) {
+        return "write" + StringUtils.capitalize(entityModel.getName());
+    }
+
+    static String writeMethodName(String entityName) {
+        return "write" + StringUtils.capitalize(entityName);
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -1,0 +1,98 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a list property to JSON (primitive list or entity list).
+ */
+public class WriteListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+
+        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        if (listValueType.isPrimitiveType()) {
+            WritePrimitivePropertyBlock helper = new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, ctx);
+            body.addContext("setPropertyMethodName", helper.determineSetPropertyVariant(property.getResolvedType()));
+
+            body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+        } else if (listValueType.isEntityType()) {
+            String entityTypeName = listValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.resolveJavaEntity(entityTypeModel);
+            if (entityTypeJavaModel == null) {
+                ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+
+            writerClassSource.addImport(entityTypeJavaModel);
+            writerClassSource.addImport(commonEntityTypeJavaModel);
+            writerClassSource.addImport(List.class);
+            writerClassSource.addImport(ArrayNode.class);
+
+            body.addContext("propertyName", property.getName());
+            body.addContext("listValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("writeMethodName", WriteEntityPropertyBlock.writeMethodName(entityTypeModel));
+            body.addContext("listValueCommonJavaType", commonEntityTypeJavaModel.getName());
+
+            body.append("{");
+            body.append("    List<? extends ${listValueCommonJavaType}> models = node.${getterMethodName}();");
+            body.append("    if (models != null && !models.isEmpty()) {");
+            body.append("        ArrayNode array = JsonUtil.arrayNode();");
+            body.append("        models.forEach(model -> {");
+            body.append("            ObjectNode object = JsonUtil.objectNode();");
+            body.append("            this.${writeMethodName}((${listValueJavaType}) model, object);");
+            body.append("            JsonUtil.addToArray(array, object);");
+            body.append("        });");
+            body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+            body.append("    }");
+            body.append("}");
+        } else {
+            ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+        }
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -1,0 +1,96 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a map property to JSON (primitive map or entity map).
+ */
+public class WriteMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel entityModel;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.entityModel = entityModel;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+
+        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        if (mapValueType.isPrimitiveType()) {
+            WritePrimitivePropertyBlock helper = new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, ctx);
+            body.addContext("setPropertyMethodName", helper.determineSetPropertyVariant(property.getResolvedType()));
+            writerClassSource.addImport(List.class);
+
+            body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+        } else if (mapValueType.isEntityType()) {
+            String entityTypeName = mapValueType.getName();
+            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
+            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+            if (entityTypeModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
+            if (entityTypeJavaModel == null) {
+                ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+                return;
+            }
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+
+            writerClassSource.addImport(Map.class);
+            writerClassSource.addImport(entityTypeJavaModel);
+            writerClassSource.addImport(commonEntityTypeJavaModel);
+
+            body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("writeMethodName", "write" + entityTypeName);
+            body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
+
+            body.append("{");
+            body.append("    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();");
+            body.append("    if (models != null && !models.isEmpty()) {");
+            body.append("        ObjectNode object = JsonUtil.objectNode();");
+            body.append("        models.keySet().forEach(jsonName -> {");
+            body.append("            ObjectNode jsonValue = JsonUtil.objectNode();");
+            body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);");
+            body.append("            JsonUtil.setObjectProperty(object, jsonName, jsonValue);");
+            body.append("        });");
+            body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
+            body.append("    }");
+            body.append("}");
+        } else {
+            ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+        }
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -1,0 +1,139 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a primitive-typed property to JSON.
+ */
+public class WritePrimitivePropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WritePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+
+        body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+    }
+
+    /**
+     * Determines the JsonUtil set method variant to use for the given type.
+     */
+    String determineSetPropertyVariant(Type type) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (ObjectNode.class.equals(_class)) {
+                writerClassSource.addImport(_class);
+                return "setObjectProperty";
+            } else if (JsonNode.class.equals(_class)) {
+                writerClassSource.addImport(_class);
+                return "setAnyProperty";
+            } else {
+                return "set" + _class.getSimpleName() + "Property";
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    writerClassSource.addImport(_class);
+                    return "setObjectArrayProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    writerClassSource.addImport(_class);
+                    return "setAnyArrayProperty";
+                } else {
+                    return "set" + _class.getSimpleName() + "ArrayProperty";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    writerClassSource.addImport(_class);
+                    return "setObjectMapProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    writerClassSource.addImport(_class);
+                    return "setAnyMapProperty";
+                } else {
+                    return "set" + _class.getSimpleName() + "MapProperty";
+                }
+            }
+        }
+
+        PropertyModel property = propertyWithOrigin.getProperty();
+        ctx.warn("Unable to determine value type for: " + property);
+        return "setProperty";
+    }
+
+    /**
+     * Determines the Java data type of the given property.
+     */
+    String determineValueType(Type type) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (_class != null) {
+                writerClassSource.addImport(_class);
+                return _class.getSimpleName();
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (_class != null) {
+                    writerClassSource.addImport(_class);
+                    return "List<" + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (_class != null) {
+                    writerClassSource.addImport(_class);
+                    return "Map<String, " + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        PropertyModel property = propertyWithOrigin.getProperty();
+        ctx.warn("Unable to determine value type for: " + property);
+        return "Object";
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -1,0 +1,69 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a list of union values to JSON using the type-based writer method.
+ */
+public class WriteUnionListPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        io.apitomy.umg.models.concept.type.ListType listType =
+                (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var valueJt = ctx.getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+        String writeMethodName = "write" + valueJt.getSimpleName();
+
+        valueJt.addImportsTo(writerClassSource);
+        writerClassSource.addImport(JsonNode.class);
+        writerClassSource.addImport(ArrayNode.class);
+        writerClassSource.addImport(List.class);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("writeMethodName", writeMethodName);
+        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+        body.append("{");
+        body.append("    List<${unionJavaType}> items = node.${getterMethodName}();");
+        body.append("    if (items != null && !items.isEmpty()) {");
+        body.append("        ArrayNode array = JsonUtil.arrayNode();");
+        body.append("        items.forEach(item -> {");
+        body.append("            JsonNode value = this.${writeMethodName}(item);");
+        body.append("            if (value != null) array.add(value);");
+        body.append("        });");
+        body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -1,0 +1,73 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a map of union values to JSON using the type-based writer method.
+ */
+public class WriteUnionMapPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        io.apitomy.umg.models.concept.type.MapType mapType =
+                (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var valueJt = ctx.getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+        String writeMethodName = "write" + valueJt.getSimpleName();
+
+        valueJt.addImportsTo(writerClassSource);
+        writerClassSource.addImport(JsonNode.class);
+        writerClassSource.addImport(ObjectNode.class);
+        writerClassSource.addImport(Map.class);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("writeMethodName", writeMethodName);
+        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+
+        writerClassSource.addImport(Collection.class);
+
+        body.append("{");
+        body.append("    Map<String, ${unionJavaType}> items = node.${getterMethodName}();");
+        body.append("    if (items != null && !items.isEmpty()) {");
+        body.append("        ObjectNode mapJson = JsonUtil.objectNode();");
+        body.append("        Collection<String> keys = items.keySet();");
+        body.append("        keys.forEach(key -> {");
+        body.append("            JsonNode value = this.${writeMethodName}(items.get(key));");
+        body.append("            if (value != null) JsonUtil.setAnyProperty(mapJson, key, value);");
+        body.append("        });");
+        body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", mapJson);");
+        body.append("    }");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
@@ -1,0 +1,56 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Generates code to write a union-typed property to JSON using the type-based writer method.
+ */
+public class WriteUnionPropertyBlock extends CodeBlock {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final JavaClassSource writerClassSource;
+    private final CodeGenContext ctx;
+
+    public WriteUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
+            JavaClassSource writerClassSource, CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.writerClassSource = writerClassSource;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        Type resolved = property.getResolvedType();
+        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
+        var jt = ctx.getJavaTypeFactory().createJavaType(resolved, nsModel);
+        String writeMethodName = "write" + jt.getSimpleName();
+
+        jt.addImportsTo(writerClassSource);
+        writerClassSource.addImport(JsonNode.class);
+
+        body.addContext("propertyName", property.getName());
+        body.addContext("getterMethodName", ctx.getterMethodName(property));
+        body.addContext("writeMethodName", writeMethodName);
+
+        body.append("{");
+        body.append("    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());");
+        body.append("    if (value != null) JsonUtil.setAnyProperty(json, \"${propertyName}\", value);");
+        body.append("}");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}


### PR DESCRIPTION
## Summary

Extract property handlers from all three code generation stages into self-contained code block classes using the `CodeBlock`/`CanAddImports`/`CodeGenContext` pattern established in C32.

| Stage | Before | After | Reduction |
|-------|--------|-------|-----------|
| CreateReadersStage | 1421 | 1249 | -172 |
| CreateWritersStage | 1152 | 983 | -169 |
| CreateClonersStage | 789 | 400 | -389 |
| **Total** | **3362** | **2632** | **-730 (-22%)** |

**21 new code block classes** in `method/reader/`, `method/writer/`, `method/cloner/` packages.

**`CodeGenContext` interface** decouples code blocks from stage internals (21 methods).

Star/regex handlers and legacy union handlers remain in the inner classes as special cases.

## Context

C32b in #1042 — applies the method class pattern from C32 (#1117) to reader/writer/cloner stages.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generator tests pass
- [x] Generated output identical