### PR TITLE
refactor(generator): simplify JsonUtil — 88 to 40 methods (C34)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/Library.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/Library.java
@@ -103,7 +103,7 @@ public class Library {
         String versionProp = ModelTypeUtil.getVersionPropertyName(type);
         String version = ModelTypeUtil.getVersion(type);
         if (versionProp != null) {
-            JsonUtil.setStringProperty(json, versionProp, version);
+            JsonUtil.setProperty(json, versionProp, JsonUtil.toJsonNode(version));
         }
         return reader.readRoot(json);
     }

--- a/data-models/src/main/java/io/apitomy/datamodels/ModelTypeDetector.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/ModelTypeDetector.java
@@ -1,5 +1,6 @@
 package io.apitomy.datamodels;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apitomy.datamodels.models.ModelType;
@@ -7,6 +8,14 @@ import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.util.JsonUtil;
 
 public class ModelTypeDetector {
+
+    private static String getStringProp(ObjectNode json, String name) {
+        JsonNode node = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isString(node)) {
+            return JsonUtil.toString(node);
+        }
+        return null;
+    }
 
     /**
      * Called to discover what type of model the given JSON data represents.  This method
@@ -23,9 +32,9 @@ public class ModelTypeDetector {
      * @param json
      */
     public static ModelType discoverModelType(ObjectNode json) {
-        String asyncapi = JsonUtil.getStringProperty(json, "asyncapi");
-        String openapi = JsonUtil.getStringProperty(json, "openapi");
-        String swagger = JsonUtil.getStringProperty(json, "swagger");
+        String asyncapi = getStringProp(json, "asyncapi");
+        String openapi = getStringProp(json, "openapi");
+        String swagger = getStringProp(json, "swagger");
         if (asyncapi != null) {
             if (asyncapi.startsWith("2.0")) {
                 return ModelType.ASYNCAPI20;
@@ -70,7 +79,7 @@ public class ModelTypeDetector {
             }
         }
 
-        String openrpc = JsonUtil.getStringProperty(json, "openrpc");
+        String openrpc = getStringProp(json, "openrpc");
         if (openrpc != null) {
             if (openrpc.startsWith("1.3")) {
                 return ModelType.OPENRPC13;
@@ -81,7 +90,7 @@ public class ModelTypeDetector {
             }
         }
 
-        String schema = JsonUtil.getStringProperty(json, "$schema");
+        String schema = getStringProp(json, "$schema");
         if (schema != null) {
             if (schema.contains("draft-04")) {
                 return ModelType.JD4;

--- a/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi3NodeImporter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/deref/AsyncApi3NodeImporter.java
@@ -55,6 +55,14 @@ import java.util.Map;
  */
 public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
 
+    private static String getStringProp(ObjectNode json, String name) {
+        JsonNode node = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isString(node)) {
+            return JsonUtil.toString(node);
+        }
+        return null;
+    }
+
     public AsyncApi3NodeImporter(Document doc, Node nodeWithUnresolvedRef, String ref, boolean shouldInline) {
         super(doc, nodeWithUnresolvedRef, ref, shouldInline);
     }
@@ -451,7 +459,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
     private boolean isAvroSchema(Schema schemaNode) {
         try {
             ObjectNode json = Library.writeNode(schemaNode);
-            String type = JsonUtil.getStringProperty(json, "type");
+            String type = getStringProp(json, "type");
 
             // Avro schemas have "type": "record", "enum", "fixed", etc.
             // JSON Schema has "type": "object", "array", "string", etc.
@@ -476,7 +484,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
     private String extractAvroSchemaName(Schema schemaNode) {
         try {
             ObjectNode json = Library.writeNode(schemaNode);
-            String name = JsonUtil.getStringProperty(json, "name");
+            String name = getStringProp(json, "name");
 
             if (!NodeUtil.isNullOrUndefined(name)) {
                 return name;
@@ -498,7 +506,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
         try {
             // Protobuf schemas have an "x-text-content" property with the .proto file text
             ObjectNode json = Library.writeNode(schemaNode);
-            String protoContent = JsonUtil.getStringProperty(json, "x-text-content");
+            String protoContent = getStringProp(json, "x-text-content");
             return !NodeUtil.isNullOrUndefined(protoContent);
         } catch (Exception e) {
             // If we can't determine, assume it's JSON Schema
@@ -516,7 +524,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
     private String extractProtobufSchemaName(Schema schemaNode) {
         try {
             ObjectNode json = Library.writeNode(schemaNode);
-            String protoContent = JsonUtil.getStringProperty(json, "x-text-content");
+            String protoContent = getStringProp(json, "x-text-content");
 
             if (!NodeUtil.isNullOrUndefined(protoContent)) {
                 // Simple regex to extract message name from "message MessageName {"
@@ -544,7 +552,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
     private String extractProtobufContent(Schema schemaNode) {
         try {
             ObjectNode json = Library.writeNode(schemaNode);
-            String protoContent = JsonUtil.getStringProperty(json, "x-text-content");
+            String protoContent = getStringProp(json, "x-text-content");
             if (!NodeUtil.isNullOrUndefined(protoContent)) {
                 return protoContent;
             }
@@ -619,7 +627,7 @@ public class AsyncApi3NodeImporter extends ReferencedNodeImporter {
     private String extractAvroNameFromJson(JsonNode jsonNode) {
         try {
             if (JsonUtil.isObject(jsonNode)) {
-                String name = JsonUtil.getStringProperty((ObjectNode) jsonNode, "name");
+                String name = getStringProp((ObjectNode) jsonNode, "name");
                 if (!NodeUtil.isNullOrUndefined(name)) {
                     return name;
                 }

--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -47,7 +47,7 @@ export class JsonUtil {
         return JSON.parse(JSON.stringify(json));
     }
 
-    public static collectionToList(collection: any[]): any[] {
+    public static collectionToList<T>(collection: T[]): T[] {
         if (!collection) {
             return [];
         }

--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -20,380 +20,19 @@ export class JsonUtil {
         }
         return rval;
     }
+
     public static setProperty(json: object, propertyName: string, propertyValue: any): void {
         if (propertyValue !== null) {
             json[propertyName] = propertyValue;
         }
     }
+
     public static consumeProperty(json: any, propertyName: string): any {
         let rval: any = JsonUtil.getProperty(json, propertyName);
         if (rval) {
             delete json[propertyName];
         }
         return rval;
-    }
-
-    /* Get/Consume a JSON (Object) property. */
-    public static getObjectProperty(json: object, propertyName: string): object {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeObjectProperty(json: object, propertyName: string): object {
-        const value: object = JsonUtil.getObjectProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/Consume a JSON (Any) property. */
-    public static getAnyProperty(json: object, propertyName: string): any {
-        return JsonUtil.getProperty(json, propertyName);
-    }
-    public static consumeAnyProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getAnyProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of anys property. */
-    public static getAnyArrayProperty(json: object, propertyName: string): any[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <any[]> value;
-        }
-        return null;
-    }
-    public static consumeAnyArrayProperty(json: object, propertyName: string): any[] {
-        const value: any[] = JsonUtil.getAnyArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of objects property. */
-    public static getObjectArrayProperty(json: object, propertyName: string): object[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <object[]> value;
-        }
-        return null;
-    }
-    public static consumeObjectArrayProperty(json: object, propertyName: string): object[] {
-        const value: object[] = JsonUtil.getObjectArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of strings property. */
-    public static getStringArrayProperty(json: object, propertyName: string): string[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <string[]> value;
-        }
-        return null;
-    }
-    public static consumeStringArrayProperty(json: object, propertyName: string): string[] {
-        const value: string[] = JsonUtil.getStringArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of integers property. */
-    public static getIntegerArrayProperty(json: object, propertyName: string): number[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <number[]> value;
-        }
-        return null;
-    }
-    public static consumeIntegerArrayProperty(json: object, propertyName: string): number[] {
-        const value: number[] = JsonUtil.getIntegerArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of numbers property. */
-    public static getNumberArrayProperty(json: object, propertyName: string): number[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <number[]> value;
-        }
-        return null;
-    }
-    public static consumeNumberArrayProperty(json: object, propertyName: string): number[] {
-        const value: number[] = JsonUtil.getNumberArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume an array of booleans property. */
-    public static getBooleanArrayProperty(json: object, propertyName: string): boolean[] {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (Array.isArray(value)) {
-            return <boolean[]> value;
-        }
-        return null;
-    }
-    public static consumeBooleanArrayProperty(json: object, propertyName: string): boolean[] {
-        const value: boolean[] = JsonUtil.getBooleanArrayProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/Consume a string property. */
-    public static getStringProperty(json: object, propertyName: string): string {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "string") {
-            return <string> value;
-        }
-        return null;
-    }
-    public static consumeStringProperty(json: object, propertyName: string): string {
-        const value: string = JsonUtil.getStringProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/Consume an Integer property. */
-    public static getIntegerProperty(json: object, propertyName: string): number {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "number") {
-            return <number> value;
-        }
-        return null;
-    }
-    public static consumeIntegerProperty(json: object, propertyName: string): number {
-        const value: number = JsonUtil.getIntegerProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/Consume a Number property. */
-    public static getNumberProperty(json: object, propertyName: string): number {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "number") {
-            return <number> value;
-        }
-        return null;
-    }
-    public static consumeNumberProperty(json: object, propertyName: string): number {
-        const value: number = JsonUtil.getNumberProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/Consume a Boolean property. */
-    public static getBooleanProperty(json: object, propertyName: string): boolean {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "boolean") {
-            return <boolean> value;
-        }
-        return null;
-    }
-    public static consumeBooleanProperty(json: object, propertyName: string): boolean {
-        const value: boolean = JsonUtil.getBooleanProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume a map of anys property. */
-    public static getAnyMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeAnyMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getAnyMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume a map of objects property. */
-    public static getObjectMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeObjectMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getObjectMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-
-    /* Get/consume a map of strings property. */
-    public static getStringMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeStringMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getStringMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume a map of integers property. */
-    public static getIntegerMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeIntegerMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getIntegerMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume a map of numbers property. */
-    public static getNumberMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeNumberMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getNumberMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-    /* Get/consume a map of numbers property. */
-    public static getBooleanMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getProperty(json, propertyName);
-        if (typeof value === "object") {
-            return value;
-        }
-        return null;
-    }
-    public static consumeBooleanMapProperty(json: object, propertyName: string): any {
-        const value: any = JsonUtil.getBooleanMapProperty(json, propertyName);
-        if (value != null && value !== undefined) {
-            delete json[propertyName];
-        }
-        return value;
-    }
-
-
-    /* Set a JSON (Object) property. */
-    public static setObjectProperty(json: object, propertyName: string, value: object): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a JSON (Any) property. */
-    public static setAnyProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a JSON (Array) property. */
-    public static setArrayProperty(json: object, propertyName: string, value: any[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of anys property. */
-    public static setAnyArrayProperty(json: object, propertyName: string, value: any[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of objects property. */
-    public static setObjectArrayProperty(json: object, propertyName: string, value: object[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of strings property. */
-    public static setStringArrayProperty(json: object, propertyName: string, value: string[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of integers property. */
-    public static setIntegerArrayProperty(json: object, propertyName: string, value: number[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of numbers property. */
-    public static setNumberArrayProperty(json: object, propertyName: string, value: number[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an array of booleans property. */
-    public static setBooleanArrayProperty(json: object, propertyName: string, value: boolean[]): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a string property. */
-    public static setStringProperty(json: object, propertyName: string, value: string): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set an Integer property. */
-    public static setIntegerProperty(json: object, propertyName: string, value: number): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a Number property. */
-    public static setNumberProperty(json: object, propertyName: string, value: number): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a Boolean property. */
-    public static setBooleanProperty(json: object, propertyName: string, value: boolean): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of anys property. */
-    public static setAnyMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of objects property. */
-    public static setObjectMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of strings property. */
-    public static setStringMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of integers property. */
-    public static setIntegerMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of numbers property. */
-    public static setNumberMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
-    }
-    /* Set a map of numbers property. */
-    public static setBooleanMapProperty(json: object, propertyName: string, value: any): void {
-        JsonUtil.setProperty(json, propertyName, value);
     }
 
     public static stringify(json: any): string {
@@ -407,8 +46,8 @@ export class JsonUtil {
     public static clone(json: any): any {
         return JSON.parse(JSON.stringify(json));
     }
-    
-    public static cloneCollection(collection: Array<any>): Array<any> {
+
+    public static collectionToList(collection: any[]): any[] {
         if (!collection) {
             return [];
         }
@@ -427,14 +66,83 @@ export class JsonUtil {
         return [];
     }
 
+    public static toJsonNode(value: any): any {
+        return value;
+    }
+
+    public static toArrayNode(list: any[]): any[] {
+        if (list == null) {
+            return null;
+        }
+        const array: any[] = [];
+        for (let i: number = 0; i < list.length; i++) {
+            const node: any = list[i];
+            if (node != null) {
+                array.push(node);
+            }
+        }
+        return array;
+    }
+
+    public static toObjectNode(value: any): object {
+        return value;
+    }
+
+    public static allMatch(array: any, expectedType: string): boolean {
+        if (array == null || !Array.isArray(array)) {
+            return false;
+        }
+        for (let i: number = 0; i < array.length; i++) {
+            const item: any = array[i];
+            if (expectedType === "string") {
+                if (typeof item !== "string") return false;
+            } else if (expectedType === "boolean") {
+                if (typeof item !== "boolean") return false;
+            } else if (expectedType === "number") {
+                if (typeof item !== "number") return false;
+            } else if (expectedType === "integer") {
+                if (typeof item !== "number" || !Number.isInteger(item)) return false;
+            } else if (expectedType === "object") {
+                if (typeof item !== "object" || Array.isArray(item)) return false;
+            } else if (expectedType === "any") {
+                if (item == null) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static allValuesMatch(obj: any, expectedType: string): boolean {
+        if (obj == null) {
+            return false;
+        }
+        const fieldNames: string[] = JsonUtil.keys(obj);
+        for (let i: number = 0; i < fieldNames.length; i++) {
+            const item: any = obj[fieldNames[i]];
+            if (expectedType === "string") {
+                if (typeof item !== "string") return false;
+            } else if (expectedType === "boolean") {
+                if (typeof item !== "boolean") return false;
+            } else if (expectedType === "number") {
+                if (typeof item !== "number") return false;
+            } else if (expectedType === "integer") {
+                if (typeof item !== "number" || !Number.isInteger(item)) return false;
+            } else if (expectedType === "object") {
+                if (typeof item !== "object" || Array.isArray(item)) return false;
+            } else if (expectedType === "any") {
+                if (item == null) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static addToArray(array: Array<any>, value: any): void {
         array.push(value);
     }
 
-    public static isPropertyDefined(json: any, propertyName: string): boolean {
-        return json && json[propertyName] != null && json[propertyName] != undefined;
-    }
-    
     public static isString(value: any): boolean {
         if (value == null) {
             return false;
@@ -460,26 +168,6 @@ export class JsonUtil {
         return value;
     }
 
-    public static toJsonNode(value: any): any {
-        return value;
-    }
-
-    public static booleanToJsonNode(value: boolean): any {
-        return value;
-    }
-
-    public static stringToJsonNode(value: string): any {
-        return value;
-    }
-
-    public static numberToJsonNode(value: number): any {
-        return value;
-    }
-
-    public static toObjectNode(value: any): object {
-        return value;
-    }
-
     public static isBoolean(value: any): boolean {
         if (value == null) {
             return false;
@@ -502,6 +190,10 @@ export class JsonUtil {
         return value;
     }
 
+    public static toInteger(value: any): number {
+        return value;
+    }
+
     public static isObject(value: any): boolean {
         if (value == null) {
             return false;
@@ -516,10 +208,14 @@ export class JsonUtil {
         return false;
     }
 
-    public static isObjectWithPropertyValue(value: any, propertyName: string, propertyValue: string): boolean {
+    public static isObjectWithStringPropertyValue(value: any, propertyName: string, propertyValue: string): boolean {
         if (JsonUtil.isObject(value)) {
-            // Note: intentional use of the "==" operator here.  We want to do the type conversion before comparison in this case.
-            return value[propertyName] == propertyValue;
+            if (value.hasOwnProperty(propertyName)) {
+                const pvalue: any = value[propertyName];
+                if (pvalue != null && typeof pvalue === "string") {
+                    return propertyValue === pvalue;
+                }
+            }
         }
         return false;
     }

--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -39,6 +39,12 @@ export class JsonUtil {
         return JSON.stringify(json);
     }
 
+    public static removeProperty(json: any, propertyName: string): void {
+        if (json != null && typeof json === "object") {
+            delete json[propertyName];
+        }
+    }
+
     public static parseJSON(jsonString: string): any {
         return JSON.parse(jsonString);
     }
@@ -70,8 +76,12 @@ export class JsonUtil {
         return value;
     }
 
-    // JSweet mangled name for toJsonNode(Object) overload
+    // JSweet mangled names for toJsonNode overloads
     public static toJsonNode$java_lang_Object(value: any): any {
+        return value;
+    }
+
+    public static toJsonNode$com_fasterxml_jackson_databind_JsonNode(value: any): any {
         return value;
     }
 

--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -70,6 +70,11 @@ export class JsonUtil {
         return value;
     }
 
+    // JSweet mangled name for toJsonNode(Object) overload
+    public static toJsonNode$java_lang_Object(value: any): any {
+        return value;
+    }
+
     public static toArrayNode(list: any[]): any[] {
         if (list == null) {
             return null;

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -570,7 +570,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
                 body.append("            node.${addMethodName}(name, model);");
                 body.append("            this.${readMethodName}((ObjectNode) _val, model);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -588,7 +588,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
                 body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
                 body.append("            node.addItem(name, JsonUtil.${toConversionMethod}(_val));");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -617,7 +617,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
                 body.append("            }");
                 body.append("            node.addItem(name, items);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -648,7 +648,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
                 body.append("            }");
                 body.append("            node.addItem(name, items);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -685,7 +685,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
                 body.append("            node.${addMethodName}(name, model);");
                 body.append("            this.${readMethodName}((ObjectNode) _val, model);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -705,7 +705,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
                 body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
                 body.append("            node.${addMethodName}(name, JsonUtil.${toConversionMethod}(_val));");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -736,7 +736,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
                 body.append("            }");
                 body.append("            node.${addMethodName}(name, items);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");
@@ -769,7 +769,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
                 body.append("            }");
                 body.append("            node.${addMethodName}(name, items);");
-                body.append("            json.remove(name);");
+                body.append("            JsonUtil.removeProperty(json, name);");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -554,6 +554,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 }
                 readerClassSource.addImport(resolved.javaInterface());
                 readerClassSource.addImport(List.class);
+                readerClassSource.addImport(JsonNode.class);
 
                 body.addContext("entityJavaType", resolved.javaInterface().getName());
                 body.addContext("createMethodName", createMethodName(resolved.entityModel()));
@@ -562,30 +563,94 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
 
                 body.append("{");
                 body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    propertyNames.forEach(name -> {");
-                body.append("        ObjectNode object = JsonUtil.consumeObjectProperty(json, name);");
-                body.append("        if (object != null) {");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isObject(_val)) {");
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
                 body.append("            node.${addMethodName}(name, model);");
-                body.append("            this.${readMethodName}(object, model);");
+                body.append("            this.${readMethodName}((ObjectNode) _val, model);");
+                body.append("            json.remove(name);");
                 body.append("        }");
-                body.append("    });");
+                body.append("    }");
                 body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
+            } else if (isPrimitive(property)) {
                 readerClassSource.addImport(List.class);
-                if (property.getResolvedType().isMapType()) {
-                    readerClassSource.addImport(Map.class);
-                }
+                readerClassSource.addImport(JsonNode.class);
 
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
-                body.addContext("consumePropertyMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
 
                 body.append("{");
                 body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    propertyNames.forEach(name -> {");
-                body.append("        ${valueType} value = JsonUtil.${consumePropertyMethodName}(json, name);");
-                body.append("        node.addItem(name, value);");
-                body.append("    });");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
+                body.append("            node.addItem(name, JsonUtil.${toConversionMethod}(_val));");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveList(property)) {
+                readerClassSource.addImport(List.class);
+                readerClassSource.addImport(ArrayList.class);
+                readerClassSource.addImport(JsonNode.class);
+
+                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, CreateReadersStage.this);
+                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, CreateReadersStage.this, readerClassSource);
+                String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, CreateReadersStage.this, readerClassSource);
+                body.addContext("expectedType", expectedType);
+                body.addContext("toConversionMethod", toConversionMethod);
+                body.addContext("elementValueType", elementValueType);
+
+                body.append("{");
+                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, \"${expectedType}\")) {");
+                body.append("            List<${elementValueType}> items = new ArrayList<>();");
+                body.append("            List<JsonNode> _nodes = JsonUtil.toList(_val);");
+                body.append("            for (int _j = 0; _j < _nodes.size(); _j++) {");
+                body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
+                body.append("            }");
+                body.append("            node.addItem(name, items);");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveMap(property)) {
+                readerClassSource.addImport(List.class);
+                readerClassSource.addImport(JsonNode.class);
+                readerClassSource.addImport(Map.class);
+                readerClassSource.addImport(java.util.LinkedHashMap.class);
+
+                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, CreateReadersStage.this);
+                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, CreateReadersStage.this, readerClassSource);
+                String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, CreateReadersStage.this, readerClassSource);
+                body.addContext("expectedType", expectedType);
+                body.addContext("toConversionMethod", toConversionMethod);
+                body.addContext("elementValueType", elementValueType);
+
+                body.append("{");
+                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, \"${expectedType}\")) {");
+                body.append("            Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
+                body.append("            List<String> _keys = JsonUtil.keys((ObjectNode) _val);");
+                body.append("            for (int _j = 0; _j < _keys.size(); _j++) {");
+                body.append("                String _key = _keys.get(_j);");
+                body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
+                body.append("            }");
+                body.append("            node.addItem(name, items);");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
                 body.append("}");
             } else {
                 warn("STAR Entity property '" + property.getName() + "' not read (unhandled) for entity: " + entityModel.fullyQualifiedName());
@@ -603,6 +668,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 }
                 readerClassSource.addImport(resolved.javaInterface());
                 readerClassSource.addImport(List.class);
+                readerClassSource.addImport(JsonNode.class);
 
                 body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
                 body.addContext("entityJavaType", resolved.javaInterface().getName());
@@ -612,32 +678,100 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
 
                 body.append("{");
                 body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    propertyNames.forEach(name -> {");
-                body.append("        ObjectNode object = JsonUtil.consumeObjectProperty(json, name);");
-                body.append("        if (object != null) {");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isObject(_val)) {");
                 body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
                 body.append("            node.${addMethodName}(name, model);");
-                body.append("            this.${readMethodName}(object, model);");
+                body.append("            this.${readMethodName}((ObjectNode) _val, model);");
+                body.append("            json.remove(name);");
                 body.append("        }");
-                body.append("    });");
+                body.append("    }");
                 body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
+            } else if (isPrimitive(property)) {
                 readerClassSource.addImport(List.class);
-                if (property.getResolvedType().isMapType()) {
-                    readerClassSource.addImport(Map.class);
-                }
+                readerClassSource.addImport(JsonNode.class);
 
                 body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
-                body.addContext("consumeProperty", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
+                body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), CreateReadersStage.this, readerClassSource));
                 body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
 
                 body.append("{");
                 body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    propertyNames.forEach(name -> {");
-                body.append("        ${valueType} value = JsonUtil.${consumeProperty}(json, name);");
-                body.append("        node.${addMethodName}(name, value);");
-                body.append("    });");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
+                body.append("            node.${addMethodName}(name, JsonUtil.${toConversionMethod}(_val));");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveList(property)) {
+                readerClassSource.addImport(List.class);
+                readerClassSource.addImport(ArrayList.class);
+                readerClassSource.addImport(JsonNode.class);
+
+                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, CreateReadersStage.this);
+                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, CreateReadersStage.this, readerClassSource);
+                String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, CreateReadersStage.this, readerClassSource);
+                body.addContext("expectedType", expectedType);
+                body.addContext("toConversionMethod", toConversionMethod);
+                body.addContext("elementValueType", elementValueType);
+                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+                body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
+
+                body.append("{");
+                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, \"${expectedType}\")) {");
+                body.append("            List<${elementValueType}> items = new ArrayList<>();");
+                body.append("            List<JsonNode> _nodes = JsonUtil.toList(_val);");
+                body.append("            for (int _j = 0; _j < _nodes.size(); _j++) {");
+                body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
+                body.append("            }");
+                body.append("            node.${addMethodName}(name, items);");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveMap(property)) {
+                readerClassSource.addImport(List.class);
+                readerClassSource.addImport(JsonNode.class);
+                readerClassSource.addImport(Map.class);
+                readerClassSource.addImport(java.util.LinkedHashMap.class);
+
+                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, CreateReadersStage.this);
+                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, CreateReadersStage.this, readerClassSource);
+                String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, CreateReadersStage.this, readerClassSource);
+                body.addContext("expectedType", expectedType);
+                body.addContext("toConversionMethod", toConversionMethod);
+                body.addContext("elementValueType", elementValueType);
+                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+                body.addContext("addMethodName", addMethodName(singularize(property.getCollection())));
+
+                body.append("{");
+                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String name = propertyNames.get(_i);");
+                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
+                body.append("        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, \"${expectedType}\")) {");
+                body.append("            Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
+                body.append("            List<String> _keys = JsonUtil.keys((ObjectNode) _val);");
+                body.append("            for (int _j = 0; _j < _keys.size(); _j++) {");
+                body.append("                String _key = _keys.get(_j);");
+                body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
+                body.append("            }");
+                body.append("            node.${addMethodName}(name, items);");
+                body.append("            json.remove(name);");
+                body.append("        }");
+                body.append("    }");
                 body.append("}");
             } else {
                 warn("REGEX Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -167,7 +167,7 @@ public class CreateReadersStage extends AbstractJavaStage implements CodeGenCont
                 } else if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYVALUE) {
                     body.addContext("rulePropName", rule.getPropertyName());
                     body.addContext("rulePropValue", rule.getPropertyValue());
-                    condition = "JsonUtil.isObjectWithPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
+                    condition = "JsonUtil.isObjectWithStringPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
                 } else {
                     condition = "JsonUtil.isObject(json)";
                 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -504,24 +504,52 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
 
                 body.append("{");
                 body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    propertyNames.forEach(propertyName -> {");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String propertyName = propertyNames.get(_i);");
                 body.append("        ObjectNode object = JsonUtil.objectNode();");
                 body.append("        this.${writeMethodName}((${entityJavaType}) node.getItem(propertyName), object);");
-                body.append("        JsonUtil.setObjectProperty(json, propertyName, object);");
-                body.append("    });");
+                body.append("        JsonUtil.setProperty(json, propertyName, object);");
+                body.append("    }");
                 body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
+            } else if (isPrimitive(property)) {
                 writerClassSource.addImport(List.class);
 
                 body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
-                body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
 
                 body.append("{");
                 body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    propertyNames.forEach(propertyName -> {");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String propertyName = propertyNames.get(_i);");
                 body.append("        ${valueType} value = node.getItem(propertyName);");
-                body.append("        JsonUtil.${setPropertyMethodName}(json, propertyName, value);");
-                body.append("    });");
+                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveList(property)) {
+                writerClassSource.addImport(List.class);
+
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
+
+                body.append("{");
+                body.append("    List<String> propertyNames = node.getItemNames();");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String propertyName = propertyNames.get(_i);");
+                body.append("        ${valueType} value = node.getItem(propertyName);");
+                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveMap(property)) {
+                writerClassSource.addImport(List.class);
+                writerClassSource.addImport(Map.class);
+
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
+
+                body.append("{");
+                body.append("    List<String> propertyNames = node.getItemNames();");
+                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
+                body.append("        String propertyName = propertyNames.get(_i);");
+                body.append("        ${valueType} value = node.getItem(propertyName);");
+                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toObjectNode(value));");
+                body.append("    }");
                 body.append("}");
             } else {
                 warn("STAR Entity property '" + property.getName() + "' not written (unhandled) for entity: " + entityModel.fullyQualifiedName());
@@ -540,6 +568,7 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                 JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(resolved.entityModel());
 
                 writerClassSource.addImport(Map.class);
+                writerClassSource.addImport(List.class);
                 writerClassSource.addImport(resolved.javaInterface());
                 writerClassSource.addImport(commonEntityTypeJavaModel);
 
@@ -551,27 +580,67 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("{");
                 body.append("    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();");
                 body.append("    if (models != null && !models.isEmpty()) {");
-                body.append("        models.keySet().forEach(propertyName -> {");
+                body.append("        List<String> _keys = new java.util.ArrayList<>(models.keySet());");
+                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+                body.append("            String propertyName = _keys.get(_i);");
                 body.append("            ObjectNode object = JsonUtil.objectNode();");
                 body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(propertyName), object);");
-                body.append("            JsonUtil.setObjectProperty(json, propertyName, object);");
-                body.append("        });");
+                body.append("            JsonUtil.setProperty(json, propertyName, object);");
+                body.append("        }");
                 body.append("    }");
                 body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
+            } else if (isPrimitive(property)) {
                 writerClassSource.addImport(List.class);
+                writerClassSource.addImport(Map.class);
 
                 body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
                 body.addContext("getterMethodName", getterMethodName(property));
-                body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
 
                 body.append("{");
                 body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
                 body.append("    if (values != null && !values.isEmpty()) {");
-                body.append("        values.keySet().forEach(propertyName -> {");
+                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
+                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+                body.append("            String propertyName = _keys.get(_i);");
                 body.append("            ${valueType} value = values.get(propertyName);");
-                body.append("            JsonUtil.${setPropertyMethodName}(json, propertyName, value);");
-                body.append("        });");
+                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveList(property)) {
+                writerClassSource.addImport(List.class);
+                writerClassSource.addImport(Map.class);
+
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
+                body.addContext("getterMethodName", getterMethodName(property));
+
+                body.append("{");
+                body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
+                body.append("    if (values != null && !values.isEmpty()) {");
+                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
+                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+                body.append("            String propertyName = _keys.get(_i);");
+                body.append("            ${valueType} value = values.get(propertyName);");
+                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));");
+                body.append("        }");
+                body.append("    }");
+                body.append("}");
+            } else if (isPrimitiveMap(property)) {
+                writerClassSource.addImport(List.class);
+                writerClassSource.addImport(Map.class);
+
+                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), CreateWritersStage.this, writerClassSource));
+                body.addContext("getterMethodName", getterMethodName(property));
+
+                body.append("{");
+                body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
+                body.append("    if (values != null && !values.isEmpty()) {");
+                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
+                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+                body.append("            String propertyName = _keys.get(_i);");
+                body.append("            ${valueType} value = values.get(propertyName);");
+                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toObjectNode(value));");
+                body.append("        }");
                 body.append("    }");
                 body.append("}");
             } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -161,14 +161,8 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                     body.append("    return union.${asMethod}();");
                     body.append("}");
                 } else {
-                    String toJsonMethod;
-                    if (Boolean.class.equals(javaClass)) toJsonMethod = "booleanToJsonNode";
-                    else if (String.class.equals(javaClass)) toJsonMethod = "stringToJsonNode";
-                    else toJsonMethod = "numberToJsonNode";
-
-                    body.addContext("toJsonMethod", toJsonMethod);
                     body.append("if (union.${isMethod}()) {");
-                    body.append("    return JsonUtil.${toJsonMethod}(union.${asMethod}());");
+                    body.append("    return JsonUtil.toJsonNode(union.${asMethod}());");
                     body.append("}");
                 }
             } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType) {
@@ -205,12 +199,7 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                     writerClassSource.addImport(javaClass);
                     body.addContext("primType", javaClass.getSimpleName());
 
-                    String addExpr;
-                    if (Boolean.class.equals(javaClass)) addExpr = "array.add((Boolean) item)";
-                    else if (String.class.equals(javaClass)) addExpr = "array.add((String) item)";
-                    else addExpr = "array.add(JsonUtil.numberToJsonNode((Number) item))";
-
-                    body.addContext("addExpr", addExpr);
+                    body.addContext("addExpr", "array.add(JsonUtil.toJsonNode(item))");
                     body.append("if (union.${isMethod}()) {");
                     body.append("    ArrayNode array = JsonUtil.arrayNode();");
                     body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -537,7 +537,7 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
                 body.append("        String propertyName = propertyNames.get(_i);");
                 body.append("        ${valueType} value = node.getItem(propertyName);");
-                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toObjectNode(value));");
+                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));");
                 body.append("    }");
                 body.append("}");
             } else {
@@ -628,7 +628,7 @@ public class CreateWritersStage extends AbstractJavaStage implements CodeGenCont
                 body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
                 body.append("            String propertyName = _keys.get(_i);");
                 body.append("            ${valueType} value = values.get(propertyName);");
-                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toObjectNode(value));");
+                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));");
                 body.append("        }");
                 body.append("    }");
                 body.append("}");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeHelper.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeHelper.java
@@ -58,114 +58,79 @@ public final class PrimitiveTypeHelper {
     }
 
     /**
-     * Determines the {@code JsonUtil.consume*} method variant for reading a property of the given type.
-     *
-     * @return the method name, e.g. "consumeStringProperty", "consumeObjectArrayProperty"
+     * Determines the {@code JsonUtil.isXxx} type-check method name for a primitive type.
+     * E.g. String → "isString", Boolean → "isBoolean", ObjectNode → "isObject", JsonNode → "isJsonNode".
      */
-    public static String determineConsumePropertyVariant(Type type, CodeGenContext ctx, JavaClassSource classSource) {
-        if (type.isEntityType()) {
-            return "consumeObjectProperty";
+    public static String determineIsCheckMethod(Type primitiveType, CodeGenContext ctx, JavaClassSource classSource) {
+        Class<?> _class = ctx.primitiveTypeToClass(primitiveType);
+        if (ObjectNode.class.equals(_class)) {
+            classSource.addImport(_class);
+            return "isObject";
+        } else if (JsonNode.class.equals(_class)) {
+            classSource.addImport(_class);
+            return "isJsonNode";
+        } else if (String.class.equals(_class)) {
+            return "isString";
+        } else if (Boolean.class.equals(_class)) {
+            return "isBoolean";
+        } else if (Number.class.equals(_class) || Integer.class.equals(_class)) {
+            return "isNumber";
         }
-
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (ObjectNode.class.equals(_class)) {
-                classSource.addImport(_class);
-                return "consumeObjectProperty";
-            } else if (JsonNode.class.equals(_class)) {
-                classSource.addImport(_class);
-                return "consumeAnyProperty";
-            } else {
-                return "consume" + _class.getSimpleName() + "Property";
-            }
-        }
-
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "consumeObjectArrayProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "consumeAnyArrayProperty";
-                } else {
-                    return "consume" + _class.getSimpleName() + "ArrayProperty";
-                }
-            }
-        }
-
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "consumeObjectMapProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "consumeAnyMapProperty";
-                } else {
-                    return "consume" + _class.getSimpleName() + "MapProperty";
-                }
-            }
-        }
-
-        return "consumeProperty";
+        return "isJsonNode";
     }
 
     /**
-     * Determines the {@code JsonUtil.set*} method variant for writing a property of the given type.
-     *
-     * @return the method name, e.g. "setStringProperty", "setObjectArrayProperty"
+     * Determines the {@code JsonUtil.toXxx} conversion method name for a primitive type.
+     * E.g. String → "toString", Boolean → "toBoolean", ObjectNode → "toObject", JsonNode → "toJsonNode".
      */
-    public static String determineSetPropertyVariant(Type type, CodeGenContext ctx, JavaClassSource classSource) {
-        if (type.isPrimitiveType()) {
-            Class<?> _class = ctx.primitiveTypeToClass(type);
-            if (ObjectNode.class.equals(_class)) {
-                classSource.addImport(_class);
-                return "setObjectProperty";
-            } else if (JsonNode.class.equals(_class)) {
-                classSource.addImport(_class);
-                return "setAnyProperty";
-            } else {
-                return "set" + _class.getSimpleName() + "Property";
-            }
+    public static String determineToConversionMethod(Type primitiveType, CodeGenContext ctx, JavaClassSource classSource) {
+        Class<?> _class = ctx.primitiveTypeToClass(primitiveType);
+        if (ObjectNode.class.equals(_class)) {
+            classSource.addImport(_class);
+            return "toObject";
+        } else if (JsonNode.class.equals(_class)) {
+            classSource.addImport(_class);
+            return "toJsonNode";
+        } else if (String.class.equals(_class)) {
+            return "toString";
+        } else if (Boolean.class.equals(_class)) {
+            return "toBoolean";
+        } else if (Integer.class.equals(_class)) {
+            return "toInteger";
+        } else if (Number.class.equals(_class)) {
+            return "toNumber";
         }
+        return "toJsonNode";
+    }
 
-        if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
-            if (listValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(listValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "setObjectArrayProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "setAnyArrayProperty";
-                } else {
-                    return "set" + _class.getSimpleName() + "ArrayProperty";
-                }
-            }
+    /**
+     * Determines the expected type string for {@code JsonUtil.allMatch} / {@code JsonUtil.allValuesMatch}.
+     * E.g. String → "string", Boolean → "boolean", ObjectNode → "object", JsonNode → "any".
+     */
+    public static String determineExpectedTypeString(Type primitiveType, CodeGenContext ctx) {
+        Class<?> _class = ctx.primitiveTypeToClass(primitiveType);
+        if (ObjectNode.class.equals(_class)) {
+            return "object";
+        } else if (JsonNode.class.equals(_class)) {
+            return "any";
+        } else if (String.class.equals(_class)) {
+            return "string";
+        } else if (Boolean.class.equals(_class)) {
+            return "boolean";
+        } else if (Number.class.equals(_class)) {
+            return "number";
+        } else if (Integer.class.equals(_class)) {
+            return "number";
         }
+        return "any";
+    }
 
-        if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
-            if (mapValueType.isPrimitiveType()) {
-                Class<?> _class = ctx.primitiveTypeToClass(mapValueType);
-                if (ObjectNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "setObjectMapProperty";
-                } else if (JsonNode.class.equals(_class)) {
-                    classSource.addImport(_class);
-                    return "setAnyMapProperty";
-                } else {
-                    return "set" + _class.getSimpleName() + "MapProperty";
-                }
-            }
-        }
-
-        return "setProperty";
+    /**
+     * Returns true if the primitive type maps directly to a JsonNode subtype (ObjectNode or JsonNode),
+     * meaning no wrapping via toJsonNode() is needed for writers and no conversion is needed for readers.
+     */
+    public static boolean isJsonNodeType(Type primitiveType, CodeGenContext ctx) {
+        Class<?> _class = ctx.primitiveTypeToClass(primitiveType);
+        return ObjectNode.class.equals(_class) || JsonNode.class.equals(_class);
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
@@ -37,6 +39,7 @@ public class ReadEntityPropertyBlock extends CodeBlock {
             return;
         }
         readerClassSource.addImport(resolved.javaInterface());
+        readerClassSource.addImport(JsonNode.class);
 
         body.addContext("propertyName", property.getName());
         body.addContext("setterMethodName", ctx.setterMethodName(property));
@@ -44,12 +47,14 @@ public class ReadEntityPropertyBlock extends CodeBlock {
         body.addContext("getterMethodName", ctx.getterMethodName(property));
         body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
         body.addContext("propertyEntityType", resolved.javaInterface().getName());
+        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
         body.append("{");
-        body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-        body.append("    if (object != null) {");
+        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+        body.append("    if (JsonUtil.isObject(${varName})) {");
         body.append("        node.${setterMethodName}(node.${createMethodName}());");
-        body.append("        ${readMethodName}(object, (${propertyEntityType}) node.${getterMethodName}());");
+        body.append("        ${readMethodName}((ObjectNode) ${varName}, (${propertyEntityType}) node.${getterMethodName}());");
+        body.append("        json.remove(\"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -54,7 +54,7 @@ public class ReadEntityPropertyBlock extends CodeBlock {
         body.append("    if (JsonUtil.isObject(${varName})) {");
         body.append("        node.${setterMethodName}(node.${createMethodName}());");
         body.append("        ${readMethodName}(JsonUtil.toObject(${varName}), (${propertyEntityType}) node.${getterMethodName}());");
-        body.append("        json.remove(\"${propertyName}\");");
+        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -53,7 +53,7 @@ public class ReadEntityPropertyBlock extends CodeBlock {
         body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
         body.append("    if (JsonUtil.isObject(${varName})) {");
         body.append("        node.${setterMethodName}(node.${createMethodName}());");
-        body.append("        ${readMethodName}((ObjectNode) ${varName}, (${propertyEntityType}) node.${getterMethodName}());");
+        body.append("        ${readMethodName}(JsonUtil.toObject(${varName}), (${propertyEntityType}) node.${getterMethodName}());");
         body.append("        json.remove(\"${propertyName}\");");
         body.append("    }");
         body.append("}");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -65,7 +65,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.append("            items.add(JsonUtil.${toConversionMethod}(_nodes.get(_i)));");
             body.append("        }");
             body.append("        node.${setterMethodName}(items);");
-            body.append("        json.remove(\"${propertyName}\");");
+            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
             body.append("    }");
             body.append("}");
         } else if (listValueType.isEntityType()) {
@@ -93,7 +93,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.append("            node.${addMethodName}(model);");
             body.append("            this.${readMethodName}(object, model);");
             body.append("        }");
-            body.append("        json.remove(\"${propertyName}\");");
+            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
             body.append("    }");
             body.append("}");
         } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -1,6 +1,9 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
@@ -41,13 +44,29 @@ public class ReadListPropertyBlock extends CodeBlock {
 
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
-            body.addContext("consumeMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
-            body.addContext("propertyValueJavaType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
+            readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(List.class);
+            readerClassSource.addImport(ArrayList.class);
+
+            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, ctx);
+            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, ctx, readerClassSource);
+            String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, ctx, readerClassSource);
+            body.addContext("expectedType", expectedType);
+            body.addContext("toConversionMethod", toConversionMethod);
+            body.addContext("elementValueType", elementValueType);
+            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
             body.append("{");
-            body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
-            body.append("    node.${setterMethodName}(value);");
+            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+            body.append("    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, \"${expectedType}\")) {");
+            body.append("        List<${elementValueType}> items = new ArrayList<>();");
+            body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
+            body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
+            body.append("            items.add(JsonUtil.${toConversionMethod}(_nodes.get(_i)));");
+            body.append("        }");
+            body.append("        node.${setterMethodName}(items);");
+            body.append("        json.remove(\"${propertyName}\");");
+            body.append("    }");
             body.append("}");
         } else if (listValueType.isEntityType()) {
             var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
@@ -55,21 +74,26 @@ public class ReadListPropertyBlock extends CodeBlock {
                 return;
             }
             readerClassSource.addImport(resolved.javaInterface());
+            readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(List.class);
 
             body.addContext("listValueJavaType", resolved.javaInterface().getName());
             body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
             body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
             body.append("{");
-            body.append("    List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, \"${propertyName}\");");
-            body.append("    if (objects != null) {");
-            body.append("        objects.forEach(object -> {");
+            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+            body.append("    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, \"object\")) {");
+            body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
+            body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
+            body.append("            ObjectNode object = (ObjectNode) _nodes.get(_i);");
             body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
             body.append("            node.${addMethodName}(model);");
             body.append("            this.${readMethodName}(object, model);");
-            body.append("        });");
+            body.append("        }");
+            body.append("        json.remove(\"${propertyName}\");");
             body.append("    }");
             body.append("}");
         } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -88,7 +88,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.append("    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, \"object\")) {");
             body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
             body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
-            body.append("            ObjectNode object = (ObjectNode) _nodes.get(_i);");
+            body.append("            ObjectNode object = JsonUtil.toObject(_nodes.get(_i));");
             body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
             body.append("            node.${addMethodName}(model);");
             body.append("            this.${readMethodName}(object, model);");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -70,7 +70,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.append("            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty(JsonUtil.toObject(${varName}), _key)));");
             body.append("        }");
             body.append("        node.${setterMethodName}(items);");
-            body.append("        json.remove(\"${propertyName}\");");
+            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
             body.append("    }");
             body.append("}");
         } else if (mapValueType.isEntityType()) {
@@ -104,7 +104,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.append("                this.${readMethodName}(JsonUtil.toObject(_val), model);");
             body.append("            }");
             body.append("        }");
-            body.append("        json.remove(\"${propertyName}\");");
+            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
             body.append("    }");
             body.append("}");
         } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -1,6 +1,11 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
@@ -41,13 +46,32 @@ public class ReadMapPropertyBlock extends CodeBlock {
 
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
-            body.addContext("consumeMethodName", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
-            body.addContext("propertyValueJavaType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
+            readerClassSource.addImport(JsonNode.class);
+            readerClassSource.addImport(ObjectNode.class);
             readerClassSource.addImport(Map.class);
+            readerClassSource.addImport(LinkedHashMap.class);
+            readerClassSource.addImport(List.class);
+
+            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, ctx);
+            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, ctx, readerClassSource);
+            String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, ctx, readerClassSource);
+            body.addContext("expectedType", expectedType);
+            body.addContext("toConversionMethod", toConversionMethod);
+            body.addContext("elementValueType", elementValueType);
+            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
             body.append("{");
-            body.append("    ${propertyValueJavaType} value = JsonUtil.${consumeMethodName}(json, \"${propertyName}\");");
-            body.append("    node.${setterMethodName}(value);");
+            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+            body.append("    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch((ObjectNode) ${varName}, \"${expectedType}\")) {");
+            body.append("        Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
+            body.append("        List<String> _keys = JsonUtil.keys((ObjectNode) ${varName});");
+            body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+            body.append("            String _key = _keys.get(_i);");
+            body.append("            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) ${varName}, _key)));");
+            body.append("        }");
+            body.append("        node.${setterMethodName}(items);");
+            body.append("        json.remove(\"${propertyName}\");");
+            body.append("    }");
             body.append("}");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
@@ -56,22 +80,32 @@ public class ReadMapPropertyBlock extends CodeBlock {
                 return;
             }
             readerClassSource.addImport(resolved.javaInterface());
+            readerClassSource.addImport(JsonNode.class);
+            readerClassSource.addImport(ObjectNode.class);
+            readerClassSource.addImport(List.class);
 
             body.addContext("mapValueJavaType", resolved.javaInterface().getName());
             body.addContext("createMethodName", "create" + entityTypeName);
             body.addContext("readMethodName", "read" + entityTypeName);
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
             body.append("{");
-            body.append("    ObjectNode object = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-            body.append("    JsonUtil.keys(object).forEach(name -> {");
-            body.append("        ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);");
-            body.append("        if (mapValue != null) {");
-            body.append("            ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
-            body.append("            node.${addMethodName}(name, model);");
-            body.append("            this.${readMethodName}(mapValue, model);");
+            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+            body.append("    if (JsonUtil.isObject(${varName})) {");
+            body.append("        ObjectNode _obj = (ObjectNode) ${varName};");
+            body.append("        List<String> _keys = JsonUtil.keys(_obj);");
+            body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+            body.append("            String _key = _keys.get(_i);");
+            body.append("            JsonNode _val = JsonUtil.getProperty(_obj, _key);");
+            body.append("            if (JsonUtil.isObject(_val)) {");
+            body.append("                ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
+            body.append("                node.${addMethodName}(_key, model);");
+            body.append("                this.${readMethodName}((ObjectNode) _val, model);");
+            body.append("            }");
             body.append("        }");
-            body.append("    });");
+            body.append("        json.remove(\"${propertyName}\");");
+            body.append("    }");
             body.append("}");
         } else {
             ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -62,12 +62,12 @@ public class ReadMapPropertyBlock extends CodeBlock {
 
             body.append("{");
             body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-            body.append("    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch((ObjectNode) ${varName}, \"${expectedType}\")) {");
+            body.append("    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch(JsonUtil.toObject(${varName}), \"${expectedType}\")) {");
             body.append("        Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
-            body.append("        List<String> _keys = JsonUtil.keys((ObjectNode) ${varName});");
+            body.append("        List<String> _keys = JsonUtil.keys(JsonUtil.toObject(${varName}));");
             body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
             body.append("            String _key = _keys.get(_i);");
-            body.append("            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) ${varName}, _key)));");
+            body.append("            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty(JsonUtil.toObject(${varName}), _key)));");
             body.append("        }");
             body.append("        node.${setterMethodName}(items);");
             body.append("        json.remove(\"${propertyName}\");");
@@ -93,7 +93,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.append("{");
             body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
             body.append("    if (JsonUtil.isObject(${varName})) {");
-            body.append("        ObjectNode _obj = (ObjectNode) ${varName};");
+            body.append("        ObjectNode _obj = JsonUtil.toObject(${varName});");
             body.append("        List<String> _keys = JsonUtil.keys(_obj);");
             body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
             body.append("            String _key = _keys.get(_i);");
@@ -101,7 +101,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.append("            if (JsonUtil.isObject(_val)) {");
             body.append("                ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
             body.append("                node.${addMethodName}(_key, model);");
-            body.append("                this.${readMethodName}((ObjectNode) _val, model);");
+            body.append("                this.${readMethodName}(JsonUtil.toObject(_val), model);");
             body.append("            }");
             body.append("        }");
             body.append("        json.remove(\"${propertyName}\");");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -46,7 +46,7 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
         body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
         body.append("    if (JsonUtil.${isCheckMethod}(${varName})) {");
         body.append("        node.${setterMethodName}(JsonUtil.${toConversionMethod}(${varName}));");
-        body.append("        json.remove(\"${propertyName}\");");
+        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
@@ -29,14 +31,23 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, readerClassSource));
-        body.addContext("consumeProperty", PrimitiveTypeHelper.determineConsumePropertyVariant(property.getResolvedType(), ctx, readerClassSource));
         body.addContext("propertyName", property.getName());
         body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+
+        readerClassSource.addImport(JsonNode.class);
+
+        String isCheckMethod = PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), ctx, readerClassSource);
+        String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), ctx, readerClassSource);
+        body.addContext("isCheckMethod", isCheckMethod);
+        body.addContext("toConversionMethod", toConversionMethod);
 
         body.append("{");
-        body.append("    ${valueType} value = JsonUtil.${consumeProperty}(json, \"${propertyName}\");");
-        body.append("    node.${setterMethodName}(value);");
+        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+        body.append("    if (JsonUtil.${isCheckMethod}(${varName})) {");
+        body.append("        node.${setterMethodName}(JsonUtil.${toConversionMethod}(${varName}));");
+        body.append("        json.remove(\"${propertyName}\");");
+        body.append("    }");
         body.append("}");
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -66,7 +66,7 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
         body.append("            for (int _i = 0; _i < _items.size(); _i++) {");
         body.append("                node.${addMethodName}(_items.get(_i));");
         body.append("            }");
-        body.append("            json.remove(\"${propertyName}\");");
+        body.append("            JsonUtil.removeProperty(json, \"${propertyName}\");");
         body.append("        }");
         body.append("    }");
         body.append("}");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -49,13 +49,25 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
         body.addContext("readMethodName", readMethodName);
         body.addContext("unionJavaType", valueJt.toJavaTypeString());
 
+        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+
         body.append("{");
-        body.append("    List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, \"${propertyName}\");");
-        body.append("    if (array != null) {");
-        body.append("        array.forEach(item -> {");
-        body.append("            ${unionJavaType} value = this.${readMethodName}(item, null);");
-        body.append("            if (value != null) node.${addMethodName}(value);");
-        body.append("        });");
+        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+        body.append("    if (JsonUtil.isArray(${varName})) {");
+        body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
+        body.append("        List<${unionJavaType}> _items = new ArrayList<>();");
+        body.append("        boolean _valid = true;");
+        body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
+        body.append("            ${unionJavaType} _result = this.${readMethodName}(_nodes.get(_i), null);");
+        body.append("            if (_result == null) { _valid = false; break; }");
+        body.append("            _items.add(_result);");
+        body.append("        }");
+        body.append("        if (_valid) {");
+        body.append("            for (int _i = 0; _i < _items.size(); _i++) {");
+        body.append("                node.${addMethodName}(_items.get(_i));");
+        body.append("            }");
+        body.append("            json.remove(\"${propertyName}\");");
+        body.append("        }");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -49,16 +49,22 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
         body.addContext("readMethodName", readMethodName);
         body.addContext("unionJavaType", valueJt.toJavaTypeString());
 
+        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+
         body.append("{");
-        body.append("    ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, \"${propertyName}\");");
-        body.append("    if (mapObj != null) {");
-        body.append("        JsonUtil.keys(mapObj).forEach(key -> {");
-        body.append("            JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);");
-        body.append("            if (value != null) {");
-        body.append("                ${unionJavaType} model = this.${readMethodName}(value, null);");
-        body.append("                if (model != null) node.${addMethodName}(key, model);");
+        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+        body.append("    if (JsonUtil.isObject(${varName})) {");
+        body.append("        ObjectNode _obj = (ObjectNode) ${varName};");
+        body.append("        List<String> _keys = JsonUtil.keys(_obj);");
+        body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
+        body.append("            String _key = _keys.get(_i);");
+        body.append("            JsonNode _val = JsonUtil.getProperty(_obj, _key);");
+        body.append("            if (JsonUtil.isJsonNode(_val)) {");
+        body.append("                ${unionJavaType} model = this.${readMethodName}(_val, null);");
+        body.append("                if (model != null) node.${addMethodName}(_key, model);");
         body.append("            }");
-        body.append("        });");
+        body.append("        }");
+        body.append("        json.remove(\"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -64,7 +64,7 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
         body.append("                if (model != null) node.${addMethodName}(_key, model);");
         body.append("            }");
         body.append("        }");
-        body.append("        json.remove(\"${propertyName}\");");
+        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -54,7 +54,7 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
         body.append("{");
         body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
         body.append("    if (JsonUtil.isObject(${varName})) {");
-        body.append("        ObjectNode _obj = (ObjectNode) ${varName};");
+        body.append("        ObjectNode _obj = JsonUtil.toObject(${varName});");
         body.append("        List<String> _keys = JsonUtil.keys(_obj);");
         body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
         body.append("            String _key = _keys.get(_i);");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -43,10 +43,13 @@ public class ReadUnionPropertyBlock extends CodeBlock {
         body.addContext("setterMethodName", ctx.setterMethodName(property));
         body.addContext("readMethodName", readMethodName);
 
+        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+
         body.append("{");
-        body.append("    JsonNode value = JsonUtil.consumeAnyProperty(json, \"${propertyName}\");");
-        body.append("    if (value != null) {");
-        body.append("        node.${setterMethodName}(this.${readMethodName}(value, null));");
+        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
+        body.append("    if (JsonUtil.isJsonNode(${varName})) {");
+        body.append("        node.${setterMethodName}(this.${readMethodName}(${varName}, null));");
+        body.append("        json.remove(\"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -49,7 +49,7 @@ public class ReadUnionPropertyBlock extends CodeBlock {
         body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
         body.append("    if (JsonUtil.isJsonNode(${varName})) {");
         body.append("        node.${setterMethodName}(this.${readMethodName}(${varName}, null));");
-        body.append("        json.remove(\"${propertyName}\");");
+        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -48,7 +48,7 @@ public class WriteEntityPropertyBlock extends CodeBlock {
         body.append("    if (node.${getterMethodName}() != null) {");
         body.append("        ObjectNode object = JsonUtil.objectNode();");
         body.append("        this.${writeMethodName}((${propertyTypeJavaEntity}) node.${getterMethodName}(), object);");
-        body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
+        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", object);");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -44,9 +44,7 @@ public class WriteListPropertyBlock extends CodeBlock {
 
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
-            body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
-
-            body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+            body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toArrayNode(node.${getterMethodName}()));");
         } else if (listValueType.isEntityType()) {
             var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
             if (resolved == null) {
@@ -73,7 +71,7 @@ public class WriteListPropertyBlock extends CodeBlock {
             body.append("            this.${writeMethodName}((${listValueJavaType}) model, object);");
             body.append("            JsonUtil.addToArray(array, object);");
             body.append("        });");
-            body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+            body.append("        JsonUtil.setProperty(json, \"${propertyName}\", array);");
             body.append("    }");
             body.append("}");
         } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -43,10 +43,7 @@ public class WriteMapPropertyBlock extends CodeBlock {
 
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
-            body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
-            writerClassSource.addImport(List.class);
-
-            body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+            body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toObjectNode(node.${getterMethodName}()));");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
             var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
@@ -70,9 +67,9 @@ public class WriteMapPropertyBlock extends CodeBlock {
             body.append("        models.keySet().forEach(jsonName -> {");
             body.append("            ObjectNode jsonValue = JsonUtil.objectNode();");
             body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);");
-            body.append("            JsonUtil.setObjectProperty(object, jsonName, jsonValue);");
+            body.append("            JsonUtil.setProperty(object, jsonName, jsonValue);");
             body.append("        });");
-            body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", object);");
+            body.append("        JsonUtil.setProperty(json, \"${propertyName}\", object);");
             body.append("    }");
             body.append("}");
         } else {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -29,11 +29,15 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("setPropertyMethodName", PrimitiveTypeHelper.determineSetPropertyVariant(property.getResolvedType(), ctx, writerClassSource));
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", ctx.getterMethodName(property));
 
-        body.append("JsonUtil.${setPropertyMethodName}(json, \"${propertyName}\", node.${getterMethodName}());");
+        if (PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), ctx)) {
+            // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly
+            body.append("JsonUtil.setProperty(json, \"${propertyName}\", node.${getterMethodName}());");
+        } else {
+            body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toJsonNode(node.${getterMethodName}()));");
+        }
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -57,7 +57,7 @@ public class WriteUnionListPropertyBlock extends CodeBlock {
         body.append("            JsonNode value = this.${writeMethodName}(item);");
         body.append("            if (value != null) array.add(value);");
         body.append("        });");
-        body.append("        JsonUtil.setAnyProperty(json, \"${propertyName}\", array);");
+        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", array);");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -59,9 +59,9 @@ public class WriteUnionMapPropertyBlock extends CodeBlock {
         body.append("        Collection<String> keys = items.keySet();");
         body.append("        keys.forEach(key -> {");
         body.append("            JsonNode value = this.${writeMethodName}(items.get(key));");
-        body.append("            if (value != null) JsonUtil.setAnyProperty(mapJson, key, value);");
+        body.append("            if (value != null) JsonUtil.setProperty(mapJson, key, value);");
         body.append("        });");
-        body.append("        JsonUtil.setObjectProperty(json, \"${propertyName}\", mapJson);");
+        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", mapJson);");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
@@ -45,7 +45,7 @@ public class WriteUnionPropertyBlock extends CodeBlock {
 
         body.append("{");
         body.append("    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());");
-        body.append("    if (value != null) JsonUtil.setAnyProperty(json, \"${propertyName}\", value);");
+        body.append("    if (value != null) JsonUtil.setProperty(json, \"${propertyName}\", value);");
         body.append("}");
     }
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -55,608 +54,6 @@ public class JsonUtil {
         }
     }
 
-    /* Get/Consume a JSON (Object) property. */
-    public static ObjectNode getObjectProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode objectNode = json.get(propertyName);
-            if (objectNode.isObject()) {
-                return (ObjectNode) objectNode;
-            }
-        }
-        return null;
-    }
-    public static ObjectNode consumeObjectProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            ObjectNode rval = getObjectProperty(json, propertyName);
-            if (rval != null) {
-                json.remove(propertyName);
-                return rval;
-            }
-        }
-        return null;
-    }
-
-    /* Get/Consume a JSON (Any) property. */
-    public static JsonNode getAnyProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode jsonNode = json.get(propertyName);
-            if (!jsonNode.isNull()) {
-                return jsonNode;
-            }
-        }
-        return null;
-    }
-    public static JsonNode consumeAnyProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode rval = getAnyProperty(json, propertyName);
-            json.remove(propertyName);
-            return rval;
-        }
-        return null;
-    }
-
-    /* Get/consume an array of anys property. */
-    public static List<JsonNode> getAnyArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<JsonNode> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                rval.add(item);
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<JsonNode> consumeAnyArrayProperty(ObjectNode json, String propertyName) {
-        List<JsonNode> rval = getAnyArrayProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume an array of objects property. */
-    public static List<ObjectNode> getObjectArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<ObjectNode> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                if (item.isObject()) {
-                    rval.add((ObjectNode) item);
-                }
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<ObjectNode> consumeObjectArrayProperty(ObjectNode json, String propertyName) {
-        List<ObjectNode> rval = getObjectArrayProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume an array of strings property. */
-    public static List<String> getStringArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<String> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                rval.add(item.isNull() ? null : item.asText());
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<String> consumeStringArrayProperty(ObjectNode json, String propertyName) {
-        ObjectNode node = json;
-        if (node.has(propertyName)) {
-            List<String> rval = getStringArrayProperty(json, propertyName);
-            node.remove(propertyName);
-            return rval;
-        }
-        return null;
-    }
-
-    /* Get/consume an array of integers property. */
-    public static List<Integer> getIntegerArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<Integer> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                if (item.isInt()) {
-                    rval.add(item.asInt());
-                }
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<Integer> consumeIntegerArrayProperty(ObjectNode json, String propertyName) {
-        ObjectNode node = json;
-        if (node.has(propertyName)) {
-            List<Integer> rval = getIntegerArrayProperty(json, propertyName);
-            node.remove(propertyName);
-            return rval;
-        }
-        return null;
-    }
-
-    /* Get/consume an array of numbers property. */
-    public static List<Number> getNumberArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<Number> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                if (item.isInt()) {
-                    rval.add(item.asInt());
-                }
-                if (item.isLong()) {
-                    rval.add(item.asLong());
-                }
-                if (item.isFloat() || item.isDouble() || item.isBigDecimal() || item.isBigInteger()) {
-                    rval.add(item.asDouble());
-                }
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<Number> consumeNumberArrayProperty(ObjectNode json, String propertyName) {
-        ObjectNode node = json;
-        if (node.has(propertyName)) {
-            List<Number> rval = getNumberArrayProperty(json, propertyName);
-            node.remove(propertyName);
-            return rval;
-        }
-        return null;
-    }
-
-    /* Get/consume an array of booleans property. */
-    public static List<Boolean> getBooleanArrayProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isArray()) {
-            ArrayNode array = (ArrayNode) node;
-            List<Boolean> rval = new ArrayList<>();
-            for (JsonNode item : array) {
-                if (item.isBoolean()) {
-                    rval.add(item.asBoolean());
-                }
-            }
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static List<Boolean> consumeBooleanArrayProperty(ObjectNode json, String propertyName) {
-        ObjectNode node = json;
-        if (node.has(propertyName)) {
-            List<Boolean> rval = getBooleanArrayProperty(json, propertyName);
-            node.remove(propertyName);
-            return rval;
-        }
-        return null;
-    }
-
-    /* Get/Consume a string property. */
-    public static String getStringProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode textNode = json.get(propertyName);
-            if (textNode.isTextual()) {
-                return textNode.asText();
-            }
-        }
-        return null;
-    }
-    public static String consumeStringProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            String rval = getStringProperty(json, propertyName);
-            if (rval != null) {
-                json.remove(propertyName);
-                return rval;
-            }
-        }
-        return null;
-    }
-
-    /* Get/Consume an Integer property. */
-    public static Integer getIntegerProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode textNode = json.get(propertyName);
-            if (textNode.isInt()) {
-                return textNode.asInt();
-            }
-        }
-        return null;
-    }
-    public static Integer consumeIntegerProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            Integer rval = getIntegerProperty(json, propertyName);
-            if (rval != null) {
-                json.remove(propertyName);
-                return rval;
-            }
-        }
-        return null;
-    }
-
-    /* Get/Consume a Number property. */
-    public static Number getNumberProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode node = json.get(propertyName);
-            if (node.isInt()) {
-                return node.asInt();
-            }
-            if (node.isLong()) {
-                return node.asLong();
-            }
-            if (node.isFloat() || node.isDouble()) {
-                return node.asDouble();
-            }
-        }
-        return null;
-    }
-    public static Number consumeNumberProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            Number rval = getNumberProperty(json, propertyName);
-            if (rval != null) {
-                json.remove(propertyName);
-                return rval;
-            }
-        }
-        return null;
-    }
-
-    /* Get/Consume a Boolean property. */
-    public static Boolean getBooleanProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            JsonNode textNode = json.get(propertyName);
-            if (textNode.isBoolean()) {
-                return textNode.asBoolean();
-            }
-        }
-        return null;
-    }
-    public static Boolean consumeBooleanProperty(ObjectNode json, String propertyName) {
-        if (json.has(propertyName)) {
-            Boolean rval = getBooleanProperty(json, propertyName);
-            if (rval != null) {
-                json.remove(propertyName);
-                return rval;
-            }
-        }
-        return null;
-    }
-
-    /* Get/consume a map of anys property. */
-    public static Map<String, JsonNode> getAnyMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, JsonNode> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getAnyProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, JsonNode> consumeAnyMapProperty(ObjectNode json, String propertyName) {
-        Map<String, JsonNode> rval = getAnyMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume a map of objects property. */
-    public static Map<String, ObjectNode> getObjectMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, ObjectNode> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getObjectProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, ObjectNode> consumeObjectMapProperty(ObjectNode json, String propertyName) {
-        Map<String, ObjectNode> rval = getObjectMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume a map of strings property. */
-    public static Map<String, String> getStringMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, String> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getStringProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, String> consumeStringMapProperty(ObjectNode json, String propertyName) {
-        Map<String, String> rval = getStringMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume a map of integers property. */
-    public static Map<String, Integer> getIntegerMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, Integer> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getIntegerProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, Integer> consumeIntegerMapProperty(ObjectNode json, String propertyName) {
-        Map<String, Integer> rval = getIntegerMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume a map of numbers property. */
-    public static Map<String, Number> getNumberMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, Number> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getNumberProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, Number> consumeNumberMapProperty(ObjectNode json, String propertyName) {
-        Map<String, Number> rval = getNumberMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Get/consume a map of numbers property. */
-    public static Map<String, Boolean> getBooleanMapProperty(ObjectNode json, String propertyName) {
-        if (!json.has(propertyName)) {
-            return null;
-        }
-        JsonNode node = json.get(propertyName);
-        if (node.isObject()) {
-            ObjectNode object = (ObjectNode) node;
-            Map<String, Boolean> rval = new LinkedHashMap<>();
-            List<String> keys = keys(object);
-            keys.forEach(key -> {
-                rval.put(key, getBooleanProperty(object, key));
-            });
-            return rval;
-        } else {
-            return null;
-        }
-    }
-    public static Map<String, Boolean> consumeBooleanMapProperty(ObjectNode json, String propertyName) {
-        Map<String, Boolean> rval = getBooleanMapProperty(json, propertyName);
-        if (rval != null) {
-            json.remove(propertyName);
-        }
-        return rval;
-    }
-
-    /* Set a JSON (Object) property. */
-    public static void setObjectProperty(ObjectNode json, String propertyName, ObjectNode value) {
-        if (value != null) {
-            json.set(propertyName, value);
-        }
-    }
-    /* Set a JSON (Any) property. */
-    public static void setAnyProperty(ObjectNode json, String propertyName, JsonNode value) {
-        if (value != null) {
-            json.set(propertyName, value);
-        }
-    }
-    /* Set an array of anys property. */
-    public static void setAnyArrayProperty(ObjectNode json, String propertyName, List<JsonNode> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set an array of objects property. */
-    public static void setObjectArrayProperty(ObjectNode json, String propertyName, List<ObjectNode> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set an array of strings property. */
-    public static void setStringArrayProperty(ObjectNode json, String propertyName, List<String> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set an array of integers property. */
-    public static void setIntegerArrayProperty(ObjectNode json, String propertyName, List<Integer> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set an array of numbers property. */
-    public static void setNumberArrayProperty(ObjectNode json, String propertyName, List<Number> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v != null ? v.doubleValue() : null));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set an array of booleans property. */
-    public static void setBooleanArrayProperty(ObjectNode json, String propertyName, List<Boolean> value) {
-        if (value != null) {
-            ArrayNode array = json.arrayNode(value.size());
-            value.forEach(v -> array.add(v));
-            json.set(propertyName, array);
-        }
-    }
-    /* Set a string property. */
-    public static void setStringProperty(ObjectNode json, String propertyName, String value) {
-        if (value != null) {
-            json.set(propertyName, factory.textNode(value));
-        }
-    }
-    /* Set an Integer property. */
-    public static void setIntegerProperty(ObjectNode json, String propertyName, Integer value) {
-        if (value != null) {
-            json.set(propertyName, factory.numberNode(value));
-        }
-    }
-    /* Set a Number property. */
-    public static void setNumberProperty(ObjectNode json, String propertyName, Number value) {
-        if (value != null) {
-            json.set(propertyName, factory.numberNode(value.doubleValue()));
-        }
-    }
-    /* Set a Boolean property. */
-    public static void setBooleanProperty(ObjectNode json, String propertyName, Boolean value) {
-        if (value != null) {
-            json.set(propertyName, factory.booleanNode(value));
-        }
-    }
-    /* Set a map of anys property. */
-    public static void setAnyMapProperty(ObjectNode json, String propertyName, Map<String, JsonNode> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                object.set(entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
-    /* Set a map of objects property. */
-    public static void setObjectMapProperty(ObjectNode json, String propertyName, Map<String, ObjectNode> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                object.set(entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
-    /* Set a map of strings property. */
-    public static void setStringMapProperty(ObjectNode json, String propertyName, Map<String, String> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                setStringProperty(object, entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
-    /* Set a map of integers property. */
-    public static void setIntegerMapProperty(ObjectNode json, String propertyName, Map<String, Integer> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                setIntegerProperty(object, entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
-    /* Set a map of numbers property. */
-    public static void setNumberMapProperty(ObjectNode json, String propertyName, Map<String, Number> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                setNumberProperty(object, entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
-    /* Set a map of numbers property. */
-    public static void setBooleanMapProperty(ObjectNode json, String propertyName, Map<String, Boolean> value) {
-        if (value != null) {
-            ObjectNode object = objectNode();
-            value.entrySet().forEach(entry -> {
-                setBooleanProperty(object, entry.getKey(), entry.getValue());
-            });
-            setProperty(json, propertyName, object);
-        }
-    }
 
     public static String stringify(JsonNode json) {
         try {
@@ -721,6 +118,111 @@ public class JsonUtil {
     public static JsonNode numberToJsonNode(Number value) {
         if (value == null) return null;
         return factory.numberNode(value.doubleValue());
+    }
+
+    public static JsonNode toJsonNode(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof JsonNode) {
+            return (JsonNode) value;
+        }
+        if (value instanceof String) {
+            return factory.textNode((String) value);
+        }
+        if (value instanceof Boolean) {
+            return factory.booleanNode((Boolean) value);
+        }
+        if (value instanceof Integer) {
+            return factory.numberNode((Integer) value);
+        }
+        if (value instanceof Number) {
+            return factory.numberNode(((Number) value).doubleValue());
+        }
+        return null;
+    }
+
+    public static ArrayNode toArrayNode(List<?> list) {
+        if (list == null) {
+            return null;
+        }
+        ArrayNode array = factory.arrayNode(list.size());
+        for (int i = 0; i < list.size(); i++) {
+            JsonNode node = toJsonNode(list.get(i));
+            if (node != null) {
+                array.add(node);
+            }
+        }
+        return array;
+    }
+
+    public static ObjectNode toObjectNode(Map<String, ?> map) {
+        if (map == null) {
+            return null;
+        }
+        ObjectNode object = factory.objectNode();
+        List<String> mapKeys = new ArrayList<>(map.keySet());
+        for (int i = 0; i < mapKeys.size(); i++) {
+            String key = mapKeys.get(i);
+            JsonNode node = toJsonNode(map.get(key));
+            if (node != null) {
+                object.set(key, node);
+            }
+        }
+        return object;
+    }
+
+    public static boolean allMatch(JsonNode array, String expectedType) {
+        if (array == null || !array.isArray()) {
+            return false;
+        }
+        ArrayNode arrayNode = (ArrayNode) array;
+        for (int i = 0; i < arrayNode.size(); i++) {
+            JsonNode item = arrayNode.get(i);
+            if ("string".equals(expectedType)) {
+                if (!item.isTextual()) return false;
+            } else if ("boolean".equals(expectedType)) {
+                if (!item.isBoolean()) return false;
+            } else if ("number".equals(expectedType)) {
+                if (!item.isNumber()) return false;
+            } else if ("integer".equals(expectedType)) {
+                if (!item.isInt()) return false;
+            } else if ("object".equals(expectedType)) {
+                if (!item.isObject()) return false;
+            } else if ("any".equals(expectedType)) {
+                if (item.isNull()) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean allValuesMatch(ObjectNode obj, String expectedType) {
+        if (obj == null) {
+            return false;
+        }
+        Iterator<String> fieldNames = obj.fieldNames();
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode item = obj.get(fieldName);
+            if ("string".equals(expectedType)) {
+                if (!item.isTextual()) return false;
+            } else if ("boolean".equals(expectedType)) {
+                if (!item.isBoolean()) return false;
+            } else if ("number".equals(expectedType)) {
+                if (!item.isNumber()) return false;
+            } else if ("integer".equals(expectedType)) {
+                if (!item.isInt()) return false;
+            } else if ("object".equals(expectedType)) {
+                if (!item.isObject()) return false;
+            } else if ("any".equals(expectedType)) {
+                if (item.isNull()) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void addToArray(ArrayNode array, JsonNode value) {
@@ -795,6 +297,10 @@ public class JsonUtil {
             return value.asLong();
         }
         return value.asDouble();
+    }
+
+    public static Integer toInteger(JsonNode value) {
+        return value.asInt();
     }
 
     public static boolean isObject(JsonNode value) {

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -85,6 +85,12 @@ public class JsonUtil {
         return new ArrayList<>(collection);
     }
 
+    public static void removeProperty(ObjectNode json, String propertyName) {
+        if (json != null) {
+            json.remove(propertyName);
+        }
+    }
+
     public static ObjectNode objectNode() {
         return factory.objectNode();
     }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -233,10 +233,6 @@ public class JsonUtil {
         return value;
     }
 
-    public static ObjectNode toObjectNode(JsonNode value) {
-        return (ObjectNode) value;
-    }
-
     public static boolean isBoolean(JsonNode value) {
         if (value == null) {
             return false;

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -97,19 +97,6 @@ public class JsonUtil {
         return factory.textNode(value);
     }
 
-    public static JsonNode booleanToJsonNode(Boolean value) {
-        return value != null ? factory.booleanNode(value) : null;
-    }
-
-    public static JsonNode stringToJsonNode(String value) {
-        return value != null ? factory.textNode(value) : null;
-    }
-
-    public static JsonNode numberToJsonNode(Number value) {
-        if (value == null) return null;
-        return factory.numberNode(value.doubleValue());
-    }
-
     public static JsonNode toJsonNode(Object value) {
         if (value == null) {
             return null;

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -78,7 +78,7 @@ public class JsonUtil {
         }
     }
 
-    public static Collection<?> cloneCollection(Collection<?> collection) {
+    public static <T> List<T> collectionToList(Collection<T> collection) {
         if (collection == null) {
             return new ArrayList<>();
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -3,7 +3,7 @@ package io.apitomy.umg.base.util;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -28,11 +28,7 @@ public class JsonUtil {
     public static List<String> keys(ObjectNode json) {
         List<String> rval = new ArrayList<>();
         if (json != null) {
-            Iterator<String> fieldNames = json.fieldNames();
-            while (fieldNames.hasNext()) {
-                String fieldName = fieldNames.next();
-                rval.add(fieldName);
-            }
+            json.fieldNames().forEachRemaining(rval::add);
         }
         return rval;
     }
@@ -101,12 +97,6 @@ public class JsonUtil {
         return factory.textNode(value);
     }
 
-    public static void setArrayProperty(ObjectNode json, String propertyName, ArrayNode value) {
-        if (value != null) {
-            json.set(propertyName, value);
-        }
-    }
-
     public static JsonNode booleanToJsonNode(Boolean value) {
         return value != null ? factory.booleanNode(value) : null;
     }
@@ -134,10 +124,10 @@ public class JsonUtil {
             return factory.booleanNode((Boolean) value);
         }
         if (value instanceof Integer) {
-            return factory.numberNode((Integer) value);
+            return factory.numberNode((Integer) value); // IntNode — preserves 42 (not 42.0)
         }
         if (value instanceof Number) {
-            return factory.numberNode(((Number) value).doubleValue());
+            return factory.numberNode(((Number) value).doubleValue()); // DoubleNode
         }
         return null;
     }
@@ -202,9 +192,7 @@ public class JsonUtil {
         if (obj == null) {
             return false;
         }
-        Iterator<String> fieldNames = obj.fieldNames();
-        while (fieldNames.hasNext()) {
-            String fieldName = fieldNames.next();
+        for (String fieldName : keys(obj)) {
             JsonNode item = obj.get(fieldName);
             if ("string".equals(expectedType)) {
                 if (!item.isTextual()) return false;
@@ -227,15 +215,6 @@ public class JsonUtil {
 
     public static void addToArray(ArrayNode array, JsonNode value) {
         array.add(value);
-    }
-
-    public static boolean isPropertyDefined(JsonNode json, String propertyName) {
-        if (json.isObject()) {
-            ObjectNode node = (ObjectNode) json;
-            return node.has(propertyName) && !node.get(propertyName).isNull();
-        } else {
-            return false;
-        }
     }
 
     public static boolean isString(JsonNode value) {

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -212,10 +212,7 @@ public class JsonUtil {
     }
 
     public static boolean isJsonNode(JsonNode value) {
-        if (value == null) {
-            return false;
-        }
-        return true;
+        return value != null;
     }
 
     public static boolean isObjectNode(JsonNode value) {
@@ -283,7 +280,7 @@ public class JsonUtil {
         return false;
     }
 
-    public static boolean isObjectWithPropertyValue(JsonNode value, String propertyName, String propertyValue) {
+    public static boolean isObjectWithStringPropertyValue(JsonNode value, String propertyName, String propertyValue) {
         if (value == null) {
             return false;
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/ReaderUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/ReaderUtil.java
@@ -15,7 +15,7 @@ public class ReaderUtil {
                 JsonNode value = JsonUtil.getProperty(json, key);
                 if (JsonUtil.isJsonNode(value)) {
                     node.addExtraProperty(key, value);
-                    json.remove(key);
+                    JsonUtil.removeProperty(json, key);
                 }
             }
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/ReaderUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/ReaderUtil.java
@@ -9,10 +9,15 @@ public class ReaderUtil {
 
     public static final void readExtraProperties(ObjectNode json, Node node) {
         if (json != null) {
-            JsonUtil.keys(json).forEach(key -> {
-                JsonNode value = JsonUtil.consumeAnyProperty(json, key);
-                node.addExtraProperty(key, value);
-            });
+            java.util.List<String> _keys = JsonUtil.keys(json);
+            for (int _i = 0; _i < _keys.size(); _i++) {
+                String key = _keys.get(_i);
+                JsonNode value = JsonUtil.getProperty(json, key);
+                if (JsonUtil.isJsonNode(value)) {
+                    node.addExtraProperty(key, value);
+                    json.remove(key);
+                }
+            }
         }
     }
     

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -1,6 +1,7 @@
 package io.apitomy.umg.base.visitors;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import io.apitomy.umg.base.Any;
@@ -62,12 +63,11 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      * @param propertyName
      * @param items
      */
-    @SuppressWarnings("unchecked")
     protected void traverseList(String propertyName, Collection<? extends Any> items) {
         if (items != null) {
             int index = 0;
             traversalContext.pushProperty(propertyName);
-            Collection<? extends Any> clonedItems = (Collection<? extends Any>) JsonUtil.cloneCollection(items);
+            List<? extends Any> clonedItems = JsonUtil.collectionToList(items);
             for (Any item : clonedItems) {
                 if (item != null && item.isNode()) {
                     traversalContext.pushListIndex(index);
@@ -86,11 +86,10 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      * @param propertyName
      * @param items
      */
-    @SuppressWarnings("unchecked")
     protected void traverseMap(String propertyName, Map<String, ? extends Any> items) {
         if (items != null) {
             traversalContext.pushProperty(propertyName);
-            Collection<String> keys = (Collection<String>) JsonUtil.cloneCollection(items.keySet());
+            List<String> keys = JsonUtil.collectionToList(items.keySet());
             keys.forEach(key -> {
                 Any value = items.get(key);
                 if (value != null && value.isNode()) {
@@ -108,10 +107,9 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
      *
      * @param items
      */
-    @SuppressWarnings("unchecked")
     protected void traverseMappedNode(MappedNode<? extends Node> mappedNode) {
         if (mappedNode != null) {
-            Collection<String> names = (Collection<String>) JsonUtil.cloneCollection(mappedNode.getItemNames());
+            List<String> names = JsonUtil.collectionToList(mappedNode.getItemNames());
             names.forEach(name -> {
                 Node value = mappedNode.getItem(name);
                 if (value != null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -221,10 +221,7 @@ public class JsonUtil {
 	}
 
 	public static boolean isJsonNode(JsonNode value) {
-		if (value == null) {
-			return false;
-		}
-		return true;
+		return value != null;
 	}
 
 	public static boolean isObjectNode(JsonNode value) {
@@ -292,7 +289,7 @@ public class JsonUtil {
 		return false;
 	}
 
-	public static boolean isObjectWithPropertyValue(JsonNode value, String propertyName, String propertyValue) {
+	public static boolean isObjectWithStringPropertyValue(JsonNode value, String propertyName, String propertyValue) {
 		if (value == null) {
 			return false;
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +26,7 @@ public class JsonUtil {
 	public static List<String> keys(ObjectNode json) {
 		List<String> rval = new ArrayList<>();
 		if (json != null) {
-			Iterator<String> fieldNames = json.fieldNames();
-			while (fieldNames.hasNext()) {
-				String fieldName = fieldNames.next();
-				rval.add(fieldName);
-			}
+			json.fieldNames().forEachRemaining(rval::add);
 		}
 		return rval;
 	}
@@ -99,12 +94,6 @@ public class JsonUtil {
 		return factory.textNode(value);
 	}
 
-	public static void setArrayProperty(ObjectNode json, String propertyName, ArrayNode value) {
-		if (value != null) {
-			json.set(propertyName, value);
-		}
-	}
-
 	public static JsonNode booleanToJsonNode(Boolean value) {
 		return value != null ? factory.booleanNode(value) : null;
 	}
@@ -133,10 +122,10 @@ public class JsonUtil {
 			return factory.booleanNode((Boolean) value);
 		}
 		if (value instanceof Integer) {
-			return factory.numberNode((Integer) value);
+			return factory.numberNode((Integer) value); // IntNode — preserves 42 (not 42.0)
 		}
 		if (value instanceof Number) {
-			return factory.numberNode(((Number) value).doubleValue());
+			return factory.numberNode(((Number) value).doubleValue()); // DoubleNode
 		}
 		return null;
 	}
@@ -207,9 +196,7 @@ public class JsonUtil {
 		if (obj == null) {
 			return false;
 		}
-		Iterator<String> fieldNames = obj.fieldNames();
-		while (fieldNames.hasNext()) {
-			String fieldName = fieldNames.next();
+		for (String fieldName : keys(obj)) {
 			JsonNode item = obj.get(fieldName);
 			if ("string".equals(expectedType)) {
 				if (!item.isTextual())
@@ -238,15 +225,6 @@ public class JsonUtil {
 
 	public static void addToArray(ArrayNode array, JsonNode value) {
 		array.add(value);
-	}
-
-	public static boolean isPropertyDefined(JsonNode json, String propertyName) {
-		if (json.isObject()) {
-			ObjectNode node = (ObjectNode) json;
-			return node.has(propertyName) && !node.get(propertyName).isNull();
-		} else {
-			return false;
-		}
 	}
 
 	public static boolean isString(JsonNode value) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -51,609 +50,6 @@ public class JsonUtil {
 	public static void setProperty(ObjectNode json, String propertyName, JsonNode value) {
 		if (value != null) {
 			json.set(propertyName, value);
-		}
-	}
-
-	/* Get/Consume a JSON (Object) property. */
-	public static ObjectNode getObjectProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode objectNode = json.get(propertyName);
-			if (objectNode.isObject()) {
-				return (ObjectNode) objectNode;
-			}
-		}
-		return null;
-	}
-	public static ObjectNode consumeObjectProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			ObjectNode rval = getObjectProperty(json, propertyName);
-			if (rval != null) {
-				json.remove(propertyName);
-				return rval;
-			}
-		}
-		return null;
-	}
-
-	/* Get/Consume a JSON (Any) property. */
-	public static JsonNode getAnyProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode jsonNode = json.get(propertyName);
-			if (!jsonNode.isNull()) {
-				return jsonNode;
-			}
-		}
-		return null;
-	}
-	public static JsonNode consumeAnyProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode rval = getAnyProperty(json, propertyName);
-			json.remove(propertyName);
-			return rval;
-		}
-		return null;
-	}
-
-	/* Get/consume an array of anys property. */
-	public static List<JsonNode> getAnyArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<JsonNode> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				rval.add(item);
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<JsonNode> consumeAnyArrayProperty(ObjectNode json, String propertyName) {
-		List<JsonNode> rval = getAnyArrayProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume an array of objects property. */
-	public static List<ObjectNode> getObjectArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<ObjectNode> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				if (item.isObject()) {
-					rval.add((ObjectNode) item);
-				}
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<ObjectNode> consumeObjectArrayProperty(ObjectNode json, String propertyName) {
-		List<ObjectNode> rval = getObjectArrayProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume an array of strings property. */
-	public static List<String> getStringArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<String> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				rval.add(item.isNull() ? null : item.asText());
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<String> consumeStringArrayProperty(ObjectNode json, String propertyName) {
-		ObjectNode node = json;
-		if (node.has(propertyName)) {
-			List<String> rval = getStringArrayProperty(json, propertyName);
-			node.remove(propertyName);
-			return rval;
-		}
-		return null;
-	}
-
-	/* Get/consume an array of integers property. */
-	public static List<Integer> getIntegerArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<Integer> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				if (item.isInt()) {
-					rval.add(item.asInt());
-				}
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<Integer> consumeIntegerArrayProperty(ObjectNode json, String propertyName) {
-		ObjectNode node = json;
-		if (node.has(propertyName)) {
-			List<Integer> rval = getIntegerArrayProperty(json, propertyName);
-			node.remove(propertyName);
-			return rval;
-		}
-		return null;
-	}
-
-	/* Get/consume an array of numbers property. */
-	public static List<Number> getNumberArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<Number> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				if (item.isInt()) {
-					rval.add(item.asInt());
-				}
-				if (item.isLong()) {
-					rval.add(item.asLong());
-				}
-				if (item.isFloat() || item.isDouble() || item.isBigDecimal() || item.isBigInteger()) {
-					rval.add(item.asDouble());
-				}
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<Number> consumeNumberArrayProperty(ObjectNode json, String propertyName) {
-		ObjectNode node = json;
-		if (node.has(propertyName)) {
-			List<Number> rval = getNumberArrayProperty(json, propertyName);
-			node.remove(propertyName);
-			return rval;
-		}
-		return null;
-	}
-
-	/* Get/consume an array of booleans property. */
-	public static List<Boolean> getBooleanArrayProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isArray()) {
-			ArrayNode array = (ArrayNode) node;
-			List<Boolean> rval = new ArrayList<>();
-			for (JsonNode item : array) {
-				if (item.isBoolean()) {
-					rval.add(item.asBoolean());
-				}
-			}
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static List<Boolean> consumeBooleanArrayProperty(ObjectNode json, String propertyName) {
-		ObjectNode node = json;
-		if (node.has(propertyName)) {
-			List<Boolean> rval = getBooleanArrayProperty(json, propertyName);
-			node.remove(propertyName);
-			return rval;
-		}
-		return null;
-	}
-
-	/* Get/Consume a string property. */
-	public static String getStringProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode textNode = json.get(propertyName);
-			if (textNode.isTextual()) {
-				return textNode.asText();
-			}
-		}
-		return null;
-	}
-	public static String consumeStringProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			String rval = getStringProperty(json, propertyName);
-			if (rval != null) {
-				json.remove(propertyName);
-				return rval;
-			}
-		}
-		return null;
-	}
-
-	/* Get/Consume an Integer property. */
-	public static Integer getIntegerProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode textNode = json.get(propertyName);
-			if (textNode.isInt()) {
-				return textNode.asInt();
-			}
-		}
-		return null;
-	}
-	public static Integer consumeIntegerProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			Integer rval = getIntegerProperty(json, propertyName);
-			if (rval != null) {
-				json.remove(propertyName);
-				return rval;
-			}
-		}
-		return null;
-	}
-
-	/* Get/Consume a Number property. */
-	public static Number getNumberProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode node = json.get(propertyName);
-			if (node.isInt()) {
-				return node.asInt();
-			}
-			if (node.isLong()) {
-				return node.asLong();
-			}
-			if (node.isFloat() || node.isDouble()) {
-				return node.asDouble();
-			}
-		}
-		return null;
-	}
-	public static Number consumeNumberProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			Number rval = getNumberProperty(json, propertyName);
-			if (rval != null) {
-				json.remove(propertyName);
-				return rval;
-			}
-		}
-		return null;
-	}
-
-	/* Get/Consume a Boolean property. */
-	public static Boolean getBooleanProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			JsonNode textNode = json.get(propertyName);
-			if (textNode.isBoolean()) {
-				return textNode.asBoolean();
-			}
-		}
-		return null;
-	}
-	public static Boolean consumeBooleanProperty(ObjectNode json, String propertyName) {
-		if (json.has(propertyName)) {
-			Boolean rval = getBooleanProperty(json, propertyName);
-			if (rval != null) {
-				json.remove(propertyName);
-				return rval;
-			}
-		}
-		return null;
-	}
-
-	/* Get/consume a map of anys property. */
-	public static Map<String, JsonNode> getAnyMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, JsonNode> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getAnyProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, JsonNode> consumeAnyMapProperty(ObjectNode json, String propertyName) {
-		Map<String, JsonNode> rval = getAnyMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume a map of objects property. */
-	public static Map<String, ObjectNode> getObjectMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, ObjectNode> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getObjectProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, ObjectNode> consumeObjectMapProperty(ObjectNode json, String propertyName) {
-		Map<String, ObjectNode> rval = getObjectMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume a map of strings property. */
-	public static Map<String, String> getStringMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, String> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getStringProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, String> consumeStringMapProperty(ObjectNode json, String propertyName) {
-		Map<String, String> rval = getStringMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume a map of integers property. */
-	public static Map<String, Integer> getIntegerMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, Integer> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getIntegerProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, Integer> consumeIntegerMapProperty(ObjectNode json, String propertyName) {
-		Map<String, Integer> rval = getIntegerMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume a map of numbers property. */
-	public static Map<String, Number> getNumberMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, Number> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getNumberProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, Number> consumeNumberMapProperty(ObjectNode json, String propertyName) {
-		Map<String, Number> rval = getNumberMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Get/consume a map of numbers property. */
-	public static Map<String, Boolean> getBooleanMapProperty(ObjectNode json, String propertyName) {
-		if (!json.has(propertyName)) {
-			return null;
-		}
-		JsonNode node = json.get(propertyName);
-		if (node.isObject()) {
-			ObjectNode object = (ObjectNode) node;
-			Map<String, Boolean> rval = new LinkedHashMap<>();
-			List<String> keys = keys(object);
-			keys.forEach(key -> {
-				rval.put(key, getBooleanProperty(object, key));
-			});
-			return rval;
-		} else {
-			return null;
-		}
-	}
-	public static Map<String, Boolean> consumeBooleanMapProperty(ObjectNode json, String propertyName) {
-		Map<String, Boolean> rval = getBooleanMapProperty(json, propertyName);
-		if (rval != null) {
-			json.remove(propertyName);
-		}
-		return rval;
-	}
-
-	/* Set a JSON (Object) property. */
-	public static void setObjectProperty(ObjectNode json, String propertyName, ObjectNode value) {
-		if (value != null) {
-			json.set(propertyName, value);
-		}
-	}
-	/* Set a JSON (Any) property. */
-	public static void setAnyProperty(ObjectNode json, String propertyName, JsonNode value) {
-		if (value != null) {
-			json.set(propertyName, value);
-		}
-	}
-	/* Set an array of anys property. */
-	public static void setAnyArrayProperty(ObjectNode json, String propertyName, List<JsonNode> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set an array of objects property. */
-	public static void setObjectArrayProperty(ObjectNode json, String propertyName, List<ObjectNode> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set an array of strings property. */
-	public static void setStringArrayProperty(ObjectNode json, String propertyName, List<String> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set an array of integers property. */
-	public static void setIntegerArrayProperty(ObjectNode json, String propertyName, List<Integer> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set an array of numbers property. */
-	public static void setNumberArrayProperty(ObjectNode json, String propertyName, List<Number> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v != null ? v.doubleValue() : null));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set an array of booleans property. */
-	public static void setBooleanArrayProperty(ObjectNode json, String propertyName, List<Boolean> value) {
-		if (value != null) {
-			ArrayNode array = json.arrayNode(value.size());
-			value.forEach(v -> array.add(v));
-			json.set(propertyName, array);
-		}
-	}
-	/* Set a string property. */
-	public static void setStringProperty(ObjectNode json, String propertyName, String value) {
-		if (value != null) {
-			json.set(propertyName, factory.textNode(value));
-		}
-	}
-	/* Set an Integer property. */
-	public static void setIntegerProperty(ObjectNode json, String propertyName, Integer value) {
-		if (value != null) {
-			json.set(propertyName, factory.numberNode(value));
-		}
-	}
-	/* Set a Number property. */
-	public static void setNumberProperty(ObjectNode json, String propertyName, Number value) {
-		if (value != null) {
-			json.set(propertyName, factory.numberNode(value.doubleValue()));
-		}
-	}
-	/* Set a Boolean property. */
-	public static void setBooleanProperty(ObjectNode json, String propertyName, Boolean value) {
-		if (value != null) {
-			json.set(propertyName, factory.booleanNode(value));
-		}
-	}
-	/* Set a map of anys property. */
-	public static void setAnyMapProperty(ObjectNode json, String propertyName, Map<String, JsonNode> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				object.set(entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
-		}
-	}
-	/* Set a map of objects property. */
-	public static void setObjectMapProperty(ObjectNode json, String propertyName, Map<String, ObjectNode> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				object.set(entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
-		}
-	}
-	/* Set a map of strings property. */
-	public static void setStringMapProperty(ObjectNode json, String propertyName, Map<String, String> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				setStringProperty(object, entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
-		}
-	}
-	/* Set a map of integers property. */
-	public static void setIntegerMapProperty(ObjectNode json, String propertyName, Map<String, Integer> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				setIntegerProperty(object, entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
-		}
-	}
-	/* Set a map of numbers property. */
-	public static void setNumberMapProperty(ObjectNode json, String propertyName, Map<String, Number> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				setNumberProperty(object, entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
-		}
-	}
-	/* Set a map of numbers property. */
-	public static void setBooleanMapProperty(ObjectNode json, String propertyName, Map<String, Boolean> value) {
-		if (value != null) {
-			ObjectNode object = objectNode();
-			value.entrySet().forEach(entry -> {
-				setBooleanProperty(object, entry.getKey(), entry.getValue());
-			});
-			setProperty(json, propertyName, object);
 		}
 	}
 
@@ -721,6 +117,123 @@ public class JsonUtil {
 		if (value == null)
 			return null;
 		return factory.numberNode(value.doubleValue());
+	}
+
+	public static JsonNode toJsonNode(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof JsonNode) {
+			return (JsonNode) value;
+		}
+		if (value instanceof String) {
+			return factory.textNode((String) value);
+		}
+		if (value instanceof Boolean) {
+			return factory.booleanNode((Boolean) value);
+		}
+		if (value instanceof Integer) {
+			return factory.numberNode((Integer) value);
+		}
+		if (value instanceof Number) {
+			return factory.numberNode(((Number) value).doubleValue());
+		}
+		return null;
+	}
+
+	public static ArrayNode toArrayNode(List<?> list) {
+		if (list == null) {
+			return null;
+		}
+		ArrayNode array = factory.arrayNode(list.size());
+		for (int i = 0; i < list.size(); i++) {
+			JsonNode node = toJsonNode(list.get(i));
+			if (node != null) {
+				array.add(node);
+			}
+		}
+		return array;
+	}
+
+	public static ObjectNode toObjectNode(Map<String, ?> map) {
+		if (map == null) {
+			return null;
+		}
+		ObjectNode object = factory.objectNode();
+		List<String> mapKeys = new ArrayList<>(map.keySet());
+		for (int i = 0; i < mapKeys.size(); i++) {
+			String key = mapKeys.get(i);
+			JsonNode node = toJsonNode(map.get(key));
+			if (node != null) {
+				object.set(key, node);
+			}
+		}
+		return object;
+	}
+
+	public static boolean allMatch(JsonNode array, String expectedType) {
+		if (array == null || !array.isArray()) {
+			return false;
+		}
+		ArrayNode arrayNode = (ArrayNode) array;
+		for (int i = 0; i < arrayNode.size(); i++) {
+			JsonNode item = arrayNode.get(i);
+			if ("string".equals(expectedType)) {
+				if (!item.isTextual())
+					return false;
+			} else if ("boolean".equals(expectedType)) {
+				if (!item.isBoolean())
+					return false;
+			} else if ("number".equals(expectedType)) {
+				if (!item.isNumber())
+					return false;
+			} else if ("integer".equals(expectedType)) {
+				if (!item.isInt())
+					return false;
+			} else if ("object".equals(expectedType)) {
+				if (!item.isObject())
+					return false;
+			} else if ("any".equals(expectedType)) {
+				if (item.isNull())
+					return false;
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static boolean allValuesMatch(ObjectNode obj, String expectedType) {
+		if (obj == null) {
+			return false;
+		}
+		Iterator<String> fieldNames = obj.fieldNames();
+		while (fieldNames.hasNext()) {
+			String fieldName = fieldNames.next();
+			JsonNode item = obj.get(fieldName);
+			if ("string".equals(expectedType)) {
+				if (!item.isTextual())
+					return false;
+			} else if ("boolean".equals(expectedType)) {
+				if (!item.isBoolean())
+					return false;
+			} else if ("number".equals(expectedType)) {
+				if (!item.isNumber())
+					return false;
+			} else if ("integer".equals(expectedType)) {
+				if (!item.isInt())
+					return false;
+			} else if ("object".equals(expectedType)) {
+				if (!item.isObject())
+					return false;
+			} else if ("any".equals(expectedType)) {
+				if (item.isNull())
+					return false;
+			} else {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public static void addToArray(ArrayNode array, JsonNode value) {
@@ -795,6 +308,10 @@ public class JsonUtil {
 			return value.asLong();
 		}
 		return value.asDouble();
+	}
+
+	public static Integer toInteger(JsonNode value) {
+		return value.asInt();
 	}
 
 	public static boolean isObject(JsonNode value) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -94,20 +94,6 @@ public class JsonUtil {
 		return factory.textNode(value);
 	}
 
-	public static JsonNode booleanToJsonNode(Boolean value) {
-		return value != null ? factory.booleanNode(value) : null;
-	}
-
-	public static JsonNode stringToJsonNode(String value) {
-		return value != null ? factory.textNode(value) : null;
-	}
-
-	public static JsonNode numberToJsonNode(Number value) {
-		if (value == null)
-			return null;
-		return factory.numberNode(value.doubleValue());
-	}
-
 	public static JsonNode toJsonNode(Object value) {
 		if (value == null) {
 			return null;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -242,10 +242,6 @@ public class JsonUtil {
 		return value;
 	}
 
-	public static ObjectNode toObjectNode(JsonNode value) {
-		return (ObjectNode) value;
-	}
-
 	public static boolean isBoolean(JsonNode value) {
 		if (value == null) {
 			return false;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -82,6 +82,12 @@ public class JsonUtil {
 		return new ArrayList<>(collection);
 	}
 
+	public static void removeProperty(ObjectNode json, String propertyName) {
+		if (json != null) {
+			json.remove(propertyName);
+		}
+	}
+
 	public static ObjectNode objectNode() {
 		return factory.objectNode();
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -75,7 +75,7 @@ public class JsonUtil {
 		}
 	}
 
-	public static Collection<?> cloneCollection(Collection<?> collection) {
+	public static <T> List<T> collectionToList(Collection<T> collection) {
 		if (collection == null) {
 			return new ArrayList<>();
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
@@ -8,10 +8,15 @@ public class ReaderUtil {
 
 	public static final void readExtraProperties(ObjectNode json, Node node) {
 		if (json != null) {
-			JsonUtil.keys(json).forEach(key -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, key);
-				node.addExtraProperty(key, value);
-			});
+			java.util.List<String> _keys = JsonUtil.keys(json);
+			for (int _i = 0; _i < _keys.size(); _i++) {
+				String key = _keys.get(_i);
+				JsonNode value = JsonUtil.getProperty(json, key);
+				if (JsonUtil.isJsonNode(value)) {
+					node.addExtraProperty(key, value);
+					json.remove(key);
+				}
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/ReaderUtil.java
@@ -14,7 +14,7 @@ public class ReaderUtil {
 				JsonNode value = JsonUtil.getProperty(json, key);
 				if (JsonUtil.isJsonNode(value)) {
 					node.addExtraProperty(key, value);
-					json.remove(key);
+					JsonUtil.removeProperty(json, key);
 				}
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -33,7 +33,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _version = JsonUtil.getProperty(json, "version");
 			if (JsonUtil.isString(_version)) {
 				node.setVersion(JsonUtil.toString(_version));
-				json.remove("version");
+				JsonUtil.removeProperty(json, "version");
 			}
 		}
 		{
@@ -41,7 +41,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_info)) {
 				node.setInfo(node.createInfo());
 				readInfo(JsonUtil.toObject(_info), (Syn1Info) node.getInfo());
-				json.remove("info");
+				JsonUtil.removeProperty(json, "info");
 			}
 		}
 		{
@@ -54,7 +54,7 @@ public class Syn1ModelReader implements ModelReader {
 					node.addItem(model);
 					this.readItem(object, model);
 				}
-				json.remove("items");
+				JsonUtil.removeProperty(json, "items");
 			}
 		}
 		{
@@ -66,7 +66,7 @@ public class Syn1ModelReader implements ModelReader {
 					items.add(JsonUtil.toString(_nodes.get(_i)));
 				}
 				node.setTags(items);
-				json.remove("tags");
+				JsonUtil.removeProperty(json, "tags");
 			}
 		}
 		{
@@ -79,14 +79,14 @@ public class Syn1ModelReader implements ModelReader {
 					items.put(_key, JsonUtil.toString(JsonUtil.getProperty(JsonUtil.toObject(_metadata), _key)));
 				}
 				node.setMetadata(items);
-				json.remove("metadata");
+				JsonUtil.removeProperty(json, "metadata");
 			}
 		}
 		{
 			JsonNode _additionalSchema = JsonUtil.getProperty(json, "additionalSchema");
 			if (JsonUtil.isJsonNode(_additionalSchema)) {
 				node.setAdditionalSchema(this.readSchemaOrBoolean(_additionalSchema, null));
-				json.remove("additionalSchema");
+				JsonUtil.removeProperty(json, "additionalSchema");
 			}
 		}
 		{
@@ -108,7 +108,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _name = JsonUtil.getProperty(json, "name");
 			if (JsonUtil.isString(_name)) {
 				node.setName(JsonUtil.toString(_name));
-				json.remove("name");
+				JsonUtil.removeProperty(json, "name");
 			}
 		}
 		{
@@ -116,14 +116,14 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_contact)) {
 				node.setContact(node.createContact());
 				readContact(JsonUtil.toObject(_contact), (Syn1Contact) node.getContact());
-				json.remove("contact");
+				JsonUtil.removeProperty(json, "contact");
 			}
 		}
 		{
 			JsonNode _version = JsonUtil.getProperty(json, "version");
 			if (JsonUtil.isString(_version)) {
 				node.setVersion(JsonUtil.toString(_version));
-				json.remove("version");
+				JsonUtil.removeProperty(json, "version");
 			}
 		}
 		{
@@ -145,21 +145,21 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _name = JsonUtil.getProperty(json, "name");
 			if (JsonUtil.isString(_name)) {
 				node.setName(JsonUtil.toString(_name));
-				json.remove("name");
+				JsonUtil.removeProperty(json, "name");
 			}
 		}
 		{
 			JsonNode _email = JsonUtil.getProperty(json, "email");
 			if (JsonUtil.isString(_email)) {
 				node.setEmail(JsonUtil.toString(_email));
-				json.remove("email");
+				JsonUtil.removeProperty(json, "email");
 			}
 		}
 		{
 			JsonNode _url = JsonUtil.getProperty(json, "url");
 			if (JsonUtil.isString(_url)) {
 				node.setUrl(JsonUtil.toString(_url));
-				json.remove("url");
+				JsonUtil.removeProperty(json, "url");
 			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
@@ -170,49 +170,49 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _description = JsonUtil.getProperty(json, "description");
 			if (JsonUtil.isString(_description)) {
 				node.setDescription(JsonUtil.toString(_description));
-				json.remove("description");
+				JsonUtil.removeProperty(json, "description");
 			}
 		}
 		{
 			JsonNode _required = JsonUtil.getProperty(json, "required");
 			if (JsonUtil.isBoolean(_required)) {
 				node.setRequired(JsonUtil.toBoolean(_required));
-				json.remove("required");
+				JsonUtil.removeProperty(json, "required");
 			}
 		}
 		{
 			JsonNode _order = JsonUtil.getProperty(json, "order");
 			if (JsonUtil.isNumber(_order)) {
 				node.setOrder(JsonUtil.toInteger(_order));
-				json.remove("order");
+				JsonUtil.removeProperty(json, "order");
 			}
 		}
 		{
 			JsonNode _weight = JsonUtil.getProperty(json, "weight");
 			if (JsonUtil.isNumber(_weight)) {
 				node.setWeight(JsonUtil.toNumber(_weight));
-				json.remove("weight");
+				JsonUtil.removeProperty(json, "weight");
 			}
 		}
 		{
 			JsonNode _extra = JsonUtil.getProperty(json, "extra");
 			if (JsonUtil.isJsonNode(_extra)) {
 				node.setExtra(JsonUtil.toJsonNode(_extra));
-				json.remove("extra");
+				JsonUtil.removeProperty(json, "extra");
 			}
 		}
 		{
 			JsonNode _raw = JsonUtil.getProperty(json, "raw");
 			if (JsonUtil.isObject(_raw)) {
 				node.setRaw(JsonUtil.toObject(_raw));
-				json.remove("raw");
+				JsonUtil.removeProperty(json, "raw");
 			}
 		}
 		{
@@ -220,7 +220,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
 				readSchema(JsonUtil.toObject(_schema), (Syn1Schema) node.getSchema());
-				json.remove("schema");
+				JsonUtil.removeProperty(json, "schema");
 			}
 		}
 		{
@@ -232,21 +232,21 @@ public class Syn1ModelReader implements ModelReader {
 					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
 				}
 				node.setExamples(items);
-				json.remove("examples");
+				JsonUtil.removeProperty(json, "examples");
 			}
 		}
 		{
 			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
 			if (JsonUtil.isJsonNode(_defaultValue)) {
 				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
-				json.remove("defaultValue");
+				JsonUtil.removeProperty(json, "defaultValue");
 			}
 		}
 		{
 			JsonNode _title = JsonUtil.getProperty(json, "title");
 			if (JsonUtil.isString(_title)) {
 				node.setTitle(JsonUtil.toString(_title));
-				json.remove("title");
+				JsonUtil.removeProperty(json, "title");
 			}
 		}
 		{
@@ -268,21 +268,21 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _type = JsonUtil.getProperty(json, "type");
 			if (JsonUtil.isString(_type)) {
 				node.setType(JsonUtil.toString(_type));
-				json.remove("type");
+				JsonUtil.removeProperty(json, "type");
 			}
 		}
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
 			if (JsonUtil.isJsonNode(_items)) {
 				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
-				json.remove("items");
+				JsonUtil.removeProperty(json, "items");
 			}
 		}
 		{
@@ -299,7 +299,7 @@ public class Syn1ModelReader implements ModelReader {
 							node.addProperty(_key, model);
 					}
 				}
-				json.remove("properties");
+				JsonUtil.removeProperty(json, "properties");
 			}
 		}
 		{
@@ -320,7 +320,7 @@ public class Syn1ModelReader implements ModelReader {
 					for (int _i = 0; _i < _items.size(); _i++) {
 						node.addAllOf(_items.get(_i));
 					}
-					json.remove("allOf");
+					JsonUtil.removeProperty(json, "allOf");
 				}
 			}
 		}
@@ -338,7 +338,7 @@ public class Syn1ModelReader implements ModelReader {
 							node.addDefinition(_key, model);
 					}
 				}
-				json.remove("definitions");
+				JsonUtil.removeProperty(json, "definitions");
 			}
 		}
 		{
@@ -355,7 +355,7 @@ public class Syn1ModelReader implements ModelReader {
 							node.addNestedSchema(_key, model);
 					}
 				}
-				json.remove("nestedSchemas");
+				JsonUtil.removeProperty(json, "nestedSchemas");
 			}
 		}
 		{
@@ -376,7 +376,7 @@ public class Syn1ModelReader implements ModelReader {
 					for (int _i = 0; _i < _items.size(); _i++) {
 						node.addComposedSchema(_items.get(_i));
 					}
-					json.remove("composedSchemas");
+					JsonUtil.removeProperty(json, "composedSchemas");
 				}
 			}
 		}
@@ -384,14 +384,14 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _minLength = JsonUtil.getProperty(json, "minLength");
 			if (JsonUtil.isNumber(_minLength)) {
 				node.setMinLength(JsonUtil.toInteger(_minLength));
-				json.remove("minLength");
+				JsonUtil.removeProperty(json, "minLength");
 			}
 		}
 		{
 			JsonNode _maxLength = JsonUtil.getProperty(json, "maxLength");
 			if (JsonUtil.isNumber(_maxLength)) {
 				node.setMaxLength(JsonUtil.toInteger(_maxLength));
-				json.remove("maxLength");
+				JsonUtil.removeProperty(json, "maxLength");
 			}
 		}
 		{
@@ -403,7 +403,7 @@ public class Syn1ModelReader implements ModelReader {
 					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
 				}
 				node.setEnum(items);
-				json.remove("enum");
+				JsonUtil.removeProperty(json, "enum");
 			}
 		}
 		{
@@ -453,14 +453,14 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _summary = JsonUtil.getProperty(json, "summary");
 			if (JsonUtil.isString(_summary)) {
 				node.setSummary(JsonUtil.toString(_summary));
-				json.remove("summary");
+				JsonUtil.removeProperty(json, "summary");
 			}
 		}
 		{
@@ -468,7 +468,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
 				readOperation(JsonUtil.toObject(_get), (Syn1Operation) node.getGet());
-				json.remove("get");
+				JsonUtil.removeProperty(json, "get");
 			}
 		}
 		{
@@ -476,7 +476,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
 				readOperation(JsonUtil.toObject(_put), (Syn1Operation) node.getPut());
-				json.remove("put");
+				JsonUtil.removeProperty(json, "put");
 			}
 		}
 		{
@@ -484,7 +484,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
 				readOperation(JsonUtil.toObject(_post), (Syn1Operation) node.getPost());
-				json.remove("post");
+				JsonUtil.removeProperty(json, "post");
 			}
 		}
 		{
@@ -506,14 +506,14 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _operationId = JsonUtil.getProperty(json, "operationId");
 			if (JsonUtil.isString(_operationId)) {
 				node.setOperationId(JsonUtil.toString(_operationId));
-				json.remove("operationId");
+				JsonUtil.removeProperty(json, "operationId");
 			}
 		}
 		{
 			JsonNode _summary = JsonUtil.getProperty(json, "summary");
 			if (JsonUtil.isString(_summary)) {
 				node.setSummary(JsonUtil.toString(_summary));
-				json.remove("summary");
+				JsonUtil.removeProperty(json, "summary");
 			}
 		}
 		{
@@ -525,7 +525,7 @@ public class Syn1ModelReader implements ModelReader {
 					items.add(JsonUtil.toString(_nodes.get(_i)));
 				}
 				node.setTags(items);
-				json.remove("tags");
+				JsonUtil.removeProperty(json, "tags");
 			}
 		}
 		{
@@ -538,7 +538,7 @@ public class Syn1ModelReader implements ModelReader {
 					node.addParameter(model);
 					this.readItem(object, model);
 				}
-				json.remove("parameters");
+				JsonUtil.removeProperty(json, "parameters");
 			}
 		}
 		{

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -22,6 +22,7 @@ import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.v1.Syn1SchemaImpl;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,244 +30,392 @@ public class Syn1ModelReader implements ModelReader {
 
 	public void readDocument(ObjectNode json, Syn1Document node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "version");
-			node.setVersion(value);
-		}
-		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "info");
-			if (object != null) {
-				node.setInfo(node.createInfo());
-				readInfo(object, (Syn1Info) node.getInfo());
+			JsonNode _version = JsonUtil.getProperty(json, "version");
+			if (JsonUtil.isString(_version)) {
+				node.setVersion(JsonUtil.toString(_version));
+				json.remove("version");
 			}
 		}
 		{
-			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "items");
-			if (objects != null) {
-				objects.forEach(object -> {
+			JsonNode _info = JsonUtil.getProperty(json, "info");
+			if (JsonUtil.isObject(_info)) {
+				node.setInfo(node.createInfo());
+				readInfo((ObjectNode) _info, (Syn1Info) node.getInfo());
+				json.remove("info");
+			}
+		}
+		{
+			JsonNode _items = JsonUtil.getProperty(json, "items");
+			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
+				List<JsonNode> _nodes = JsonUtil.toList(_items);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					ObjectNode object = (ObjectNode) _nodes.get(_i);
 					Syn1Item model = (Syn1Item) node.createItem();
 					node.addItem(model);
 					this.readItem(object, model);
-				});
+				}
+				json.remove("items");
 			}
 		}
 		{
-			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
-			node.setTags(value);
+			JsonNode _tags = JsonUtil.getProperty(json, "tags");
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+				List<String> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_tags);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toString(_nodes.get(_i)));
+				}
+				node.setTags(items);
+				json.remove("tags");
+			}
 		}
 		{
-			Map<String, String> value = JsonUtil.consumeStringMapProperty(json, "metadata");
-			node.setMetadata(value);
+			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
+			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch((ObjectNode) _metadata, "string")) {
+				Map<String, String> items = new LinkedHashMap<>();
+				List<String> _keys = JsonUtil.keys((ObjectNode) _metadata);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					items.put(_key, JsonUtil.toString(JsonUtil.getProperty((ObjectNode) _metadata, _key)));
+				}
+				node.setMetadata(items);
+				json.remove("metadata");
+			}
 		}
 		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
-			if (value != null) {
-				node.setAdditionalSchema(this.readSchemaOrBoolean(value, null));
+			JsonNode _additionalSchema = JsonUtil.getProperty(json, "additionalSchema");
+			if (JsonUtil.isJsonNode(_additionalSchema)) {
+				node.setAdditionalSchema(this.readSchemaOrBoolean(_additionalSchema, null));
+				json.remove("additionalSchema");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readInfo(ObjectNode json, Syn1Info node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "name");
-			node.setName(value);
-		}
-		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "contact");
-			if (object != null) {
-				node.setContact(node.createContact());
-				readContact(object, (Syn1Contact) node.getContact());
+			JsonNode _name = JsonUtil.getProperty(json, "name");
+			if (JsonUtil.isString(_name)) {
+				node.setName(JsonUtil.toString(_name));
+				json.remove("name");
 			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "version");
-			node.setVersion(value);
+			JsonNode _contact = JsonUtil.getProperty(json, "contact");
+			if (JsonUtil.isObject(_contact)) {
+				node.setContact(node.createContact());
+				readContact((ObjectNode) _contact, (Syn1Contact) node.getContact());
+				json.remove("contact");
+			}
+		}
+		{
+			JsonNode _version = JsonUtil.getProperty(json, "version");
+			if (JsonUtil.isString(_version)) {
+				node.setVersion(JsonUtil.toString(_version));
+				json.remove("version");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readContact(ObjectNode json, Syn1Contact node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "name");
-			node.setName(value);
+			JsonNode _name = JsonUtil.getProperty(json, "name");
+			if (JsonUtil.isString(_name)) {
+				node.setName(JsonUtil.toString(_name));
+				json.remove("name");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "email");
-			node.setEmail(value);
+			JsonNode _email = JsonUtil.getProperty(json, "email");
+			if (JsonUtil.isString(_email)) {
+				node.setEmail(JsonUtil.toString(_email));
+				json.remove("email");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "url");
-			node.setUrl(value);
+			JsonNode _url = JsonUtil.getProperty(json, "url");
+			if (JsonUtil.isString(_url)) {
+				node.setUrl(JsonUtil.toString(_url));
+				json.remove("url");
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readItem(ObjectNode json, Syn1Item node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "description");
-			node.setDescription(value);
+			JsonNode _description = JsonUtil.getProperty(json, "description");
+			if (JsonUtil.isString(_description)) {
+				node.setDescription(JsonUtil.toString(_description));
+				json.remove("description");
+			}
 		}
 		{
-			Boolean value = JsonUtil.consumeBooleanProperty(json, "required");
-			node.setRequired(value);
+			JsonNode _required = JsonUtil.getProperty(json, "required");
+			if (JsonUtil.isBoolean(_required)) {
+				node.setRequired(JsonUtil.toBoolean(_required));
+				json.remove("required");
+			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "order");
-			node.setOrder(value);
+			JsonNode _order = JsonUtil.getProperty(json, "order");
+			if (JsonUtil.isNumber(_order)) {
+				node.setOrder(JsonUtil.toInteger(_order));
+				json.remove("order");
+			}
 		}
 		{
-			Number value = JsonUtil.consumeNumberProperty(json, "weight");
-			node.setWeight(value);
+			JsonNode _weight = JsonUtil.getProperty(json, "weight");
+			if (JsonUtil.isNumber(_weight)) {
+				node.setWeight(JsonUtil.toNumber(_weight));
+				json.remove("weight");
+			}
 		}
 		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "extra");
-			node.setExtra(value);
+			JsonNode _extra = JsonUtil.getProperty(json, "extra");
+			if (JsonUtil.isJsonNode(_extra)) {
+				node.setExtra(JsonUtil.toJsonNode(_extra));
+				json.remove("extra");
+			}
 		}
 		{
-			ObjectNode value = JsonUtil.consumeObjectProperty(json, "raw");
-			node.setRaw(value);
+			JsonNode _raw = JsonUtil.getProperty(json, "raw");
+			if (JsonUtil.isObject(_raw)) {
+				node.setRaw(JsonUtil.toObject(_raw));
+				json.remove("raw");
+			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "schema");
-			if (object != null) {
+			JsonNode _schema = JsonUtil.getProperty(json, "schema");
+			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
-				readSchema(object, (Syn1Schema) node.getSchema());
+				readSchema((ObjectNode) _schema, (Syn1Schema) node.getSchema());
+				json.remove("schema");
 			}
 		}
 		{
-			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "examples");
-			node.setExamples(value);
-		}
-		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
-			if (value != null) {
-				node.setDefaultValue(this.readBooleanSchemaUnion(value, null));
+			JsonNode _examples = JsonUtil.getProperty(json, "examples");
+			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, "any")) {
+				List<JsonNode> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_examples);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
+				}
+				node.setExamples(items);
+				json.remove("examples");
 			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "title");
-			node.setTitle(value);
+			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
+			if (JsonUtil.isJsonNode(_defaultValue)) {
+				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
+				json.remove("defaultValue");
+			}
+		}
+		{
+			JsonNode _title = JsonUtil.getProperty(json, "title");
+			if (JsonUtil.isString(_title)) {
+				node.setTitle(JsonUtil.toString(_title));
+				json.remove("title");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readSchema(ObjectNode json, Syn1Schema node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
-		}
-		{
-			String value = JsonUtil.consumeStringProperty(json, "type");
-			node.setType(value);
-		}
-		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
-			if (value != null) {
-				node.setItems(this.readBooleanSchemaSchemaListUnion(value, null));
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "properties");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+			JsonNode _type = JsonUtil.getProperty(json, "type");
+			if (JsonUtil.isString(_type)) {
+				node.setType(JsonUtil.toString(_type));
+				json.remove("type");
+			}
+		}
+		{
+			JsonNode _items = JsonUtil.getProperty(json, "items");
+			if (JsonUtil.isJsonNode(_items)) {
+				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
+				json.remove("items");
+			}
+		}
+		{
+			JsonNode _properties = JsonUtil.getProperty(json, "properties");
+			if (JsonUtil.isObject(_properties)) {
+				ObjectNode _obj = (ObjectNode) _properties;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
 						if (model != null)
-							node.addProperty(key, model);
+							node.addProperty(_key, model);
 					}
-				});
+				}
+				json.remove("properties");
 			}
 		}
 		{
-			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
-			if (array != null) {
-				array.forEach(item -> {
-					BooleanSchemaUnion value = this.readBooleanSchemaUnion(item, null);
-					if (value != null)
-						node.addAllOf(value);
-				});
+			JsonNode _allOf = JsonUtil.getProperty(json, "allOf");
+			if (JsonUtil.isArray(_allOf)) {
+				List<JsonNode> _nodes = JsonUtil.toList(_allOf);
+				List<BooleanSchemaUnion> _items = new ArrayList<>();
+				boolean _valid = true;
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i), null);
+					if (_result == null) {
+						_valid = false;
+						break;
+					}
+					_items.add(_result);
+				}
+				if (_valid) {
+					for (int _i = 0; _i < _items.size(); _i++) {
+						node.addAllOf(_items.get(_i));
+					}
+					json.remove("allOf");
+				}
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "definitions");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+			JsonNode _definitions = JsonUtil.getProperty(json, "definitions");
+			if (JsonUtil.isObject(_definitions)) {
+				ObjectNode _obj = (ObjectNode) _definitions;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
 						if (model != null)
-							node.addDefinition(key, model);
+							node.addDefinition(_key, model);
 					}
-				});
+				}
+				json.remove("definitions");
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "nestedSchemas");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						SchemaOrBoolean model = this.readSchemaOrBoolean(value, null);
+			JsonNode _nestedSchemas = JsonUtil.getProperty(json, "nestedSchemas");
+			if (JsonUtil.isObject(_nestedSchemas)) {
+				ObjectNode _obj = (ObjectNode) _nestedSchemas;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						SchemaOrBoolean model = this.readSchemaOrBoolean(_val, null);
 						if (model != null)
-							node.addNestedSchema(key, model);
+							node.addNestedSchema(_key, model);
 					}
-				});
+				}
+				json.remove("nestedSchemas");
 			}
 		}
 		{
-			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
-			if (array != null) {
-				array.forEach(item -> {
-					SchemaOrBoolean value = this.readSchemaOrBoolean(item, null);
-					if (value != null)
-						node.addComposedSchema(value);
-				});
+			JsonNode _composedSchemas = JsonUtil.getProperty(json, "composedSchemas");
+			if (JsonUtil.isArray(_composedSchemas)) {
+				List<JsonNode> _nodes = JsonUtil.toList(_composedSchemas);
+				List<SchemaOrBoolean> _items = new ArrayList<>();
+				boolean _valid = true;
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					SchemaOrBoolean _result = this.readSchemaOrBoolean(_nodes.get(_i), null);
+					if (_result == null) {
+						_valid = false;
+						break;
+					}
+					_items.add(_result);
+				}
+				if (_valid) {
+					for (int _i = 0; _i < _items.size(); _i++) {
+						node.addComposedSchema(_items.get(_i));
+					}
+					json.remove("composedSchemas");
+				}
 			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
-			node.setMinLength(value);
+			JsonNode _minLength = JsonUtil.getProperty(json, "minLength");
+			if (JsonUtil.isNumber(_minLength)) {
+				node.setMinLength(JsonUtil.toInteger(_minLength));
+				json.remove("minLength");
+			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "maxLength");
-			node.setMaxLength(value);
+			JsonNode _maxLength = JsonUtil.getProperty(json, "maxLength");
+			if (JsonUtil.isNumber(_maxLength)) {
+				node.setMaxLength(JsonUtil.toInteger(_maxLength));
+				json.remove("maxLength");
+			}
 		}
 		{
-			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "enum");
-			node.setEnum(value);
+			JsonNode _enum = JsonUtil.getProperty(json, "enum");
+			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, "any")) {
+				List<JsonNode> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_enum);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
+				}
+				node.setEnum(items);
+				json.remove("enum");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
@@ -274,94 +423,134 @@ public class Syn1ModelReader implements ModelReader {
 	public void readPaths(ObjectNode json, Syn1Paths node) {
 		{
 			List<String> propertyNames = JsonUtil.keys(json);
-			propertyNames.forEach(name -> {
-				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
-				if (object != null) {
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isObject(_val)) {
 					Syn1PathItem model = (Syn1PathItem) node.createPathItem();
 					node.addItem(name, model);
-					this.readPathItem(object, model);
+					this.readPathItem((ObjectNode) _val, model);
+					json.remove(name);
 				}
-			});
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readPathItem(ObjectNode json, Syn1PathItem node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "summary");
-			node.setSummary(value);
+			JsonNode _summary = JsonUtil.getProperty(json, "summary");
+			if (JsonUtil.isString(_summary)) {
+				node.setSummary(JsonUtil.toString(_summary));
+				json.remove("summary");
+			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "get");
-			if (object != null) {
+			JsonNode _get = JsonUtil.getProperty(json, "get");
+			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
-				readOperation(object, (Syn1Operation) node.getGet());
+				readOperation((ObjectNode) _get, (Syn1Operation) node.getGet());
+				json.remove("get");
 			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "put");
-			if (object != null) {
+			JsonNode _put = JsonUtil.getProperty(json, "put");
+			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
-				readOperation(object, (Syn1Operation) node.getPut());
+				readOperation((ObjectNode) _put, (Syn1Operation) node.getPut());
+				json.remove("put");
 			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "post");
-			if (object != null) {
+			JsonNode _post = JsonUtil.getProperty(json, "post");
+			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
-				readOperation(object, (Syn1Operation) node.getPost());
+				readOperation((ObjectNode) _post, (Syn1Operation) node.getPost());
+				json.remove("post");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readOperation(ObjectNode json, Syn1Operation node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "operationId");
-			node.setOperationId(value);
+			JsonNode _operationId = JsonUtil.getProperty(json, "operationId");
+			if (JsonUtil.isString(_operationId)) {
+				node.setOperationId(JsonUtil.toString(_operationId));
+				json.remove("operationId");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "summary");
-			node.setSummary(value);
+			JsonNode _summary = JsonUtil.getProperty(json, "summary");
+			if (JsonUtil.isString(_summary)) {
+				node.setSummary(JsonUtil.toString(_summary));
+				json.remove("summary");
+			}
 		}
 		{
-			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
-			node.setTags(value);
+			JsonNode _tags = JsonUtil.getProperty(json, "tags");
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+				List<String> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_tags);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toString(_nodes.get(_i)));
+				}
+				node.setTags(items);
+				json.remove("tags");
+			}
 		}
 		{
-			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "parameters");
-			if (objects != null) {
-				objects.forEach(object -> {
+			JsonNode _parameters = JsonUtil.getProperty(json, "parameters");
+			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
+				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					ObjectNode object = (ObjectNode) _nodes.get(_i);
 					Syn1Item model = (Syn1Item) node.createItem();
 					node.addParameter(model);
 					this.readItem(object, model);
-				});
+				}
+				json.remove("parameters");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -40,7 +40,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _info = JsonUtil.getProperty(json, "info");
 			if (JsonUtil.isObject(_info)) {
 				node.setInfo(node.createInfo());
-				readInfo((ObjectNode) _info, (Syn1Info) node.getInfo());
+				readInfo(JsonUtil.toObject(_info), (Syn1Info) node.getInfo());
 				json.remove("info");
 			}
 		}
@@ -49,7 +49,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
 				List<JsonNode> _nodes = JsonUtil.toList(_items);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					ObjectNode object = (ObjectNode) _nodes.get(_i);
+					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
 					Syn1Item model = (Syn1Item) node.createItem();
 					node.addItem(model);
 					this.readItem(object, model);
@@ -71,12 +71,12 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
-			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch((ObjectNode) _metadata, "string")) {
+			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), "string")) {
 				Map<String, String> items = new LinkedHashMap<>();
-				List<String> _keys = JsonUtil.keys((ObjectNode) _metadata);
+				List<String> _keys = JsonUtil.keys(JsonUtil.toObject(_metadata));
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
-					items.put(_key, JsonUtil.toString(JsonUtil.getProperty((ObjectNode) _metadata, _key)));
+					items.put(_key, JsonUtil.toString(JsonUtil.getProperty(JsonUtil.toObject(_metadata), _key)));
 				}
 				node.setMetadata(items);
 				json.remove("metadata");
@@ -115,7 +115,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _contact = JsonUtil.getProperty(json, "contact");
 			if (JsonUtil.isObject(_contact)) {
 				node.setContact(node.createContact());
-				readContact((ObjectNode) _contact, (Syn1Contact) node.getContact());
+				readContact(JsonUtil.toObject(_contact), (Syn1Contact) node.getContact());
 				json.remove("contact");
 			}
 		}
@@ -219,7 +219,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _schema = JsonUtil.getProperty(json, "schema");
 			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
-				readSchema((ObjectNode) _schema, (Syn1Schema) node.getSchema());
+				readSchema(JsonUtil.toObject(_schema), (Syn1Schema) node.getSchema());
 				json.remove("schema");
 			}
 		}
@@ -288,7 +288,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode _properties = JsonUtil.getProperty(json, "properties");
 			if (JsonUtil.isObject(_properties)) {
-				ObjectNode _obj = (ObjectNode) _properties;
+				ObjectNode _obj = JsonUtil.toObject(_properties);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -327,7 +327,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode _definitions = JsonUtil.getProperty(json, "definitions");
 			if (JsonUtil.isObject(_definitions)) {
-				ObjectNode _obj = (ObjectNode) _definitions;
+				ObjectNode _obj = JsonUtil.toObject(_definitions);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -344,7 +344,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode _nestedSchemas = JsonUtil.getProperty(json, "nestedSchemas");
 			if (JsonUtil.isObject(_nestedSchemas)) {
-				ObjectNode _obj = (ObjectNode) _nestedSchemas;
+				ObjectNode _obj = JsonUtil.toObject(_nestedSchemas);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -467,7 +467,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _get = JsonUtil.getProperty(json, "get");
 			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
-				readOperation((ObjectNode) _get, (Syn1Operation) node.getGet());
+				readOperation(JsonUtil.toObject(_get), (Syn1Operation) node.getGet());
 				json.remove("get");
 			}
 		}
@@ -475,7 +475,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _put = JsonUtil.getProperty(json, "put");
 			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
-				readOperation((ObjectNode) _put, (Syn1Operation) node.getPut());
+				readOperation(JsonUtil.toObject(_put), (Syn1Operation) node.getPut());
 				json.remove("put");
 			}
 		}
@@ -483,7 +483,7 @@ public class Syn1ModelReader implements ModelReader {
 			JsonNode _post = JsonUtil.getProperty(json, "post");
 			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
-				readOperation((ObjectNode) _post, (Syn1Operation) node.getPost());
+				readOperation(JsonUtil.toObject(_post), (Syn1Operation) node.getPost());
 				json.remove("post");
 			}
 		}
@@ -533,7 +533,7 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
 				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					ObjectNode object = (ObjectNode) _nodes.get(_i);
+					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
 					Syn1Item model = (Syn1Item) node.createItem();
 					node.addParameter(model);
 					this.readItem(object, model);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -96,7 +96,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -133,7 +133,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -256,7 +256,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -413,7 +413,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -430,7 +430,7 @@ public class Syn1ModelReader implements ModelReader {
 					Syn1PathItem model = (Syn1PathItem) node.createPathItem();
 					node.addItem(name, model);
 					this.readPathItem((ObjectNode) _val, model);
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -441,7 +441,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -494,7 +494,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -548,7 +548,7 @@ public class Syn1ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -29,12 +29,12 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		JsonUtil.setProperty(json, "version", JsonUtil.toJsonNode(node.getVersion()));
 		{
 			if (node.getInfo() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeInfo((Syn1Info) node.getInfo(), object);
-				JsonUtil.setObjectProperty(json, "info", object);
+				JsonUtil.setProperty(json, "info", object);
 			}
 		}
 		{
@@ -46,23 +46,25 @@ public class Syn1ModelWriter implements ModelWriter {
 					this.writeItem((Syn1Item) model, object);
 					JsonUtil.addToArray(array, object);
 				});
-				JsonUtil.setAnyProperty(json, "items", array);
+				JsonUtil.setProperty(json, "items", array);
 			}
 		}
-		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
-		JsonUtil.setStringMapProperty(json, "metadata", node.getMetadata());
+		JsonUtil.setProperty(json, "tags", JsonUtil.toArrayNode(node.getTags()));
+		JsonUtil.setProperty(json, "metadata", JsonUtil.toObjectNode(node.getMetadata()));
 		{
 			JsonNode value = this.writeSchemaOrBoolean(node.getAdditionalSchema());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "additionalSchema", value);
+				JsonUtil.setProperty(json, "additionalSchema", value);
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -72,22 +74,24 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "name", node.getName());
+		JsonUtil.setProperty(json, "name", JsonUtil.toJsonNode(node.getName()));
 		{
 			if (node.getContact() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeContact((Syn1Contact) node.getContact(), object);
-				JsonUtil.setObjectProperty(json, "contact", object);
+				JsonUtil.setProperty(json, "contact", object);
 			}
 		}
-		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		JsonUtil.setProperty(json, "version", JsonUtil.toJsonNode(node.getVersion()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -97,9 +101,9 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "name", node.getName());
-		JsonUtil.setStringProperty(json, "email", node.getEmail());
-		JsonUtil.setStringProperty(json, "url", node.getUrl());
+		JsonUtil.setProperty(json, "name", JsonUtil.toJsonNode(node.getName()));
+		JsonUtil.setProperty(json, "email", JsonUtil.toJsonNode(node.getEmail()));
+		JsonUtil.setProperty(json, "url", JsonUtil.toJsonNode(node.getUrl()));
 		WriterUtil.writeExtraProperties(node, json);
 	}
 
@@ -107,34 +111,36 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "description", node.getDescription());
-		JsonUtil.setBooleanProperty(json, "required", node.isRequired());
-		JsonUtil.setIntegerProperty(json, "order", node.getOrder());
-		JsonUtil.setNumberProperty(json, "weight", node.getWeight());
-		JsonUtil.setAnyProperty(json, "extra", node.getExtra());
-		JsonUtil.setObjectProperty(json, "raw", node.getRaw());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "description", JsonUtil.toJsonNode(node.getDescription()));
+		JsonUtil.setProperty(json, "required", JsonUtil.toJsonNode(node.isRequired()));
+		JsonUtil.setProperty(json, "order", JsonUtil.toJsonNode(node.getOrder()));
+		JsonUtil.setProperty(json, "weight", JsonUtil.toJsonNode(node.getWeight()));
+		JsonUtil.setProperty(json, "extra", node.getExtra());
+		JsonUtil.setProperty(json, "raw", node.getRaw());
 		{
 			if (node.getSchema() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeSchema((Syn1Schema) node.getSchema(), object);
-				JsonUtil.setObjectProperty(json, "schema", object);
+				JsonUtil.setProperty(json, "schema", object);
 			}
 		}
-		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
+		JsonUtil.setProperty(json, "examples", JsonUtil.toArrayNode(node.getExamples()));
 		{
 			JsonNode value = this.writeBooleanSchemaUnion(node.getDefaultValue());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "defaultValue", value);
+				JsonUtil.setProperty(json, "defaultValue", value);
 		}
-		JsonUtil.setStringProperty(json, "title", node.getTitle());
+		JsonUtil.setProperty(json, "title", JsonUtil.toJsonNode(node.getTitle()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -144,12 +150,12 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "type", node.getType());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "type", JsonUtil.toJsonNode(node.getType()));
 		{
 			JsonNode value = this.writeBooleanSchemaSchemaListUnion(node.getItems());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "items", value);
+				JsonUtil.setProperty(json, "items", value);
 		}
 		{
 			Map<String, BooleanSchemaUnion> items = node.getProperties();
@@ -159,9 +165,9 @@ public class Syn1ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "properties", mapJson);
+				JsonUtil.setProperty(json, "properties", mapJson);
 			}
 		}
 		{
@@ -173,7 +179,7 @@ public class Syn1ModelWriter implements ModelWriter {
 					if (value != null)
 						array.add(value);
 				});
-				JsonUtil.setAnyProperty(json, "allOf", array);
+				JsonUtil.setProperty(json, "allOf", array);
 			}
 		}
 		{
@@ -184,9 +190,9 @@ public class Syn1ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "definitions", mapJson);
+				JsonUtil.setProperty(json, "definitions", mapJson);
 			}
 		}
 		{
@@ -197,9 +203,9 @@ public class Syn1ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "nestedSchemas", mapJson);
+				JsonUtil.setProperty(json, "nestedSchemas", mapJson);
 			}
 		}
 		{
@@ -211,19 +217,21 @@ public class Syn1ModelWriter implements ModelWriter {
 					if (value != null)
 						array.add(value);
 				});
-				JsonUtil.setAnyProperty(json, "composedSchemas", array);
+				JsonUtil.setProperty(json, "composedSchemas", array);
 			}
 		}
-		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
-		JsonUtil.setIntegerProperty(json, "maxLength", node.getMaxLength());
-		JsonUtil.setAnyArrayProperty(json, "enum", node.getEnum());
+		JsonUtil.setProperty(json, "minLength", JsonUtil.toJsonNode(node.getMinLength()));
+		JsonUtil.setProperty(json, "maxLength", JsonUtil.toJsonNode(node.getMaxLength()));
+		JsonUtil.setProperty(json, "enum", JsonUtil.toArrayNode(node.getEnum()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -235,19 +243,22 @@ public class Syn1ModelWriter implements ModelWriter {
 		}
 		{
 			List<String> propertyNames = node.getItemNames();
-			propertyNames.forEach(propertyName -> {
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String propertyName = propertyNames.get(_i);
 				ObjectNode object = JsonUtil.objectNode();
 				this.writePathItem((Syn1PathItem) node.getItem(propertyName), object);
-				JsonUtil.setObjectProperty(json, propertyName, object);
-			});
+				JsonUtil.setProperty(json, propertyName, object);
+			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -257,36 +268,38 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "summary", JsonUtil.toJsonNode(node.getSummary()));
 		{
 			if (node.getGet() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn1Operation) node.getGet(), object);
-				JsonUtil.setObjectProperty(json, "get", object);
+				JsonUtil.setProperty(json, "get", object);
 			}
 		}
 		{
 			if (node.getPut() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn1Operation) node.getPut(), object);
-				JsonUtil.setObjectProperty(json, "put", object);
+				JsonUtil.setProperty(json, "put", object);
 			}
 		}
 		{
 			if (node.getPost() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn1Operation) node.getPost(), object);
-				JsonUtil.setObjectProperty(json, "post", object);
+				JsonUtil.setProperty(json, "post", object);
 			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -296,9 +309,9 @@ public class Syn1ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "operationId", node.getOperationId());
-		JsonUtil.setStringProperty(json, "summary", node.getSummary());
-		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		JsonUtil.setProperty(json, "operationId", JsonUtil.toJsonNode(node.getOperationId()));
+		JsonUtil.setProperty(json, "summary", JsonUtil.toJsonNode(node.getSummary()));
+		JsonUtil.setProperty(json, "tags", JsonUtil.toArrayNode(node.getTags()));
 		{
 			List<? extends SynItem> models = node.getParameters();
 			if (models != null && !models.isEmpty()) {
@@ -308,16 +321,18 @@ public class Syn1ModelWriter implements ModelWriter {
 					this.writeItem((Syn1Item) model, object);
 					JsonUtil.addToArray(array, object);
 				});
-				JsonUtil.setAnyProperty(json, "parameters", array);
+				JsonUtil.setProperty(json, "parameters", array);
 			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -347,7 +347,7 @@ public class Syn1ModelWriter implements ModelWriter {
 			return jsonValue;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}
@@ -370,7 +370,7 @@ public class Syn1ModelWriter implements ModelWriter {
 			return array;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}
@@ -384,7 +384,7 @@ public class Syn1ModelWriter implements ModelWriter {
 			return jsonValue;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -22,6 +22,7 @@ import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.v2.Syn2SchemaImpl;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,263 +30,423 @@ public class Syn2ModelReader implements ModelReader {
 
 	public void readDocument(ObjectNode json, Syn2Document node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "version");
-			node.setVersion(value);
-		}
-		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "info");
-			if (object != null) {
-				node.setInfo(node.createInfo());
-				readInfo(object, (Syn2Info) node.getInfo());
+			JsonNode _version = JsonUtil.getProperty(json, "version");
+			if (JsonUtil.isString(_version)) {
+				node.setVersion(JsonUtil.toString(_version));
+				json.remove("version");
 			}
 		}
 		{
-			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "items");
-			if (objects != null) {
-				objects.forEach(object -> {
+			JsonNode _info = JsonUtil.getProperty(json, "info");
+			if (JsonUtil.isObject(_info)) {
+				node.setInfo(node.createInfo());
+				readInfo((ObjectNode) _info, (Syn2Info) node.getInfo());
+				json.remove("info");
+			}
+		}
+		{
+			JsonNode _items = JsonUtil.getProperty(json, "items");
+			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
+				List<JsonNode> _nodes = JsonUtil.toList(_items);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					ObjectNode object = (ObjectNode) _nodes.get(_i);
 					Syn2Item model = (Syn2Item) node.createItem();
 					node.addItem(model);
 					this.readItem(object, model);
-				});
+				}
+				json.remove("items");
 			}
 		}
 		{
-			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
-			node.setTags(value);
-		}
-		{
-			Map<String, String> value = JsonUtil.consumeStringMapProperty(json, "metadata");
-			node.setMetadata(value);
-		}
-		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "webhooks");
-			JsonUtil.keys(object).forEach(name -> {
-				ObjectNode mapValue = JsonUtil.consumeObjectProperty(object, name);
-				if (mapValue != null) {
-					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
-					node.addWebhook(name, model);
-					this.readPathItem(mapValue, model);
+			JsonNode _tags = JsonUtil.getProperty(json, "tags");
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+				List<String> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_tags);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toString(_nodes.get(_i)));
 				}
-			});
+				node.setTags(items);
+				json.remove("tags");
+			}
 		}
 		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "additionalSchema");
-			if (value != null) {
-				node.setAdditionalSchema(this.readSchemaOrBoolean(value, null));
+			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
+			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch((ObjectNode) _metadata, "string")) {
+				Map<String, String> items = new LinkedHashMap<>();
+				List<String> _keys = JsonUtil.keys((ObjectNode) _metadata);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					items.put(_key, JsonUtil.toString(JsonUtil.getProperty((ObjectNode) _metadata, _key)));
+				}
+				node.setMetadata(items);
+				json.remove("metadata");
+			}
+		}
+		{
+			JsonNode _webhooks = JsonUtil.getProperty(json, "webhooks");
+			if (JsonUtil.isObject(_webhooks)) {
+				ObjectNode _obj = (ObjectNode) _webhooks;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isObject(_val)) {
+						Syn2PathItem model = (Syn2PathItem) node.createPathItem();
+						node.addWebhook(_key, model);
+						this.readPathItem((ObjectNode) _val, model);
+					}
+				}
+				json.remove("webhooks");
+			}
+		}
+		{
+			JsonNode _additionalSchema = JsonUtil.getProperty(json, "additionalSchema");
+			if (JsonUtil.isJsonNode(_additionalSchema)) {
+				node.setAdditionalSchema(this.readSchemaOrBoolean(_additionalSchema, null));
+				json.remove("additionalSchema");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readInfo(ObjectNode json, Syn2Info node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "name");
-			node.setName(value);
-		}
-		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "contact");
-			if (object != null) {
-				node.setContact(node.createContact());
-				readContact(object, (Syn2Contact) node.getContact());
+			JsonNode _name = JsonUtil.getProperty(json, "name");
+			if (JsonUtil.isString(_name)) {
+				node.setName(JsonUtil.toString(_name));
+				json.remove("name");
 			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "version");
-			node.setVersion(value);
+			JsonNode _contact = JsonUtil.getProperty(json, "contact");
+			if (JsonUtil.isObject(_contact)) {
+				node.setContact(node.createContact());
+				readContact((ObjectNode) _contact, (Syn2Contact) node.getContact());
+				json.remove("contact");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "license");
-			node.setLicense(value);
+			JsonNode _version = JsonUtil.getProperty(json, "version");
+			if (JsonUtil.isString(_version)) {
+				node.setVersion(JsonUtil.toString(_version));
+				json.remove("version");
+			}
+		}
+		{
+			JsonNode _license = JsonUtil.getProperty(json, "license");
+			if (JsonUtil.isString(_license)) {
+				node.setLicense(JsonUtil.toString(_license));
+				json.remove("license");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readContact(ObjectNode json, Syn2Contact node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "name");
-			node.setName(value);
+			JsonNode _name = JsonUtil.getProperty(json, "name");
+			if (JsonUtil.isString(_name)) {
+				node.setName(JsonUtil.toString(_name));
+				json.remove("name");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "email");
-			node.setEmail(value);
+			JsonNode _email = JsonUtil.getProperty(json, "email");
+			if (JsonUtil.isString(_email)) {
+				node.setEmail(JsonUtil.toString(_email));
+				json.remove("email");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "url");
-			node.setUrl(value);
+			JsonNode _url = JsonUtil.getProperty(json, "url");
+			if (JsonUtil.isString(_url)) {
+				node.setUrl(JsonUtil.toString(_url));
+				json.remove("url");
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readItem(ObjectNode json, Syn2Item node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "description");
-			node.setDescription(value);
+			JsonNode _description = JsonUtil.getProperty(json, "description");
+			if (JsonUtil.isString(_description)) {
+				node.setDescription(JsonUtil.toString(_description));
+				json.remove("description");
+			}
 		}
 		{
-			Boolean value = JsonUtil.consumeBooleanProperty(json, "required");
-			node.setRequired(value);
+			JsonNode _required = JsonUtil.getProperty(json, "required");
+			if (JsonUtil.isBoolean(_required)) {
+				node.setRequired(JsonUtil.toBoolean(_required));
+				json.remove("required");
+			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "order");
-			node.setOrder(value);
+			JsonNode _order = JsonUtil.getProperty(json, "order");
+			if (JsonUtil.isNumber(_order)) {
+				node.setOrder(JsonUtil.toInteger(_order));
+				json.remove("order");
+			}
 		}
 		{
-			Number value = JsonUtil.consumeNumberProperty(json, "weight");
-			node.setWeight(value);
+			JsonNode _weight = JsonUtil.getProperty(json, "weight");
+			if (JsonUtil.isNumber(_weight)) {
+				node.setWeight(JsonUtil.toNumber(_weight));
+				json.remove("weight");
+			}
 		}
 		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "extra");
-			node.setExtra(value);
+			JsonNode _extra = JsonUtil.getProperty(json, "extra");
+			if (JsonUtil.isJsonNode(_extra)) {
+				node.setExtra(JsonUtil.toJsonNode(_extra));
+				json.remove("extra");
+			}
 		}
 		{
-			ObjectNode value = JsonUtil.consumeObjectProperty(json, "raw");
-			node.setRaw(value);
+			JsonNode _raw = JsonUtil.getProperty(json, "raw");
+			if (JsonUtil.isObject(_raw)) {
+				node.setRaw(JsonUtil.toObject(_raw));
+				json.remove("raw");
+			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "schema");
-			if (object != null) {
+			JsonNode _schema = JsonUtil.getProperty(json, "schema");
+			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
-				readSchema(object, (Syn2Schema) node.getSchema());
+				readSchema((ObjectNode) _schema, (Syn2Schema) node.getSchema());
+				json.remove("schema");
 			}
 		}
 		{
-			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "examples");
-			node.setExamples(value);
-		}
-		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "defaultValue");
-			if (value != null) {
-				node.setDefaultValue(this.readBooleanSchemaUnion(value, null));
+			JsonNode _examples = JsonUtil.getProperty(json, "examples");
+			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, "any")) {
+				List<JsonNode> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_examples);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
+				}
+				node.setExamples(items);
+				json.remove("examples");
 			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "title");
-			node.setTitle(value);
+			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
+			if (JsonUtil.isJsonNode(_defaultValue)) {
+				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
+				json.remove("defaultValue");
+			}
 		}
 		{
-			Boolean value = JsonUtil.consumeBooleanProperty(json, "deprecated");
-			node.setDeprecated(value);
+			JsonNode _title = JsonUtil.getProperty(json, "title");
+			if (JsonUtil.isString(_title)) {
+				node.setTitle(JsonUtil.toString(_title));
+				json.remove("title");
+			}
+		}
+		{
+			JsonNode _deprecated = JsonUtil.getProperty(json, "deprecated");
+			if (JsonUtil.isBoolean(_deprecated)) {
+				node.setDeprecated(JsonUtil.toBoolean(_deprecated));
+				json.remove("deprecated");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readSchema(ObjectNode json, Syn2Schema node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
-		}
-		{
-			String value = JsonUtil.consumeStringProperty(json, "type");
-			node.setType(value);
-		}
-		{
-			JsonNode value = JsonUtil.consumeAnyProperty(json, "items");
-			if (value != null) {
-				node.setItems(this.readBooleanSchemaSchemaListUnion(value, null));
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "properties");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+			JsonNode _type = JsonUtil.getProperty(json, "type");
+			if (JsonUtil.isString(_type)) {
+				node.setType(JsonUtil.toString(_type));
+				json.remove("type");
+			}
+		}
+		{
+			JsonNode _items = JsonUtil.getProperty(json, "items");
+			if (JsonUtil.isJsonNode(_items)) {
+				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
+				json.remove("items");
+			}
+		}
+		{
+			JsonNode _properties = JsonUtil.getProperty(json, "properties");
+			if (JsonUtil.isObject(_properties)) {
+				ObjectNode _obj = (ObjectNode) _properties;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
 						if (model != null)
-							node.addProperty(key, model);
+							node.addProperty(_key, model);
 					}
-				});
+				}
+				json.remove("properties");
 			}
 		}
 		{
-			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "allOf");
-			if (array != null) {
-				array.forEach(item -> {
-					BooleanSchemaUnion value = this.readBooleanSchemaUnion(item, null);
-					if (value != null)
-						node.addAllOf(value);
-				});
+			JsonNode _allOf = JsonUtil.getProperty(json, "allOf");
+			if (JsonUtil.isArray(_allOf)) {
+				List<JsonNode> _nodes = JsonUtil.toList(_allOf);
+				List<BooleanSchemaUnion> _items = new ArrayList<>();
+				boolean _valid = true;
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i), null);
+					if (_result == null) {
+						_valid = false;
+						break;
+					}
+					_items.add(_result);
+				}
+				if (_valid) {
+					for (int _i = 0; _i < _items.size(); _i++) {
+						node.addAllOf(_items.get(_i));
+					}
+					json.remove("allOf");
+				}
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "definitions");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(value, null);
+			JsonNode _definitions = JsonUtil.getProperty(json, "definitions");
+			if (JsonUtil.isObject(_definitions)) {
+				ObjectNode _obj = (ObjectNode) _definitions;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
 						if (model != null)
-							node.addDefinition(key, model);
+							node.addDefinition(_key, model);
 					}
-				});
+				}
+				json.remove("definitions");
 			}
 		}
 		{
-			ObjectNode mapObj = JsonUtil.consumeObjectProperty(json, "nestedSchemas");
-			if (mapObj != null) {
-				JsonUtil.keys(mapObj).forEach(key -> {
-					JsonNode value = JsonUtil.consumeAnyProperty(mapObj, key);
-					if (value != null) {
-						SchemaOrBoolean model = this.readSchemaOrBoolean(value, null);
+			JsonNode _nestedSchemas = JsonUtil.getProperty(json, "nestedSchemas");
+			if (JsonUtil.isObject(_nestedSchemas)) {
+				ObjectNode _obj = (ObjectNode) _nestedSchemas;
+				List<String> _keys = JsonUtil.keys(_obj);
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String _key = _keys.get(_i);
+					JsonNode _val = JsonUtil.getProperty(_obj, _key);
+					if (JsonUtil.isJsonNode(_val)) {
+						SchemaOrBoolean model = this.readSchemaOrBoolean(_val, null);
 						if (model != null)
-							node.addNestedSchema(key, model);
+							node.addNestedSchema(_key, model);
 					}
-				});
+				}
+				json.remove("nestedSchemas");
 			}
 		}
 		{
-			List<JsonNode> array = JsonUtil.consumeAnyArrayProperty(json, "composedSchemas");
-			if (array != null) {
-				array.forEach(item -> {
-					SchemaOrBoolean value = this.readSchemaOrBoolean(item, null);
-					if (value != null)
-						node.addComposedSchema(value);
-				});
+			JsonNode _composedSchemas = JsonUtil.getProperty(json, "composedSchemas");
+			if (JsonUtil.isArray(_composedSchemas)) {
+				List<JsonNode> _nodes = JsonUtil.toList(_composedSchemas);
+				List<SchemaOrBoolean> _items = new ArrayList<>();
+				boolean _valid = true;
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					SchemaOrBoolean _result = this.readSchemaOrBoolean(_nodes.get(_i), null);
+					if (_result == null) {
+						_valid = false;
+						break;
+					}
+					_items.add(_result);
+				}
+				if (_valid) {
+					for (int _i = 0; _i < _items.size(); _i++) {
+						node.addComposedSchema(_items.get(_i));
+					}
+					json.remove("composedSchemas");
+				}
 			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "minLength");
-			node.setMinLength(value);
+			JsonNode _minLength = JsonUtil.getProperty(json, "minLength");
+			if (JsonUtil.isNumber(_minLength)) {
+				node.setMinLength(JsonUtil.toInteger(_minLength));
+				json.remove("minLength");
+			}
 		}
 		{
-			Integer value = JsonUtil.consumeIntegerProperty(json, "maxLength");
-			node.setMaxLength(value);
+			JsonNode _maxLength = JsonUtil.getProperty(json, "maxLength");
+			if (JsonUtil.isNumber(_maxLength)) {
+				node.setMaxLength(JsonUtil.toInteger(_maxLength));
+				json.remove("maxLength");
+			}
 		}
 		{
-			List<JsonNode> value = JsonUtil.consumeAnyArrayProperty(json, "enum");
-			node.setEnum(value);
+			JsonNode _enum = JsonUtil.getProperty(json, "enum");
+			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, "any")) {
+				List<JsonNode> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_enum);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
+				}
+				node.setEnum(items);
+				json.remove("enum");
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
@@ -293,101 +454,142 @@ public class Syn2ModelReader implements ModelReader {
 	public void readPaths(ObjectNode json, Syn2Paths node) {
 		{
 			List<String> propertyNames = JsonUtil.keys(json);
-			propertyNames.forEach(name -> {
-				ObjectNode object = JsonUtil.consumeObjectProperty(json, name);
-				if (object != null) {
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isObject(_val)) {
 					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
 					node.addItem(name, model);
-					this.readPathItem(object, model);
+					this.readPathItem((ObjectNode) _val, model);
+					json.remove(name);
 				}
-			});
+			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readPathItem(ObjectNode json, Syn2PathItem node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "$ref");
-			node.set$ref(value);
+			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
+			if (JsonUtil.isString(__ref)) {
+				node.set$ref(JsonUtil.toString(__ref));
+				json.remove("$ref");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "summary");
-			node.setSummary(value);
+			JsonNode _summary = JsonUtil.getProperty(json, "summary");
+			if (JsonUtil.isString(_summary)) {
+				node.setSummary(JsonUtil.toString(_summary));
+				json.remove("summary");
+			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "get");
-			if (object != null) {
+			JsonNode _get = JsonUtil.getProperty(json, "get");
+			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
-				readOperation(object, (Syn2Operation) node.getGet());
+				readOperation((ObjectNode) _get, (Syn2Operation) node.getGet());
+				json.remove("get");
 			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "put");
-			if (object != null) {
+			JsonNode _put = JsonUtil.getProperty(json, "put");
+			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
-				readOperation(object, (Syn2Operation) node.getPut());
+				readOperation((ObjectNode) _put, (Syn2Operation) node.getPut());
+				json.remove("put");
 			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "post");
-			if (object != null) {
+			JsonNode _post = JsonUtil.getProperty(json, "post");
+			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
-				readOperation(object, (Syn2Operation) node.getPost());
+				readOperation((ObjectNode) _post, (Syn2Operation) node.getPost());
+				json.remove("post");
 			}
 		}
 		{
-			ObjectNode object = JsonUtil.consumeObjectProperty(json, "delete");
-			if (object != null) {
+			JsonNode _delete = JsonUtil.getProperty(json, "delete");
+			if (JsonUtil.isObject(_delete)) {
 				node.setDelete(node.createOperation());
-				readOperation(object, (Syn2Operation) node.getDelete());
+				readOperation((ObjectNode) _delete, (Syn2Operation) node.getDelete());
+				json.remove("delete");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}
 
 	public void readOperation(ObjectNode json, Syn2Operation node) {
 		{
-			String value = JsonUtil.consumeStringProperty(json, "operationId");
-			node.setOperationId(value);
+			JsonNode _operationId = JsonUtil.getProperty(json, "operationId");
+			if (JsonUtil.isString(_operationId)) {
+				node.setOperationId(JsonUtil.toString(_operationId));
+				json.remove("operationId");
+			}
 		}
 		{
-			String value = JsonUtil.consumeStringProperty(json, "summary");
-			node.setSummary(value);
+			JsonNode _summary = JsonUtil.getProperty(json, "summary");
+			if (JsonUtil.isString(_summary)) {
+				node.setSummary(JsonUtil.toString(_summary));
+				json.remove("summary");
+			}
 		}
 		{
-			List<String> value = JsonUtil.consumeStringArrayProperty(json, "tags");
-			node.setTags(value);
+			JsonNode _tags = JsonUtil.getProperty(json, "tags");
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+				List<String> items = new ArrayList<>();
+				List<JsonNode> _nodes = JsonUtil.toList(_tags);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					items.add(JsonUtil.toString(_nodes.get(_i)));
+				}
+				node.setTags(items);
+				json.remove("tags");
+			}
 		}
 		{
-			List<ObjectNode> objects = JsonUtil.consumeObjectArrayProperty(json, "parameters");
-			if (objects != null) {
-				objects.forEach(object -> {
+			JsonNode _parameters = JsonUtil.getProperty(json, "parameters");
+			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
+				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
+				for (int _i = 0; _i < _nodes.size(); _i++) {
+					ObjectNode object = (ObjectNode) _nodes.get(_i);
 					Syn2Item model = (Syn2Item) node.createItem();
 					node.addParameter(model);
 					this.readItem(object, model);
-				});
+				}
+				json.remove("parameters");
 			}
 		}
 		{
 			List<String> propertyNames = JsonUtil.matchingKeys("^x-.+$", json);
-			propertyNames.forEach(name -> {
-				JsonNode value = JsonUtil.consumeAnyProperty(json, name);
-				node.addExtension(name, value);
-			});
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String name = propertyNames.get(_i);
+				JsonNode _val = JsonUtil.getProperty(json, name);
+				if (JsonUtil.isJsonNode(_val)) {
+					node.addExtension(name, JsonUtil.toJsonNode(_val));
+					json.remove(name);
+				}
+			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -113,7 +113,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -157,7 +157,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -287,7 +287,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -444,7 +444,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -461,7 +461,7 @@ public class Syn2ModelReader implements ModelReader {
 					Syn2PathItem model = (Syn2PathItem) node.createPathItem();
 					node.addItem(name, model);
 					this.readPathItem((ObjectNode) _val, model);
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -472,7 +472,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -533,7 +533,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}
@@ -587,7 +587,7 @@ public class Syn2ModelReader implements ModelReader {
 				JsonNode _val = JsonUtil.getProperty(json, name);
 				if (JsonUtil.isJsonNode(_val)) {
 					node.addExtension(name, JsonUtil.toJsonNode(_val));
-					json.remove(name);
+					JsonUtil.removeProperty(json, name);
 				}
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -33,7 +33,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _version = JsonUtil.getProperty(json, "version");
 			if (JsonUtil.isString(_version)) {
 				node.setVersion(JsonUtil.toString(_version));
-				json.remove("version");
+				JsonUtil.removeProperty(json, "version");
 			}
 		}
 		{
@@ -41,7 +41,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_info)) {
 				node.setInfo(node.createInfo());
 				readInfo(JsonUtil.toObject(_info), (Syn2Info) node.getInfo());
-				json.remove("info");
+				JsonUtil.removeProperty(json, "info");
 			}
 		}
 		{
@@ -54,7 +54,7 @@ public class Syn2ModelReader implements ModelReader {
 					node.addItem(model);
 					this.readItem(object, model);
 				}
-				json.remove("items");
+				JsonUtil.removeProperty(json, "items");
 			}
 		}
 		{
@@ -66,7 +66,7 @@ public class Syn2ModelReader implements ModelReader {
 					items.add(JsonUtil.toString(_nodes.get(_i)));
 				}
 				node.setTags(items);
-				json.remove("tags");
+				JsonUtil.removeProperty(json, "tags");
 			}
 		}
 		{
@@ -79,7 +79,7 @@ public class Syn2ModelReader implements ModelReader {
 					items.put(_key, JsonUtil.toString(JsonUtil.getProperty(JsonUtil.toObject(_metadata), _key)));
 				}
 				node.setMetadata(items);
-				json.remove("metadata");
+				JsonUtil.removeProperty(json, "metadata");
 			}
 		}
 		{
@@ -96,14 +96,14 @@ public class Syn2ModelReader implements ModelReader {
 						this.readPathItem(JsonUtil.toObject(_val), model);
 					}
 				}
-				json.remove("webhooks");
+				JsonUtil.removeProperty(json, "webhooks");
 			}
 		}
 		{
 			JsonNode _additionalSchema = JsonUtil.getProperty(json, "additionalSchema");
 			if (JsonUtil.isJsonNode(_additionalSchema)) {
 				node.setAdditionalSchema(this.readSchemaOrBoolean(_additionalSchema, null));
-				json.remove("additionalSchema");
+				JsonUtil.removeProperty(json, "additionalSchema");
 			}
 		}
 		{
@@ -125,7 +125,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _name = JsonUtil.getProperty(json, "name");
 			if (JsonUtil.isString(_name)) {
 				node.setName(JsonUtil.toString(_name));
-				json.remove("name");
+				JsonUtil.removeProperty(json, "name");
 			}
 		}
 		{
@@ -133,21 +133,21 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_contact)) {
 				node.setContact(node.createContact());
 				readContact(JsonUtil.toObject(_contact), (Syn2Contact) node.getContact());
-				json.remove("contact");
+				JsonUtil.removeProperty(json, "contact");
 			}
 		}
 		{
 			JsonNode _version = JsonUtil.getProperty(json, "version");
 			if (JsonUtil.isString(_version)) {
 				node.setVersion(JsonUtil.toString(_version));
-				json.remove("version");
+				JsonUtil.removeProperty(json, "version");
 			}
 		}
 		{
 			JsonNode _license = JsonUtil.getProperty(json, "license");
 			if (JsonUtil.isString(_license)) {
 				node.setLicense(JsonUtil.toString(_license));
-				json.remove("license");
+				JsonUtil.removeProperty(json, "license");
 			}
 		}
 		{
@@ -169,21 +169,21 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _name = JsonUtil.getProperty(json, "name");
 			if (JsonUtil.isString(_name)) {
 				node.setName(JsonUtil.toString(_name));
-				json.remove("name");
+				JsonUtil.removeProperty(json, "name");
 			}
 		}
 		{
 			JsonNode _email = JsonUtil.getProperty(json, "email");
 			if (JsonUtil.isString(_email)) {
 				node.setEmail(JsonUtil.toString(_email));
-				json.remove("email");
+				JsonUtil.removeProperty(json, "email");
 			}
 		}
 		{
 			JsonNode _url = JsonUtil.getProperty(json, "url");
 			if (JsonUtil.isString(_url)) {
 				node.setUrl(JsonUtil.toString(_url));
-				json.remove("url");
+				JsonUtil.removeProperty(json, "url");
 			}
 		}
 		ReaderUtil.readExtraProperties(json, node);
@@ -194,49 +194,49 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _description = JsonUtil.getProperty(json, "description");
 			if (JsonUtil.isString(_description)) {
 				node.setDescription(JsonUtil.toString(_description));
-				json.remove("description");
+				JsonUtil.removeProperty(json, "description");
 			}
 		}
 		{
 			JsonNode _required = JsonUtil.getProperty(json, "required");
 			if (JsonUtil.isBoolean(_required)) {
 				node.setRequired(JsonUtil.toBoolean(_required));
-				json.remove("required");
+				JsonUtil.removeProperty(json, "required");
 			}
 		}
 		{
 			JsonNode _order = JsonUtil.getProperty(json, "order");
 			if (JsonUtil.isNumber(_order)) {
 				node.setOrder(JsonUtil.toInteger(_order));
-				json.remove("order");
+				JsonUtil.removeProperty(json, "order");
 			}
 		}
 		{
 			JsonNode _weight = JsonUtil.getProperty(json, "weight");
 			if (JsonUtil.isNumber(_weight)) {
 				node.setWeight(JsonUtil.toNumber(_weight));
-				json.remove("weight");
+				JsonUtil.removeProperty(json, "weight");
 			}
 		}
 		{
 			JsonNode _extra = JsonUtil.getProperty(json, "extra");
 			if (JsonUtil.isJsonNode(_extra)) {
 				node.setExtra(JsonUtil.toJsonNode(_extra));
-				json.remove("extra");
+				JsonUtil.removeProperty(json, "extra");
 			}
 		}
 		{
 			JsonNode _raw = JsonUtil.getProperty(json, "raw");
 			if (JsonUtil.isObject(_raw)) {
 				node.setRaw(JsonUtil.toObject(_raw));
-				json.remove("raw");
+				JsonUtil.removeProperty(json, "raw");
 			}
 		}
 		{
@@ -244,7 +244,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
 				readSchema(JsonUtil.toObject(_schema), (Syn2Schema) node.getSchema());
-				json.remove("schema");
+				JsonUtil.removeProperty(json, "schema");
 			}
 		}
 		{
@@ -256,28 +256,28 @@ public class Syn2ModelReader implements ModelReader {
 					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
 				}
 				node.setExamples(items);
-				json.remove("examples");
+				JsonUtil.removeProperty(json, "examples");
 			}
 		}
 		{
 			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
 			if (JsonUtil.isJsonNode(_defaultValue)) {
 				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
-				json.remove("defaultValue");
+				JsonUtil.removeProperty(json, "defaultValue");
 			}
 		}
 		{
 			JsonNode _title = JsonUtil.getProperty(json, "title");
 			if (JsonUtil.isString(_title)) {
 				node.setTitle(JsonUtil.toString(_title));
-				json.remove("title");
+				JsonUtil.removeProperty(json, "title");
 			}
 		}
 		{
 			JsonNode _deprecated = JsonUtil.getProperty(json, "deprecated");
 			if (JsonUtil.isBoolean(_deprecated)) {
 				node.setDeprecated(JsonUtil.toBoolean(_deprecated));
-				json.remove("deprecated");
+				JsonUtil.removeProperty(json, "deprecated");
 			}
 		}
 		{
@@ -299,21 +299,21 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _type = JsonUtil.getProperty(json, "type");
 			if (JsonUtil.isString(_type)) {
 				node.setType(JsonUtil.toString(_type));
-				json.remove("type");
+				JsonUtil.removeProperty(json, "type");
 			}
 		}
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
 			if (JsonUtil.isJsonNode(_items)) {
 				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
-				json.remove("items");
+				JsonUtil.removeProperty(json, "items");
 			}
 		}
 		{
@@ -330,7 +330,7 @@ public class Syn2ModelReader implements ModelReader {
 							node.addProperty(_key, model);
 					}
 				}
-				json.remove("properties");
+				JsonUtil.removeProperty(json, "properties");
 			}
 		}
 		{
@@ -351,7 +351,7 @@ public class Syn2ModelReader implements ModelReader {
 					for (int _i = 0; _i < _items.size(); _i++) {
 						node.addAllOf(_items.get(_i));
 					}
-					json.remove("allOf");
+					JsonUtil.removeProperty(json, "allOf");
 				}
 			}
 		}
@@ -369,7 +369,7 @@ public class Syn2ModelReader implements ModelReader {
 							node.addDefinition(_key, model);
 					}
 				}
-				json.remove("definitions");
+				JsonUtil.removeProperty(json, "definitions");
 			}
 		}
 		{
@@ -386,7 +386,7 @@ public class Syn2ModelReader implements ModelReader {
 							node.addNestedSchema(_key, model);
 					}
 				}
-				json.remove("nestedSchemas");
+				JsonUtil.removeProperty(json, "nestedSchemas");
 			}
 		}
 		{
@@ -407,7 +407,7 @@ public class Syn2ModelReader implements ModelReader {
 					for (int _i = 0; _i < _items.size(); _i++) {
 						node.addComposedSchema(_items.get(_i));
 					}
-					json.remove("composedSchemas");
+					JsonUtil.removeProperty(json, "composedSchemas");
 				}
 			}
 		}
@@ -415,14 +415,14 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _minLength = JsonUtil.getProperty(json, "minLength");
 			if (JsonUtil.isNumber(_minLength)) {
 				node.setMinLength(JsonUtil.toInteger(_minLength));
-				json.remove("minLength");
+				JsonUtil.removeProperty(json, "minLength");
 			}
 		}
 		{
 			JsonNode _maxLength = JsonUtil.getProperty(json, "maxLength");
 			if (JsonUtil.isNumber(_maxLength)) {
 				node.setMaxLength(JsonUtil.toInteger(_maxLength));
-				json.remove("maxLength");
+				JsonUtil.removeProperty(json, "maxLength");
 			}
 		}
 		{
@@ -434,7 +434,7 @@ public class Syn2ModelReader implements ModelReader {
 					items.add(JsonUtil.toJsonNode(_nodes.get(_i)));
 				}
 				node.setEnum(items);
-				json.remove("enum");
+				JsonUtil.removeProperty(json, "enum");
 			}
 		}
 		{
@@ -484,14 +484,14 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode __ref = JsonUtil.getProperty(json, "$ref");
 			if (JsonUtil.isString(__ref)) {
 				node.set$ref(JsonUtil.toString(__ref));
-				json.remove("$ref");
+				JsonUtil.removeProperty(json, "$ref");
 			}
 		}
 		{
 			JsonNode _summary = JsonUtil.getProperty(json, "summary");
 			if (JsonUtil.isString(_summary)) {
 				node.setSummary(JsonUtil.toString(_summary));
-				json.remove("summary");
+				JsonUtil.removeProperty(json, "summary");
 			}
 		}
 		{
@@ -499,7 +499,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
 				readOperation(JsonUtil.toObject(_get), (Syn2Operation) node.getGet());
-				json.remove("get");
+				JsonUtil.removeProperty(json, "get");
 			}
 		}
 		{
@@ -507,7 +507,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
 				readOperation(JsonUtil.toObject(_put), (Syn2Operation) node.getPut());
-				json.remove("put");
+				JsonUtil.removeProperty(json, "put");
 			}
 		}
 		{
@@ -515,7 +515,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
 				readOperation(JsonUtil.toObject(_post), (Syn2Operation) node.getPost());
-				json.remove("post");
+				JsonUtil.removeProperty(json, "post");
 			}
 		}
 		{
@@ -523,7 +523,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_delete)) {
 				node.setDelete(node.createOperation());
 				readOperation(JsonUtil.toObject(_delete), (Syn2Operation) node.getDelete());
-				json.remove("delete");
+				JsonUtil.removeProperty(json, "delete");
 			}
 		}
 		{
@@ -545,14 +545,14 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _operationId = JsonUtil.getProperty(json, "operationId");
 			if (JsonUtil.isString(_operationId)) {
 				node.setOperationId(JsonUtil.toString(_operationId));
-				json.remove("operationId");
+				JsonUtil.removeProperty(json, "operationId");
 			}
 		}
 		{
 			JsonNode _summary = JsonUtil.getProperty(json, "summary");
 			if (JsonUtil.isString(_summary)) {
 				node.setSummary(JsonUtil.toString(_summary));
-				json.remove("summary");
+				JsonUtil.removeProperty(json, "summary");
 			}
 		}
 		{
@@ -564,7 +564,7 @@ public class Syn2ModelReader implements ModelReader {
 					items.add(JsonUtil.toString(_nodes.get(_i)));
 				}
 				node.setTags(items);
-				json.remove("tags");
+				JsonUtil.removeProperty(json, "tags");
 			}
 		}
 		{
@@ -577,7 +577,7 @@ public class Syn2ModelReader implements ModelReader {
 					node.addParameter(model);
 					this.readItem(object, model);
 				}
-				json.remove("parameters");
+				JsonUtil.removeProperty(json, "parameters");
 			}
 		}
 		{

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -40,7 +40,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _info = JsonUtil.getProperty(json, "info");
 			if (JsonUtil.isObject(_info)) {
 				node.setInfo(node.createInfo());
-				readInfo((ObjectNode) _info, (Syn2Info) node.getInfo());
+				readInfo(JsonUtil.toObject(_info), (Syn2Info) node.getInfo());
 				json.remove("info");
 			}
 		}
@@ -49,7 +49,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
 				List<JsonNode> _nodes = JsonUtil.toList(_items);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					ObjectNode object = (ObjectNode) _nodes.get(_i);
+					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
 					Syn2Item model = (Syn2Item) node.createItem();
 					node.addItem(model);
 					this.readItem(object, model);
@@ -71,12 +71,12 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
-			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch((ObjectNode) _metadata, "string")) {
+			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), "string")) {
 				Map<String, String> items = new LinkedHashMap<>();
-				List<String> _keys = JsonUtil.keys((ObjectNode) _metadata);
+				List<String> _keys = JsonUtil.keys(JsonUtil.toObject(_metadata));
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
-					items.put(_key, JsonUtil.toString(JsonUtil.getProperty((ObjectNode) _metadata, _key)));
+					items.put(_key, JsonUtil.toString(JsonUtil.getProperty(JsonUtil.toObject(_metadata), _key)));
 				}
 				node.setMetadata(items);
 				json.remove("metadata");
@@ -85,7 +85,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _webhooks = JsonUtil.getProperty(json, "webhooks");
 			if (JsonUtil.isObject(_webhooks)) {
-				ObjectNode _obj = (ObjectNode) _webhooks;
+				ObjectNode _obj = JsonUtil.toObject(_webhooks);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -93,7 +93,7 @@ public class Syn2ModelReader implements ModelReader {
 					if (JsonUtil.isObject(_val)) {
 						Syn2PathItem model = (Syn2PathItem) node.createPathItem();
 						node.addWebhook(_key, model);
-						this.readPathItem((ObjectNode) _val, model);
+						this.readPathItem(JsonUtil.toObject(_val), model);
 					}
 				}
 				json.remove("webhooks");
@@ -132,7 +132,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _contact = JsonUtil.getProperty(json, "contact");
 			if (JsonUtil.isObject(_contact)) {
 				node.setContact(node.createContact());
-				readContact((ObjectNode) _contact, (Syn2Contact) node.getContact());
+				readContact(JsonUtil.toObject(_contact), (Syn2Contact) node.getContact());
 				json.remove("contact");
 			}
 		}
@@ -243,7 +243,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _schema = JsonUtil.getProperty(json, "schema");
 			if (JsonUtil.isObject(_schema)) {
 				node.setSchema(node.createSchema());
-				readSchema((ObjectNode) _schema, (Syn2Schema) node.getSchema());
+				readSchema(JsonUtil.toObject(_schema), (Syn2Schema) node.getSchema());
 				json.remove("schema");
 			}
 		}
@@ -319,7 +319,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _properties = JsonUtil.getProperty(json, "properties");
 			if (JsonUtil.isObject(_properties)) {
-				ObjectNode _obj = (ObjectNode) _properties;
+				ObjectNode _obj = JsonUtil.toObject(_properties);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -358,7 +358,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _definitions = JsonUtil.getProperty(json, "definitions");
 			if (JsonUtil.isObject(_definitions)) {
-				ObjectNode _obj = (ObjectNode) _definitions;
+				ObjectNode _obj = JsonUtil.toObject(_definitions);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -375,7 +375,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _nestedSchemas = JsonUtil.getProperty(json, "nestedSchemas");
 			if (JsonUtil.isObject(_nestedSchemas)) {
-				ObjectNode _obj = (ObjectNode) _nestedSchemas;
+				ObjectNode _obj = JsonUtil.toObject(_nestedSchemas);
 				List<String> _keys = JsonUtil.keys(_obj);
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
@@ -498,7 +498,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _get = JsonUtil.getProperty(json, "get");
 			if (JsonUtil.isObject(_get)) {
 				node.setGet(node.createOperation());
-				readOperation((ObjectNode) _get, (Syn2Operation) node.getGet());
+				readOperation(JsonUtil.toObject(_get), (Syn2Operation) node.getGet());
 				json.remove("get");
 			}
 		}
@@ -506,7 +506,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _put = JsonUtil.getProperty(json, "put");
 			if (JsonUtil.isObject(_put)) {
 				node.setPut(node.createOperation());
-				readOperation((ObjectNode) _put, (Syn2Operation) node.getPut());
+				readOperation(JsonUtil.toObject(_put), (Syn2Operation) node.getPut());
 				json.remove("put");
 			}
 		}
@@ -514,7 +514,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _post = JsonUtil.getProperty(json, "post");
 			if (JsonUtil.isObject(_post)) {
 				node.setPost(node.createOperation());
-				readOperation((ObjectNode) _post, (Syn2Operation) node.getPost());
+				readOperation(JsonUtil.toObject(_post), (Syn2Operation) node.getPost());
 				json.remove("post");
 			}
 		}
@@ -522,7 +522,7 @@ public class Syn2ModelReader implements ModelReader {
 			JsonNode _delete = JsonUtil.getProperty(json, "delete");
 			if (JsonUtil.isObject(_delete)) {
 				node.setDelete(node.createOperation());
-				readOperation((ObjectNode) _delete, (Syn2Operation) node.getDelete());
+				readOperation(JsonUtil.toObject(_delete), (Syn2Operation) node.getDelete());
 				json.remove("delete");
 			}
 		}
@@ -572,7 +572,7 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
 				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					ObjectNode object = (ObjectNode) _nodes.get(_i);
+					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
 					Syn2Item model = (Syn2Item) node.createItem();
 					node.addParameter(model);
 					this.readItem(object, model);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -369,7 +369,7 @@ public class Syn2ModelWriter implements ModelWriter {
 			return jsonValue;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}
@@ -392,7 +392,7 @@ public class Syn2ModelWriter implements ModelWriter {
 			return array;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}
@@ -406,7 +406,7 @@ public class Syn2ModelWriter implements ModelWriter {
 			return jsonValue;
 		}
 		if (union.isBoolean()) {
-			return JsonUtil.booleanToJsonNode(union.asBoolean());
+			return JsonUtil.toJsonNode(union.asBoolean());
 		}
 		return null;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -30,12 +30,12 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "version", node.getVersion());
+		JsonUtil.setProperty(json, "version", JsonUtil.toJsonNode(node.getVersion()));
 		{
 			if (node.getInfo() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeInfo((Syn2Info) node.getInfo(), object);
-				JsonUtil.setObjectProperty(json, "info", object);
+				JsonUtil.setProperty(json, "info", object);
 			}
 		}
 		{
@@ -47,11 +47,11 @@ public class Syn2ModelWriter implements ModelWriter {
 					this.writeItem((Syn2Item) model, object);
 					JsonUtil.addToArray(array, object);
 				});
-				JsonUtil.setAnyProperty(json, "items", array);
+				JsonUtil.setProperty(json, "items", array);
 			}
 		}
-		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
-		JsonUtil.setStringMapProperty(json, "metadata", node.getMetadata());
+		JsonUtil.setProperty(json, "tags", JsonUtil.toArrayNode(node.getTags()));
+		JsonUtil.setProperty(json, "metadata", JsonUtil.toObjectNode(node.getMetadata()));
 		{
 			Map<String, ? extends SynPathItem> models = node.getWebhooks();
 			if (models != null && !models.isEmpty()) {
@@ -59,23 +59,25 @@ public class Syn2ModelWriter implements ModelWriter {
 				models.keySet().forEach(jsonName -> {
 					ObjectNode jsonValue = JsonUtil.objectNode();
 					this.writePathItem((Syn2PathItem) models.get(jsonName), jsonValue);
-					JsonUtil.setObjectProperty(object, jsonName, jsonValue);
+					JsonUtil.setProperty(object, jsonName, jsonValue);
 				});
-				JsonUtil.setObjectProperty(json, "webhooks", object);
+				JsonUtil.setProperty(json, "webhooks", object);
 			}
 		}
 		{
 			JsonNode value = this.writeSchemaOrBoolean(node.getAdditionalSchema());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "additionalSchema", value);
+				JsonUtil.setProperty(json, "additionalSchema", value);
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -85,23 +87,25 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "name", node.getName());
+		JsonUtil.setProperty(json, "name", JsonUtil.toJsonNode(node.getName()));
 		{
 			if (node.getContact() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeContact((Syn2Contact) node.getContact(), object);
-				JsonUtil.setObjectProperty(json, "contact", object);
+				JsonUtil.setProperty(json, "contact", object);
 			}
 		}
-		JsonUtil.setStringProperty(json, "version", node.getVersion());
-		JsonUtil.setStringProperty(json, "license", node.getLicense());
+		JsonUtil.setProperty(json, "version", JsonUtil.toJsonNode(node.getVersion()));
+		JsonUtil.setProperty(json, "license", JsonUtil.toJsonNode(node.getLicense()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -111,9 +115,9 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "name", node.getName());
-		JsonUtil.setStringProperty(json, "email", node.getEmail());
-		JsonUtil.setStringProperty(json, "url", node.getUrl());
+		JsonUtil.setProperty(json, "name", JsonUtil.toJsonNode(node.getName()));
+		JsonUtil.setProperty(json, "email", JsonUtil.toJsonNode(node.getEmail()));
+		JsonUtil.setProperty(json, "url", JsonUtil.toJsonNode(node.getUrl()));
 		WriterUtil.writeExtraProperties(node, json);
 	}
 
@@ -121,35 +125,37 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "description", node.getDescription());
-		JsonUtil.setBooleanProperty(json, "required", node.isRequired());
-		JsonUtil.setIntegerProperty(json, "order", node.getOrder());
-		JsonUtil.setNumberProperty(json, "weight", node.getWeight());
-		JsonUtil.setAnyProperty(json, "extra", node.getExtra());
-		JsonUtil.setObjectProperty(json, "raw", node.getRaw());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "description", JsonUtil.toJsonNode(node.getDescription()));
+		JsonUtil.setProperty(json, "required", JsonUtil.toJsonNode(node.isRequired()));
+		JsonUtil.setProperty(json, "order", JsonUtil.toJsonNode(node.getOrder()));
+		JsonUtil.setProperty(json, "weight", JsonUtil.toJsonNode(node.getWeight()));
+		JsonUtil.setProperty(json, "extra", node.getExtra());
+		JsonUtil.setProperty(json, "raw", node.getRaw());
 		{
 			if (node.getSchema() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeSchema((Syn2Schema) node.getSchema(), object);
-				JsonUtil.setObjectProperty(json, "schema", object);
+				JsonUtil.setProperty(json, "schema", object);
 			}
 		}
-		JsonUtil.setAnyArrayProperty(json, "examples", node.getExamples());
+		JsonUtil.setProperty(json, "examples", JsonUtil.toArrayNode(node.getExamples()));
 		{
 			JsonNode value = this.writeBooleanSchemaUnion(node.getDefaultValue());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "defaultValue", value);
+				JsonUtil.setProperty(json, "defaultValue", value);
 		}
-		JsonUtil.setStringProperty(json, "title", node.getTitle());
-		JsonUtil.setBooleanProperty(json, "deprecated", node.isDeprecated());
+		JsonUtil.setProperty(json, "title", JsonUtil.toJsonNode(node.getTitle()));
+		JsonUtil.setProperty(json, "deprecated", JsonUtil.toJsonNode(node.isDeprecated()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -159,12 +165,12 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "type", node.getType());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "type", JsonUtil.toJsonNode(node.getType()));
 		{
 			JsonNode value = this.writeBooleanSchemaSchemaListUnion(node.getItems());
 			if (value != null)
-				JsonUtil.setAnyProperty(json, "items", value);
+				JsonUtil.setProperty(json, "items", value);
 		}
 		{
 			Map<String, BooleanSchemaUnion> items = node.getProperties();
@@ -174,9 +180,9 @@ public class Syn2ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "properties", mapJson);
+				JsonUtil.setProperty(json, "properties", mapJson);
 			}
 		}
 		{
@@ -188,7 +194,7 @@ public class Syn2ModelWriter implements ModelWriter {
 					if (value != null)
 						array.add(value);
 				});
-				JsonUtil.setAnyProperty(json, "allOf", array);
+				JsonUtil.setProperty(json, "allOf", array);
 			}
 		}
 		{
@@ -199,9 +205,9 @@ public class Syn2ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "definitions", mapJson);
+				JsonUtil.setProperty(json, "definitions", mapJson);
 			}
 		}
 		{
@@ -212,9 +218,9 @@ public class Syn2ModelWriter implements ModelWriter {
 				keys.forEach(key -> {
 					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
-						JsonUtil.setAnyProperty(mapJson, key, value);
+						JsonUtil.setProperty(mapJson, key, value);
 				});
-				JsonUtil.setObjectProperty(json, "nestedSchemas", mapJson);
+				JsonUtil.setProperty(json, "nestedSchemas", mapJson);
 			}
 		}
 		{
@@ -226,19 +232,21 @@ public class Syn2ModelWriter implements ModelWriter {
 					if (value != null)
 						array.add(value);
 				});
-				JsonUtil.setAnyProperty(json, "composedSchemas", array);
+				JsonUtil.setProperty(json, "composedSchemas", array);
 			}
 		}
-		JsonUtil.setIntegerProperty(json, "minLength", node.getMinLength());
-		JsonUtil.setIntegerProperty(json, "maxLength", node.getMaxLength());
-		JsonUtil.setAnyArrayProperty(json, "enum", node.getEnum());
+		JsonUtil.setProperty(json, "minLength", JsonUtil.toJsonNode(node.getMinLength()));
+		JsonUtil.setProperty(json, "maxLength", JsonUtil.toJsonNode(node.getMaxLength()));
+		JsonUtil.setProperty(json, "enum", JsonUtil.toArrayNode(node.getEnum()));
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -250,19 +258,22 @@ public class Syn2ModelWriter implements ModelWriter {
 		}
 		{
 			List<String> propertyNames = node.getItemNames();
-			propertyNames.forEach(propertyName -> {
+			for (int _i = 0; _i < propertyNames.size(); _i++) {
+				String propertyName = propertyNames.get(_i);
 				ObjectNode object = JsonUtil.objectNode();
 				this.writePathItem((Syn2PathItem) node.getItem(propertyName), object);
-				JsonUtil.setObjectProperty(json, propertyName, object);
-			});
+				JsonUtil.setProperty(json, propertyName, object);
+			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -272,43 +283,45 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "$ref", node.get$ref());
-		JsonUtil.setStringProperty(json, "summary", node.getSummary());
+		JsonUtil.setProperty(json, "$ref", JsonUtil.toJsonNode(node.get$ref()));
+		JsonUtil.setProperty(json, "summary", JsonUtil.toJsonNode(node.getSummary()));
 		{
 			if (node.getGet() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn2Operation) node.getGet(), object);
-				JsonUtil.setObjectProperty(json, "get", object);
+				JsonUtil.setProperty(json, "get", object);
 			}
 		}
 		{
 			if (node.getPut() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn2Operation) node.getPut(), object);
-				JsonUtil.setObjectProperty(json, "put", object);
+				JsonUtil.setProperty(json, "put", object);
 			}
 		}
 		{
 			if (node.getPost() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn2Operation) node.getPost(), object);
-				JsonUtil.setObjectProperty(json, "post", object);
+				JsonUtil.setProperty(json, "post", object);
 			}
 		}
 		{
 			if (node.getDelete() != null) {
 				ObjectNode object = JsonUtil.objectNode();
 				this.writeOperation((Syn2Operation) node.getDelete(), object);
-				JsonUtil.setObjectProperty(json, "delete", object);
+				JsonUtil.setProperty(json, "delete", object);
 			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);
@@ -318,9 +331,9 @@ public class Syn2ModelWriter implements ModelWriter {
 		if (node == null) {
 			return;
 		}
-		JsonUtil.setStringProperty(json, "operationId", node.getOperationId());
-		JsonUtil.setStringProperty(json, "summary", node.getSummary());
-		JsonUtil.setStringArrayProperty(json, "tags", node.getTags());
+		JsonUtil.setProperty(json, "operationId", JsonUtil.toJsonNode(node.getOperationId()));
+		JsonUtil.setProperty(json, "summary", JsonUtil.toJsonNode(node.getSummary()));
+		JsonUtil.setProperty(json, "tags", JsonUtil.toArrayNode(node.getTags()));
 		{
 			List<? extends SynItem> models = node.getParameters();
 			if (models != null && !models.isEmpty()) {
@@ -330,16 +343,18 @@ public class Syn2ModelWriter implements ModelWriter {
 					this.writeItem((Syn2Item) model, object);
 					JsonUtil.addToArray(array, object);
 				});
-				JsonUtil.setAnyProperty(json, "parameters", array);
+				JsonUtil.setProperty(json, "parameters", array);
 			}
 		}
 		{
 			Map<String, JsonNode> values = node.getExtensions();
 			if (values != null && !values.isEmpty()) {
-				values.keySet().forEach(propertyName -> {
+				List<String> _keys = new java.util.ArrayList<>(values.keySet());
+				for (int _i = 0; _i < _keys.size(); _i++) {
+					String propertyName = _keys.get(_i);
 					JsonNode value = values.get(propertyName);
-					JsonUtil.setAnyProperty(json, propertyName, value);
-				});
+					JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+				}
 			}
 		}
 		WriterUtil.writeExtraProperties(node, json);

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -8,6 +8,7 @@ import io.test.synthetic.union.EntityMapUnionValue;
 import io.test.synthetic.union.Union;
 import io.test.synthetic.util.JsonUtil;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -59,12 +60,11 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 * @param propertyName
 	 * @param items
 	 */
-	@SuppressWarnings("unchecked")
 	protected void traverseList(String propertyName, Collection<? extends Any> items) {
 		if (items != null) {
 			int index = 0;
 			traversalContext.pushProperty(propertyName);
-			Collection<? extends Any> clonedItems = (Collection<? extends Any>) JsonUtil.cloneCollection(items);
+			List<? extends Any> clonedItems = JsonUtil.collectionToList(items);
 			for (Any item : clonedItems) {
 				if (item != null && item.isNode()) {
 					traversalContext.pushListIndex(index);
@@ -83,11 +83,10 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 * @param propertyName
 	 * @param items
 	 */
-	@SuppressWarnings("unchecked")
 	protected void traverseMap(String propertyName, Map<String, ? extends Any> items) {
 		if (items != null) {
 			traversalContext.pushProperty(propertyName);
-			Collection<String> keys = (Collection<String>) JsonUtil.cloneCollection(items.keySet());
+			List<String> keys = JsonUtil.collectionToList(items.keySet());
 			keys.forEach(key -> {
 				Any value = items.get(key);
 				if (value != null && value.isNode()) {
@@ -105,10 +104,9 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	 *
 	 * @param items
 	 */
-	@SuppressWarnings("unchecked")
 	protected void traverseMappedNode(MappedNode<? extends Node> mappedNode) {
 		if (mappedNode != null) {
-			Collection<String> names = (Collection<String>) JsonUtil.cloneCollection(mappedNode.getItemNames());
+			List<String> names = JsonUtil.collectionToList(mappedNode.getItemNames());
 			names.forEach(name -> {
 				Node value = mappedNode.getItem(name);
 				if (value != null) {


### PR DESCRIPTION
## Summary

Replace 56 type-specific `consume/get/set` methods with generic patterns:

**Reader:** `getProperty` + type check + `remove` instead of `consumeXxxProperty`
- Primitives: `getProperty + isString/isNumber/etc + toString/toNumber + remove`
- Arrays: `getProperty + isArray + allMatch(expectedType) + iterate + remove`
- Maps: `getProperty + isObject + allValuesMatch(expectedType) + iterate + remove`
- Type mismatch → property treated as extra (preserved in roundtrip)

**Writer:** `setProperty` + `toJsonNode`/`toArrayNode`/`toObjectNode` instead of `setXxxProperty`

**New methods:** `toJsonNode(Object)`, `toArrayNode(List)`, `toObjectNode(Map)`, `allMatch(JsonNode, String)`, `allValuesMatch(ObjectNode, String)`, `toInteger(JsonNode)`

**Method count:** 88 → 40 (-55%)

External `for` loops used consistently in generated reader code.

## Context

C34/G25 in #1042 and #1041. Major simplification of the JsonUtil utility class, eliminating repetitive type-specific methods. The generated code now uses explicit type checking, which is also more correct — type mismatches are preserved as extra properties rather than silently dropped.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generator tests pass (FullGeneratorTest, SyntheticSnapshotTest)
- [x] Generated output changed (new method calls) but behavior identical