### PR TITLE
refactor(generator): extract PrimitiveTypeHelper and EntityResolver (C33)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -24,6 +24,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import java.util.Comparator;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.cloner.CloneEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneMapPropertyBlock;
@@ -239,23 +241,17 @@ public class CreateClonersStage extends AbstractJavaStage implements CodeGenCont
         private void handleStarProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("STAR Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateClonersStage.this, "STAR");
+                if (resolved == null) {
                     return;
                 }
-                JavaInterfaceSource propertyTypeJavaEntity = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (propertyTypeJavaEntity == null) {
-                    warn("STAR Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                clonerClassSource.addImport(propertyTypeJavaEntity);
+                clonerClassSource.addImport(resolved.javaInterface());
                 clonerClassSource.addImport(List.class);
 
-                body.addContext("entityJavaType", propertyTypeJavaEntity.getName());
-                body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-                body.addContext("cloneMethodName", cloneMethodName(propertyTypeEntity));
+                body.addContext("entityJavaType", resolved.javaInterface().getName());
+                body.addContext("createMethodName", createMethodName(resolved.entityModel()));
+                body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
 
                 body.append("{");
                 body.append("    List<String> itemNames = source.getItemNames();");
@@ -289,28 +285,22 @@ public class CreateClonersStage extends AbstractJavaStage implements CodeGenCont
         private void handleRegexProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("REGEX Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateClonersStage.this, "REGEX");
+                if (resolved == null) {
                     return;
                 }
-                JavaInterfaceSource propertyTypeJavaEntity = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (propertyTypeJavaEntity == null) {
-                    warn("REGEX Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(propertyTypeEntity);
+                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(resolved.entityModel());
 
-                clonerClassSource.addImport(propertyTypeJavaEntity);
+                clonerClassSource.addImport(resolved.javaInterface());
                 clonerClassSource.addImport(commonEntityTypeJavaModel);
                 clonerClassSource.addImport(Map.class);
 
-                body.addContext("entityJavaType", propertyTypeJavaEntity.getName());
+                body.addContext("entityJavaType", resolved.javaInterface().getName());
                 body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
                 body.addContext("getterMethodName", getterMethodName(property));
-                body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-                body.addContext("cloneMethodName", cloneMethodName(propertyTypeEntity));
+                body.addContext("createMethodName", createMethodName(resolved.entityModel()));
+                body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
                 body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
 
                 body.append("{");
@@ -329,7 +319,7 @@ public class CreateClonersStage extends AbstractJavaStage implements CodeGenCont
 
                 body.addContext("getterMethodName", getterMethodName(property));
                 body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
-                body.addContext("valueType", determineValueType(property.getResolvedType()));
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateClonersStage.this, clonerClassSource));
 
                 clonerClassSource.addImport(List.class);
                 body.append("{");
@@ -366,35 +356,6 @@ public class CreateClonersStage extends AbstractJavaStage implements CodeGenCont
             new CloneUnionMapPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, CreateClonersStage.this).appendTo(body);
         }
 
-        private String determineValueType(Type type) {
-            if (type.isPrimitiveType()) {
-                Class<?> _class = primitiveTypeToClass(type);
-                if (_class != null) {
-                    clonerClassSource.addImport(_class);
-                    return _class.getSimpleName();
-                }
-            }
-            if (type.isListType()) {
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-                if (listValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(listValueType);
-                    if (_class != null) {
-                        clonerClassSource.addImport(_class);
-                        return "List<" + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-            if (type.isMapType()) {
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-                if (mapValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(mapValueType);
-                    if (_class != null) {
-                        clonerClassSource.addImport(_class);
-                        return "Map<String, " + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-            return "Object";
-        }
+
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -28,6 +28,8 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadMapPropertyBlock;
@@ -545,25 +547,17 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
         private void handleStarProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("STAR Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type: " + property.getResolvedType());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateReadersStage.this, "STAR");
+                if (resolved == null) {
                     return;
                 }
-                JavaInterfaceSource propertyTypeJavaEntity = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (propertyTypeJavaEntity == null) {
-                    warn("STAR Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                readerClassSource.addImport(propertyTypeJavaEntity);
+                readerClassSource.addImport(resolved.javaInterface());
                 readerClassSource.addImport(List.class);
 
-                body.addContext("entityJavaType", propertyTypeJavaEntity.getName());
-                body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-                body.addContext("readMethodName", readMethodName(propertyTypeEntity));
+                body.addContext("entityJavaType", resolved.javaInterface().getName());
+                body.addContext("createMethodName", createMethodName(resolved.entityModel()));
+                body.addContext("readMethodName", readMethodName(resolved.entityModel()));
                 body.addContext("addMethodName", "addItem");
 
                 body.append("{");
@@ -583,8 +577,8 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                     readerClassSource.addImport(Map.class);
                 }
 
-                body.addContext("valueType", determineValueType(property.getResolvedType()));
-                body.addContext("consumePropertyMethodName", determineConsumePropertyVariant(property.getResolvedType()));
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("consumePropertyMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
 
                 body.append("{");
                 body.append("    List<String> propertyNames = JsonUtil.keys(json);");
@@ -602,26 +596,18 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
         private void handleRegexProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("REGEX Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type: " + property.getResolvedType());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateReadersStage.this, "REGEX");
+                if (resolved == null) {
                     return;
                 }
-                JavaInterfaceSource propertyTypeJavaEntity = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (propertyTypeJavaEntity == null) {
-                    warn("REGEX Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                readerClassSource.addImport(propertyTypeJavaEntity);
+                readerClassSource.addImport(resolved.javaInterface());
                 readerClassSource.addImport(List.class);
 
                 body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("entityJavaType", propertyTypeJavaEntity.getName());
-                body.addContext("createMethodName", createMethodName(propertyTypeEntity));
-                body.addContext("readMethodName", readMethodName(propertyTypeEntity));
+                body.addContext("entityJavaType", resolved.javaInterface().getName());
+                body.addContext("createMethodName", createMethodName(resolved.entityModel()));
+                body.addContext("readMethodName", readMethodName(resolved.entityModel()));
                 body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
 
                 body.append("{");
@@ -642,8 +628,8 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 }
 
                 body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("valueType", determineValueType(property.getResolvedType()));
-                body.addContext("consumeProperty", determineConsumePropertyVariant(property.getResolvedType()));
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("consumeProperty", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
                 body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
 
                 body.append("{");
@@ -674,101 +660,9 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
         private void handleMapProperty(BodyBuilder body) {
             new ReadMapPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, CreateReadersStage.this).appendTo(body);
         }
-        private String determineConsumePropertyVariant(Type type) {
-            if (type.isEntityType()) {
-                return "consumeObjectProperty";
-            }
 
-            if (type.isPrimitiveType()) {
-                Class<?> _class = primitiveTypeToClass(type);
-                if (ObjectNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeObjectProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeAnyProperty";
-                } else {
-                    return "consume" + _class.getSimpleName() + "Property";
-                }
-            }
 
-            if (type.isListType()) {
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-                if (listValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(listValueType);
-                    if (ObjectNode.class.equals(_class)) {
-                        readerClassSource.addImport(_class);
-                        return "consumeObjectArrayProperty";
-                    } else if (JsonNode.class.equals(_class)) {
-                        readerClassSource.addImport(_class);
-                        return "consumeAnyArrayProperty";
-                    } else {
-                        return "consume" + _class.getSimpleName() + "ArrayProperty";
-                    }
-                }
-            }
 
-            if (type.isMapType()) {
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-                if (mapValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(mapValueType);
-                    if (ObjectNode.class.equals(_class)) {
-                        readerClassSource.addImport(_class);
-                        return "consumeObjectMapProperty";
-                    } else if (JsonNode.class.equals(_class)) {
-                        readerClassSource.addImport(_class);
-                        return "consumeAnyMapProperty";
-                    } else {
-                        return "consume" + _class.getSimpleName() + "MapProperty";
-                    }
-                }
-            }
-
-            PropertyModel property = propertyWithOrigin.getProperty();
-            warn("Unable to determine value type for: " + property);
-            return "consumeProperty";
-        }
-
-        /**
-         * Determines the Java data type of the given property.
-         *
-         * @param type
-         */
-        private String determineValueType(Type type) {
-            if (type.isPrimitiveType()) {
-                Class<?> _class = primitiveTypeToClass(type);
-                if (_class != null) {
-                    readerClassSource.addImport(_class);
-                    return _class.getSimpleName();
-                }
-            }
-
-            if (type.isListType()) {
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-                if (listValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(listValueType);
-                    if (_class != null) {
-                        readerClassSource.addImport(_class);
-                        return "List<" + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-
-            if (type.isMapType()) {
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-                if (mapValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(mapValueType);
-                    if (_class != null) {
-                        readerClassSource.addImport(_class);
-                        return "Map<String, " + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-
-            PropertyModel property = propertyWithOrigin.getProperty();
-            warn("Unable to determine value type for: " + property);
-            return "Object";
-        }
 
         private String encodeRegex(String regex) {
             return regex.replace("\\", "\\\\");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -22,6 +22,8 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.writer.WriteEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteMapPropertyBlock;
@@ -488,25 +490,17 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
         private void handleStarProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("STAR Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (entityTypeJavaModel == null) {
-                    warn("STAR Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateWritersStage.this, "STAR");
+                if (resolved == null) {
                     return;
                 }
 
                 writerClassSource.addImport(List.class);
-                writerClassSource.addImport(entityTypeJavaModel);
+                writerClassSource.addImport(resolved.javaInterface());
 
-                body.addContext("writeMethodName", writeMethodName(propertyTypeEntity));
-                body.addContext("entityJavaType", entityTypeJavaModel.getName());
+                body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
+                body.addContext("entityJavaType", resolved.javaInterface().getName());
 
                 body.append("{");
                 body.append("    List<String> propertyNames = node.getItemNames();");
@@ -519,8 +513,8 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
             } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
                 writerClassSource.addImport(List.class);
 
-                body.addContext("valueType", determineValueType(property.getResolvedType()));
-                body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
+                body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
 
                 body.append("{");
                 body.append("    List<String> propertyNames = node.getItemNames();");
@@ -538,28 +532,20 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
         private void handleRegexProperty(BodyBuilder body) {
             PropertyModel property = propertyWithOrigin.getProperty();
             if (isEntity(property)) {
-                String entityTypeName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-                EntityModel propertyTypeEntity = getState().getConceptIndex().lookupEntity(entityTypeName);
-                if (propertyTypeEntity == null) {
-                    warn("REGEX Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type: " + property.getResolvedType());
+                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                        entityModel, CreateWritersStage.this, "REGEX");
+                if (resolved == null) {
                     return;
                 }
-                JavaInterfaceSource entityTypeJavaModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(propertyTypeEntity));
-                if (entityTypeJavaModel == null) {
-                    warn("REGEX Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                    warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(propertyTypeEntity);
+                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(resolved.entityModel());
 
                 writerClassSource.addImport(Map.class);
-                writerClassSource.addImport(entityTypeJavaModel);
+                writerClassSource.addImport(resolved.javaInterface());
                 writerClassSource.addImport(commonEntityTypeJavaModel);
 
-                body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
+                body.addContext("mapValueJavaType", resolved.javaInterface().getName());
                 body.addContext("getterMethodName", getterMethodName(property));
-                body.addContext("writeMethodName", writeMethodName(propertyTypeEntity));
+                body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
                 body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
 
                 body.append("{");
@@ -575,9 +561,9 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
             } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
                 writerClassSource.addImport(List.class);
 
-                body.addContext("valueType", determineValueType(property.getResolvedType()));
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
                 body.addContext("getterMethodName", getterMethodName(property));
-                body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
+                body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
 
                 body.append("{");
                 body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
@@ -610,103 +596,8 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
             new WriteMapPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, CreateWritersStage.this).appendTo(body);
         }
 
-        /**
-         * Figure out which variant of "writeProperty" from "JsonUtil" we should use for
-         * this property.  The property might be a primitive type, or a list/map of primitive
-         * types.
-         *
-         * @param type
-         */
-        private String determineSetPropertyVariant(Type type) {
-            if (type.isPrimitiveType()) {
-                Class<?> _class = primitiveTypeToClass(type);
-                if (ObjectNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setObjectProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setAnyProperty";
-                } else {
-                    return "set" + _class.getSimpleName() + "Property";
-                }
-            }
 
-            if (type.isListType()) {
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-                if (listValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(listValueType);
-                    if (ObjectNode.class.equals(_class)) {
-                        writerClassSource.addImport(_class);
-                        return "setObjectArrayProperty";
-                    } else if (JsonNode.class.equals(_class)) {
-                        writerClassSource.addImport(_class);
-                        return "setAnyArrayProperty";
-                    } else {
-                        return "set" + _class.getSimpleName() + "ArrayProperty";
-                    }
-                }
-            }
 
-            if (type.isMapType()) {
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-                if (mapValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(mapValueType);
-                    if (ObjectNode.class.equals(_class)) {
-                        writerClassSource.addImport(_class);
-                        return "setObjectMapProperty";
-                    } else if (JsonNode.class.equals(_class)) {
-                        writerClassSource.addImport(_class);
-                        return "setAnyMapProperty";
-                    } else {
-                        return "set" + _class.getSimpleName() + "MapProperty";
-                    }
-                }
-            }
 
-            PropertyModel property = propertyWithOrigin.getProperty();
-            warn("Unable to determine value type for: " + property);
-            return "setProperty";
-        }
-
-        /**
-         * Determines the Java data type of the given property.
-         *
-         * @param type
-         */
-        private String determineValueType(Type type) {
-            if (type.isPrimitiveType()) {
-                Class<?> _class = primitiveTypeToClass(type);
-                if (_class != null) {
-                    writerClassSource.addImport(_class);
-                    return _class.getSimpleName();
-                }
-            }
-
-            if (type.isListType()) {
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-                if (listValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(listValueType);
-                    if (_class != null) {
-                        writerClassSource.addImport(_class);
-                        return "List<" + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-
-            if (type.isMapType()) {
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-                if (mapValueType.isPrimitiveType()) {
-                    Class<?> _class = primitiveTypeToClass(mapValueType);
-                    if (_class != null) {
-                        writerClassSource.addImport(_class);
-                        return "Map<String, " + _class.getSimpleName() + ">";
-                    }
-                }
-            }
-
-            PropertyModel property = propertyWithOrigin.getProperty();
-            warn("Unable to determine value type for: " + property);
-            return "Object";
-        }
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/EntityResolver.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/EntityResolver.java
@@ -1,0 +1,78 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+
+/**
+ * Centralises the repeated "namespace + entity lookup + null-check + warn"
+ * pattern used across reader, writer, and cloner property blocks.
+ */
+public final class EntityResolver {
+
+    private EntityResolver() {
+    }
+
+    /**
+     * Result of resolving a property's entity type. Contains the concept-level
+     * {@link EntityModel} and the corresponding {@link JavaInterfaceSource}.
+     */
+    public record ResolvedEntity(EntityModel entityModel, JavaInterfaceSource javaInterface) {
+    }
+
+    /**
+     * Resolves the entity type referenced by a property.
+     * <ol>
+     *   <li>Builds the fully-qualified entity name from the owning entity's namespace
+     *       and the property's resolved type name.</li>
+     *   <li>Looks the entity up in the {@link io.apitomy.umg.models.concept.ConceptIndex}.</li>
+     *   <li>Looks the Java interface up in the {@link io.apitomy.umg.pipe.java.index.JavaIndex}.</li>
+     * </ol>
+     *
+     * @param prop          the property whose type to resolve
+     * @param ownerEntity   the entity that owns the property (used for namespace and warning messages)
+     * @param ctx           code-generation context for lookups and warnings
+     * @param warnPrefix    prefix for warning messages (e.g. "LIST", "MAP", "STAR", "REGEX", or empty)
+     * @return the resolved entity and Java interface, or {@code null} if resolution failed
+     */
+    public static ResolvedEntity resolveEntityInterface(PropertyModelWithOrigin prop,
+            EntityModel ownerEntity, CodeGenContext ctx, String warnPrefix) {
+        return resolveEntityInterface(prop.getProperty(), prop.getProperty().getResolvedType().getName(),
+                ownerEntity, ctx, warnPrefix);
+    }
+
+    /**
+     * Resolves an entity type by its simple name within the owning entity's namespace.
+     * This variant is useful for list/map value types where the type name comes from
+     * the inner type rather than the property's direct resolved type.
+     *
+     * @param property      the property (for warning messages)
+     * @param entityTypeName the simple entity type name to resolve
+     * @param ownerEntity   the entity that owns the property (used for namespace and warning messages)
+     * @param ctx           code-generation context for lookups and warnings
+     * @param warnPrefix    prefix for warning messages (e.g. "LIST", "MAP", or empty)
+     * @return the resolved entity and Java interface, or {@code null} if resolution failed
+     */
+    public static ResolvedEntity resolveEntityInterface(PropertyModel property, String entityTypeName,
+            EntityModel ownerEntity, CodeGenContext ctx, String warnPrefix) {
+        var prefix = warnPrefix.isEmpty() ? "" : warnPrefix + " ";
+        var fqEntityName = ownerEntity.getNamespace().fullName() + "." + entityTypeName;
+        var entityModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
+        if (entityModel == null) {
+            ctx.warn(prefix + "Property entity type not found for property: '" + property.getName()
+                    + "' of entity: " + ownerEntity.fullyQualifiedName());
+            ctx.warn("       property type: " + property.getResolvedType());
+            return null;
+        }
+        var javaInterface = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityModel));
+        if (javaInterface == null) {
+            ctx.warn(prefix + "Entity property '" + property.getName()
+                    + "' not resolved (unsupported) for entity: " + ownerEntity.fullyQualifiedName());
+            ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
+            return null;
+        }
+        return new ResolvedEntity(entityModel, javaInterface);
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeHelper.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeHelper.java
@@ -1,0 +1,171 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.models.concept.type.Type;
+
+/**
+ * Shared helpers for mapping concept-model {@link Type}s to Java type names
+ * and to the corresponding {@code JsonUtil} consume/set method variants.
+ * Extracted from duplicated code across reader, writer, and cloner blocks.
+ */
+public final class PrimitiveTypeHelper {
+
+    private PrimitiveTypeHelper() {
+    }
+
+    /**
+     * Determines the Java data type name for a primitive (or list/map-of-primitive) type.
+     * Any required import is added to {@code classSource}.
+     *
+     * @return the simple type name (e.g. "String", "List&lt;Integer&gt;") or "Object" as fallback
+     */
+    public static String determineValueType(Type type, CodeGenContext ctx, JavaClassSource classSource) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (_class != null) {
+                classSource.addImport(_class);
+                return _class.getSimpleName();
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (_class != null) {
+                    classSource.addImport(_class);
+                    return "List<" + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (_class != null) {
+                    classSource.addImport(_class);
+                    return "Map<String, " + _class.getSimpleName() + ">";
+                }
+            }
+        }
+
+        return "Object";
+    }
+
+    /**
+     * Determines the {@code JsonUtil.consume*} method variant for reading a property of the given type.
+     *
+     * @return the method name, e.g. "consumeStringProperty", "consumeObjectArrayProperty"
+     */
+    public static String determineConsumePropertyVariant(Type type, CodeGenContext ctx, JavaClassSource classSource) {
+        if (type.isEntityType()) {
+            return "consumeObjectProperty";
+        }
+
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (ObjectNode.class.equals(_class)) {
+                classSource.addImport(_class);
+                return "consumeObjectProperty";
+            } else if (JsonNode.class.equals(_class)) {
+                classSource.addImport(_class);
+                return "consumeAnyProperty";
+            } else {
+                return "consume" + _class.getSimpleName() + "Property";
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "consumeObjectArrayProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "consumeAnyArrayProperty";
+                } else {
+                    return "consume" + _class.getSimpleName() + "ArrayProperty";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "consumeObjectMapProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "consumeAnyMapProperty";
+                } else {
+                    return "consume" + _class.getSimpleName() + "MapProperty";
+                }
+            }
+        }
+
+        return "consumeProperty";
+    }
+
+    /**
+     * Determines the {@code JsonUtil.set*} method variant for writing a property of the given type.
+     *
+     * @return the method name, e.g. "setStringProperty", "setObjectArrayProperty"
+     */
+    public static String determineSetPropertyVariant(Type type, CodeGenContext ctx, JavaClassSource classSource) {
+        if (type.isPrimitiveType()) {
+            Class<?> _class = ctx.primitiveTypeToClass(type);
+            if (ObjectNode.class.equals(_class)) {
+                classSource.addImport(_class);
+                return "setObjectProperty";
+            } else if (JsonNode.class.equals(_class)) {
+                classSource.addImport(_class);
+                return "setAnyProperty";
+            } else {
+                return "set" + _class.getSimpleName() + "Property";
+            }
+        }
+
+        if (type.isListType()) {
+            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            if (listValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "setObjectArrayProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "setAnyArrayProperty";
+                } else {
+                    return "set" + _class.getSimpleName() + "ArrayProperty";
+                }
+            }
+        }
+
+        if (type.isMapType()) {
+            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            if (mapValueType.isPrimitiveType()) {
+                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
+                if (ObjectNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "setObjectMapProperty";
+                } else if (JsonNode.class.equals(_class)) {
+                    classSource.addImport(_class);
+                    return "setAnyMapProperty";
+                } else {
+                    return "set" + _class.getSimpleName() + "MapProperty";
+                }
+            }
+        }
+
+        return "setProperty";
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
@@ -10,6 +10,7 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
 
 /**
  * Generates code to clone an entity-typed property: creates the target entity,
@@ -36,19 +37,17 @@ public class CloneEntityPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
-        if (propertyTypeEntity == null) {
-            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
+        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        if (resolved == null) {
             return;
         }
-        propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
+        propertyTypeJavaEntity = resolved.javaInterface();
         clonerClassSource.addImport(propertyTypeJavaEntity);
 
         body.addContext("getterMethodName", ctx.getterMethodName(property));
         body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("createMethodName", ctx.createMethodName(propertyTypeEntity));
-        body.addContext("cloneMethodName", cloneMethodName(propertyTypeEntity));
+        body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
+        body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
         body.addContext("entityType", propertyTypeJavaEntity.getName());
 
         body.append("{");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -14,6 +14,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to clone a list property (primitive list or entity list).
@@ -44,7 +46,7 @@ public class CloneListPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(List.class);
             clonerClassSource.addImport(ArrayList.class);
             body.addContext("setterMethodName", ctx.setterMethodName(property));
-            body.addContext("valueType", determineValueType(listValueType));
+            body.addContext("valueType", PrimitiveTypeHelper.determineValueType(listValueType, ctx, clonerClassSource));
 
             body.append("{");
             body.append("    List<${valueType}> srcList = source.${getterMethodName}();");
@@ -53,27 +55,19 @@ public class CloneListPropertyBlock extends CodeBlock {
             body.append("    }");
             body.append("}");
         } else if (listValueType.isEntityType()) {
-            String entityTypeName = listValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
-            if (entityTypeJavaModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
-                return;
-            }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
-            clonerClassSource.addImport(entityTypeJavaModel);
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
+            clonerClassSource.addImport(resolved.javaInterface());
             clonerClassSource.addImport(commonEntityTypeJavaModel);
             clonerClassSource.addImport(List.class);
 
-            body.addContext("entityJavaType", entityTypeJavaModel.getName());
+            body.addContext("entityJavaType", resolved.javaInterface().getName());
             body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-            body.addContext("createMethodName", ctx.createMethodName(entityTypeModel));
-            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(entityTypeModel));
+            body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
+            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(resolved.entityModel()));
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
 
             body.append("{");
@@ -91,36 +85,7 @@ public class CloneListPropertyBlock extends CodeBlock {
         }
     }
 
-    private String determineValueType(Type type) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (_class != null) {
-                clonerClassSource.addImport(_class);
-                return _class.getSimpleName();
-            }
-        }
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (_class != null) {
-                    clonerClassSource.addImport(_class);
-                    return "List<" + _class.getSimpleName() + ">";
-                }
-            }
-        }
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (_class != null) {
-                    clonerClassSource.addImport(_class);
-                    return "Map<String, " + _class.getSimpleName() + ">";
-                }
-            }
-        }
-        return "Object";
-    }
+    
 
     @Override
     public void addImportsTo(JavaSource<?> source) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -1,7 +1,6 @@
 package io.apitomy.umg.pipe.java.method.cloner;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -15,6 +14,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to clone a map property (primitive map or entity map).
@@ -45,7 +46,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(Map.class);
             clonerClassSource.addImport(LinkedHashMap.class);
             body.addContext("setterMethodName", ctx.setterMethodName(property));
-            body.addContext("valueType", determineValueType(mapValueType));
+            body.addContext("valueType", PrimitiveTypeHelper.determineValueType(mapValueType, ctx, clonerClassSource));
 
             body.append("{");
             body.append("    Map<String, ${valueType}> srcMap = source.${getterMethodName}();");
@@ -55,24 +56,17 @@ public class CloneMapPropertyBlock extends CodeBlock {
             body.append("}");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not cloned for entity: " + entityModel.fullyQualifiedName());
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
-            if (entityTypeJavaModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not cloned (java) for entity: " + entityModel.fullyQualifiedName());
-                return;
-            }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
 
             clonerClassSource.addImport(Map.class);
-            clonerClassSource.addImport(entityTypeJavaModel);
+            clonerClassSource.addImport(resolved.javaInterface());
             clonerClassSource.addImport(commonEntityTypeJavaModel);
 
-            body.addContext("entityJavaType", entityTypeJavaModel.getName());
+            body.addContext("entityJavaType", resolved.javaInterface().getName());
             body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
             body.addContext("createMethodName", "create" + entityTypeName);
             body.addContext("cloneMethodName", "clone" + entityTypeName);
@@ -93,16 +87,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
         }
     }
 
-    private String determineValueType(Type type) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (_class != null) {
-                clonerClassSource.addImport(_class);
-                return _class.getSimpleName();
-            }
-        }
-        return "Object";
-    }
+    
 
     @Override
     public void addImportsTo(JavaSource<?> source) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -1,7 +1,6 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
@@ -10,6 +9,7 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
 
 /**
  * Generates code to read an entity-typed property from JSON.
@@ -32,22 +32,18 @@ public class ReadEntityPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
-        if (propertyTypeEntity == null) {
-            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        if (resolved == null) {
             return;
         }
-        JavaInterfaceSource propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
-        readerClassSource.addImport(propertyTypeJavaEntity);
+        readerClassSource.addImport(resolved.javaInterface());
 
         body.addContext("propertyName", property.getName());
         body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("createMethodName", ctx.createMethodName(propertyTypeEntity));
+        body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
         body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("readMethodName", ctx.readMethodName(propertyTypeEntity));
-        body.addContext("propertyEntityType", propertyTypeJavaEntity.getName());
+        body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
+        body.addContext("propertyEntityType", resolved.javaInterface().getName());
 
         body.append("{");
         body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -1,10 +1,8 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
 import java.util.List;
-import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
@@ -14,6 +12,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to read a list property from JSON (primitive list or entity list).
@@ -41,9 +41,8 @@ public class ReadListPropertyBlock extends CodeBlock {
 
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
-            ReadPrimitivePropertyBlock helper = new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, ctx);
-            body.addContext("consumeMethodName", helper.determineConsumePropertyVariant(property.getResolvedType()));
-            body.addContext("propertyValueJavaType", helper.determineValueType(property.getResolvedType()));
+            body.addContext("consumeMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
+            body.addContext("propertyValueJavaType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
             readerClassSource.addImport(List.class);
 
             body.append("{");
@@ -51,26 +50,16 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.append("    node.${setterMethodName}(value);");
             body.append("}");
         } else if (listValueType.isEntityType()) {
-            String entityTypeName = listValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
-            if (entityTypeJavaModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                return;
-            }
-            readerClassSource.addImport(entityTypeJavaModel);
+            readerClassSource.addImport(resolved.javaInterface());
             readerClassSource.addImport(List.class);
 
-            body.addContext("listValueJavaType", entityTypeJavaModel.getName());
-            body.addContext("createMethodName", ctx.createMethodName(entityTypeModel));
-            body.addContext("readMethodName", ctx.readMethodName(entityTypeModel));
+            body.addContext("listValueJavaType", resolved.javaInterface().getName());
+            body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
+            body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
 
             body.append("{");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -3,7 +3,6 @@ package io.apitomy.umg.pipe.java.method.reader;
 import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
@@ -13,6 +12,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to read a map property from JSON (primitive map or entity map).
@@ -40,9 +41,8 @@ public class ReadMapPropertyBlock extends CodeBlock {
 
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
-            ReadPrimitivePropertyBlock helper = new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, ctx);
-            body.addContext("consumeMethodName", helper.determineConsumePropertyVariant(property.getResolvedType()));
-            body.addContext("propertyValueJavaType", helper.determineValueType(property.getResolvedType()));
+            body.addContext("consumeMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
+            body.addContext("propertyValueJavaType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
             readerClassSource.addImport(Map.class);
 
             body.append("{");
@@ -51,22 +51,13 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.append("}");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
-            if (entityTypeJavaModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                return;
-            }
-            readerClassSource.addImport(entityTypeJavaModel);
+            readerClassSource.addImport(resolved.javaInterface());
 
-            body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("mapValueJavaType", resolved.javaInterface().getName());
             body.addContext("createMethodName", "create" + entityTypeName);
             body.addContext("readMethodName", "read" + entityTypeName);
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -3,15 +3,12 @@ package io.apitomy.umg.pipe.java.method.reader;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to read a primitive-typed property from JSON.
@@ -22,8 +19,8 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
     private final JavaClassSource readerClassSource;
     private final CodeGenContext ctx;
 
-    public ReadPrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
+    public ReadPrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, JavaClassSource readerClassSource,
+            CodeGenContext ctx) {
         this.propertyWithOrigin = propertyWithOrigin;
         this.readerClassSource = readerClassSource;
         this.ctx = ctx;
@@ -32,8 +29,8 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("valueType", determineValueType(property.getResolvedType()));
-        body.addContext("consumeProperty", determineConsumePropertyVariant(property.getResolvedType()));
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
+        body.addContext("consumeProperty", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
         body.addContext("propertyName", property.getName());
         body.addContext("setterMethodName", ctx.setterMethodName(property));
 
@@ -41,103 +38,6 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
         body.append("    ${valueType} value = JsonUtil.${consumeProperty}(json, \"${propertyName}\");");
         body.append("    node.${setterMethodName}(value);");
         body.append("}");
-    }
-
-    /**
-     * Determines the Java data type of the given property.
-     */
-    String determineValueType(Type type) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (_class != null) {
-                readerClassSource.addImport(_class);
-                return _class.getSimpleName();
-            }
-        }
-
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (_class != null) {
-                    readerClassSource.addImport(_class);
-                    return "List<" + _class.getSimpleName() + ">";
-                }
-            }
-        }
-
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (_class != null) {
-                    readerClassSource.addImport(_class);
-                    return "Map<String, " + _class.getSimpleName() + ">";
-                }
-            }
-        }
-
-        PropertyModel property = propertyWithOrigin.getProperty();
-        ctx.warn("Unable to determine value type for: " + property);
-        return "Object";
-    }
-
-    /**
-     * Determines the JsonUtil consume method variant to use for the given type.
-     */
-    String determineConsumePropertyVariant(Type type) {
-        if (type.isEntityType()) {
-            return "consumeObjectProperty";
-        }
-
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (ObjectNode.class.equals(_class)) {
-                readerClassSource.addImport(_class);
-                return "consumeObjectProperty";
-            } else if (JsonNode.class.equals(_class)) {
-                readerClassSource.addImport(_class);
-                return "consumeAnyProperty";
-            } else {
-                return "consume" + _class.getSimpleName() + "Property";
-            }
-        }
-
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeObjectArrayProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeAnyArrayProperty";
-                } else {
-                    return "consume" + _class.getSimpleName() + "ArrayProperty";
-                }
-            }
-        }
-
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeObjectMapProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    readerClassSource.addImport(_class);
-                    return "consumeAnyMapProperty";
-                } else {
-                    return "consume" + _class.getSimpleName() + "MapProperty";
-                }
-            }
-        }
-
-        PropertyModel property = propertyWithOrigin.getProperty();
-        ctx.warn("Unable to determine value type for: " + property);
-        return "consumeProperty";
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -2,7 +2,6 @@ package io.apitomy.umg.pipe.java.method.writer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
@@ -11,6 +10,7 @@ import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
 
 /**
  * Generates code to write an entity-typed property to JSON.
@@ -33,20 +33,16 @@ public class WriteEntityPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        String propertyTypeEntityName = entityModel.getNamespace().fullName() + "." + property.getResolvedType().getName();
-        EntityModel propertyTypeEntity = ctx.getConceptIndex().lookupEntity(propertyTypeEntityName);
-        if (propertyTypeEntity == null) {
-            ctx.warn("Property entity type not found for property: '" + property.getName() + "' of entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        if (resolved == null) {
             return;
         }
-        JavaInterfaceSource propertyTypeJavaEntity = ctx.resolveJavaEntityType(entityModel.getNamespace(), property);
-        writerClassSource.addImport(propertyTypeJavaEntity);
+        writerClassSource.addImport(resolved.javaInterface());
 
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("writeMethodName", writeMethodName(propertyTypeEntity));
-        body.addContext("propertyTypeJavaEntity", propertyTypeJavaEntity.getName());
+        body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
+        body.addContext("propertyTypeJavaEntity", resolved.javaInterface().getName());
 
         body.append("{");
         body.append("    if (node.${getterMethodName}() != null) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -15,6 +15,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to write a list property to JSON (primitive list or entity list).
@@ -42,35 +44,24 @@ public class WriteListPropertyBlock extends CodeBlock {
 
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
-            WritePrimitivePropertyBlock helper = new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, ctx);
-            body.addContext("setPropertyMethodName", helper.determineSetPropertyVariant(property.getResolvedType()));
+            body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
 
             body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
         } else if (listValueType.isEntityType()) {
-            String entityTypeName = listValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.resolveJavaEntity(entityTypeModel);
-            if (entityTypeJavaModel == null) {
-                ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                return;
-            }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
 
-            writerClassSource.addImport(entityTypeJavaModel);
+            writerClassSource.addImport(resolved.javaInterface());
             writerClassSource.addImport(commonEntityTypeJavaModel);
             writerClassSource.addImport(List.class);
             writerClassSource.addImport(ArrayNode.class);
 
             body.addContext("propertyName", property.getName());
-            body.addContext("listValueJavaType", entityTypeJavaModel.getName());
-            body.addContext("writeMethodName", WriteEntityPropertyBlock.writeMethodName(entityTypeModel));
+            body.addContext("listValueJavaType", resolved.javaInterface().getName());
+            body.addContext("writeMethodName", WriteEntityPropertyBlock.writeMethodName(resolved.entityModel()));
             body.addContext("listValueCommonJavaType", commonEntityTypeJavaModel.getName());
 
             body.append("{");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -14,6 +14,8 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to write a map property to JSON (primitive map or entity map).
@@ -41,33 +43,23 @@ public class WriteMapPropertyBlock extends CodeBlock {
 
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
-            WritePrimitivePropertyBlock helper = new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, ctx);
-            body.addContext("setPropertyMethodName", helper.determineSetPropertyVariant(property.getResolvedType()));
+            body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
             writerClassSource.addImport(List.class);
 
             body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            String fqEntityName = entityModel.getNamespace().fullName() + "." + entityTypeName;
-            EntityModel entityTypeModel = ctx.getConceptIndex().lookupEntity(fqEntityName);
-            if (entityTypeModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in index: " + property.getResolvedType());
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource entityTypeJavaModel = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(entityTypeModel));
-            if (entityTypeJavaModel == null) {
-                ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                ctx.warn("       property type is entity but not found in JAVA index: " + property.getResolvedType());
-                return;
-            }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(entityTypeModel);
+            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
 
             writerClassSource.addImport(Map.class);
-            writerClassSource.addImport(entityTypeJavaModel);
+            writerClassSource.addImport(resolved.javaInterface());
             writerClassSource.addImport(commonEntityTypeJavaModel);
 
-            body.addContext("mapValueJavaType", entityTypeJavaModel.getName());
+            body.addContext("mapValueJavaType", resolved.javaInterface().getName());
             body.addContext("writeMethodName", "write" + entityTypeName);
             body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -1,17 +1,14 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 
 /**
  * Generates code to write a primitive-typed property to JSON.
@@ -22,8 +19,8 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
     private final JavaClassSource writerClassSource;
     private final CodeGenContext ctx;
 
-    public WritePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
+    public WritePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, JavaClassSource writerClassSource,
+            CodeGenContext ctx) {
         this.propertyWithOrigin = propertyWithOrigin;
         this.writerClassSource = writerClassSource;
         this.ctx = ctx;
@@ -32,104 +29,11 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("setPropertyMethodName", determineSetPropertyVariant(property.getResolvedType()));
+        body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", ctx.getterMethodName(property));
 
         body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
-    }
-
-    /**
-     * Determines the JsonUtil set method variant to use for the given type.
-     */
-    String determineSetPropertyVariant(Type type) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (ObjectNode.class.equals(_class)) {
-                writerClassSource.addImport(_class);
-                return "setObjectProperty";
-            } else if (JsonNode.class.equals(_class)) {
-                writerClassSource.addImport(_class);
-                return "setAnyProperty";
-            } else {
-                return "set" + _class.getSimpleName() + "Property";
-            }
-        }
-
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setObjectArrayProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setAnyArrayProperty";
-                } else {
-                    return "set" + _class.getSimpleName() + "ArrayProperty";
-                }
-            }
-        }
-
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setObjectMapProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    writerClassSource.addImport(_class);
-                    return "setAnyMapProperty";
-                } else {
-                    return "set" + _class.getSimpleName() + "MapProperty";
-                }
-            }
-        }
-
-        PropertyModel property = propertyWithOrigin.getProperty();
-        ctx.warn("Unable to determine value type for: " + property);
-        return "setProperty";
-    }
-
-    /**
-     * Determines the Java data type of the given property.
-     */
-    String determineValueType(Type type) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (_class != null) {
-                writerClassSource.addImport(_class);
-                return _class.getSimpleName();
-            }
-        }
-
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (_class != null) {
-                    writerClassSource.addImport(_class);
-                    return "List<" + _class.getSimpleName() + ">";
-                }
-            }
-        }
-
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (_class != null) {
-                    writerClassSource.addImport(_class);
-                    return "Map<String, " + _class.getSimpleName() + ">";
-                }
-            }
-        }
-
-        PropertyModel property = propertyWithOrigin.getProperty();
-        ctx.warn("Unable to determine value type for: " + property);
-        return "Object";
     }
 
     @Override


### PR DESCRIPTION
## Summary

Extract duplicated logic from 14 code block files into 2 shared utilities:

**`PrimitiveTypeHelper`** — static methods for type determination:
- `determineValueType(Type)` — maps concept type to Java type string
- `determineConsumePropertyVariant(Type)` — determines `JsonUtil.consume*` method name
- `determineSetPropertyVariant(Type)` — determines `JsonUtil.set*` method name

Previously duplicated across reader/writer primitive blocks, list/map blocks, and stage inner classes.

**`EntityResolver`** — entity lookup with null-check and warn:
- `resolveEntityInterface(property, entity, ctx)` — namespace + entity lookup + null-check + warn
- Returns `ResolvedEntity` record with entity model + Java interface

Previously repeated in 9+ code blocks with identical null-check + warn pattern.

**Net: -546 lines** (141 added, 687 removed across 14 files + 2 new)

## Context

C33 in #1042 — originally "JavaType body helpers", re-scoped to focused utility extraction after evaluating that the C32/C32b refactoring changed what helpers are most valuable.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged