### PR TITLE
refactor(generator): improve BodyBuilder with text blocks, conditionals, loops (C34b)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
@@ -58,21 +58,23 @@ public class AddMethod implements CanAddImports {
         body.addContext("propertyName", propertyName);
 
         if (isEntityValue || isPrimitiveValue || isUnionValue) {
-            if (resolvedType.isMapType()) {
+            body.ifElse(resolvedType.isMapType(), () -> {
                 javaEntity.addImport(LinkedHashMap.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new LinkedHashMap<>();");
-                body.append("}");
-                body.append("this.${fieldName}.put(name, value);");
-            } else {
+                return """
+if (this.${fieldName} == null) {
+    this.${fieldName} = new LinkedHashMap<>();
+}
+this.${fieldName}.put(name, value);
+""";
+            }, () -> {
                 javaEntity.addImport(ArrayList.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new ArrayList<>();");
-                body.append("}");
-                body.append("this.${fieldName}.add(value);");
-            }
+                return """
+if (this.${fieldName} == null) {
+    this.${fieldName} = new ArrayList<>();
+}
+this.${fieldName}.add(value);
+""";
+            });
 
             if (parentBlock != null) {
                 parentBlock.appendTo(body);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/BodyBuilder.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/BodyBuilder.java
@@ -3,6 +3,7 @@ package io.apitomy.umg.pipe.java.method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Supplier;
 
 import io.apitomy.umg.logging.Logger;
 
@@ -38,15 +39,105 @@ public class BodyBuilder {
     }
 
     public void append(String line) {
-        String lineResolved = line;
-        for (Entry<String, String> entry : context.entrySet()) {
-            lineResolved = lineResolved.replace("${" + entry.getKey() + "}", entry.getValue());
-        }
-        str.append(lineResolved);
+        String resolved = resolveVars(line);
+        str.append(resolved);
         str.append("\n");
-        if (lineResolved.contains("${")) {
-            Logger.warn("[BodyBuilder] 'append' detected unresolved variables: " + lineResolved);
+        if (resolved.contains("${")) {
+            Logger.warn("[BodyBuilder] 'append' detected unresolved variables: " + resolved);
         }
+    }
+
+    /**
+     * Append a multi-line text block with ${var} substitution.
+     * Each line in the block is resolved and appended separately.
+     * Leading/trailing blank lines from text block formatting are trimmed.
+     */
+    public void appendBlock(String textBlock) {
+        String[] lines = textBlock.split("\n", -1);
+        int start = 0;
+        int end = lines.length;
+        while (start < end && lines[start].isBlank()) start++;
+        while (end > start && lines[end - 1].isBlank()) end--;
+        for (int i = start; i < end; i++) {
+            append(lines[i]);
+        }
+    }
+
+    /**
+     * Conditional code generation. Appends the result of the matching supplier.
+     * Suppliers can perform side effects (e.g., adding imports) and return
+     * a code string (single or multi-line) to append.
+     */
+    public void ifElse(boolean condition, Supplier<String> thenBlock, Supplier<String> elseBlock) {
+        String result = condition ? thenBlock.get() : elseBlock.get();
+        if (result != null && !result.isEmpty()) {
+            appendBlock(result);
+        }
+    }
+
+    /**
+     * Conditional code generation without else branch.
+     */
+    public void ifTrue(boolean condition, Supplier<String> thenBlock) {
+        if (condition) {
+            String result = thenBlock.get();
+            if (result != null && !result.isEmpty()) {
+                appendBlock(result);
+            }
+        }
+    }
+
+    /**
+     * Loop code generation with scoped context. For each item, the callback
+     * receives a LoopContext (with loop-local variable scope) and the item.
+     * The callback returns a code string to append for that iteration.
+     *
+     * @param items      collection to iterate
+     * @param callback   receives (loopContext, item, isFirst) and returns code string
+     */
+    public <T> void forEach(Iterable<T> items, LoopCallback<T> callback) {
+        Map<String, String> savedContext = new HashMap<>(context);
+        boolean isFirst = true;
+        for (T item : items) {
+            LoopContext loopCtx = new LoopContext(this);
+            String result = callback.generate(loopCtx, item, isFirst);
+            if (result != null && !result.isEmpty()) {
+                appendBlock(result);
+            }
+            // Restore parent context — loop-local additions are discarded
+            context = new HashMap<>(savedContext);
+            isFirst = false;
+        }
+    }
+
+    @FunctionalInterface
+    public interface LoopCallback<T> {
+        String generate(LoopContext ctx, T item, boolean isFirst);
+    }
+
+    /**
+     * Loop-scoped context. Inherits parent context variables but additions
+     * are discarded after each iteration.
+     */
+    public static class LoopContext {
+        private final BodyBuilder body;
+
+        LoopContext(BodyBuilder body) {
+            this.body = body;
+        }
+
+        public LoopContext set(String name, String value) {
+            body.addContext(name, value);
+            return this;
+        }
+    }
+
+    private String resolveVars(String line) {
+        String resolved = line;
+        for (Entry<String, String> entry : context.entrySet()) {
+            resolved = resolved.replace("${" + entry.getKey() + "}", entry.getValue());
+        }
+        return resolved;
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/BodyBuilder.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/BodyBuilder.java
@@ -33,6 +33,10 @@ public class BodyBuilder {
         context.clear();
     }
 
+    public void addContext(Map<String, String> values) {
+        values.forEach(this::addContext);
+    }
+
     public BodyBuilder a(String line) {
         append(line);
         return this;

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
@@ -32,21 +32,23 @@ public class ClearMethod implements CanAddImports {
         BodyBuilder body = new BodyBuilder();
         body.addContext("fieldName", fieldName);
 
-        if (needsDetach) {
+        body.ifElse(needsDetach, () -> {
             String valuesExpr = resolvedType.isMapType()
                     ? "this." + fieldName + ".values()" : "this." + fieldName;
             body.addContext("valuesExpr", valuesExpr);
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    ${valuesExpr}.forEach(item -> {");
-            body.append("        if (item != null) item.detach();");
-            body.append("    });");
-            body.append("    this.${fieldName}.clear();");
-            body.append("}");
-        } else {
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    this.${fieldName}.clear();");
-            body.append("}");
-        }
+            return """
+if (this.${fieldName} != null) {
+    ${valuesExpr}.forEach(item -> {
+        if (item != null) item.detach();
+    });
+    this.${fieldName}.clear();
+}
+""";
+        }, () -> """
+if (this.${fieldName} != null) {
+    this.${fieldName}.clear();
+}
+""");
 
         method.setBody(body.toString());
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/FactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/FactoryMethod.java
@@ -37,9 +37,11 @@ public class FactoryMethod implements CanAddImports {
 
         BodyBuilder body = new BodyBuilder();
         body.addContext("implClass", entityImpl.getName());
-        body.append("${implClass} node = new ${implClass}();");
-        body.append("node._setParent(this);");
-        body.append("return node;");
+        body.appendBlock("""
+                ${implClass} node = new ${implClass}();
+                node._setParent(this);
+                return node;
+                """);
         method.setBody(body.toString());
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
@@ -59,29 +59,31 @@ public class InsertMethod implements CanAddImports {
         body.addContext("propertyName", propertyName);
 
         if (isEntityValue || isPrimitiveValue || isUnionValue) {
-            if (resolvedType.isMapType()) {
+            body.ifElse(resolvedType.isMapType(), () -> {
                 JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
                 javaEntity.addImport(dataModelUtilSource);
                 javaEntity.addImport(LinkedHashMap.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new LinkedHashMap<>();");
-                body.append("    this.${fieldName}.put(name, value);");
-                body.append("} else {");
-                body.append("    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);");
-                body.append("}");
-            } else {
+                return """
+if (this.${fieldName} == null) {
+    this.${fieldName} = new LinkedHashMap<>();
+    this.${fieldName}.put(name, value);
+} else {
+    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);
+}
+""";
+            }, () -> {
                 JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
                 javaEntity.addImport(dataModelUtilSource);
                 javaEntity.addImport(ArrayList.class);
-
-                body.append("if (this.${fieldName} == null) {");
-                body.append("    this.${fieldName} = new ArrayList<>();");
-                body.append("    this.${fieldName}.add(value);");
-                body.append("} else {");
-                body.append("    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);");
-                body.append("}");
-            }
+                return """
+if (this.${fieldName} == null) {
+    this.${fieldName} = new ArrayList<>();
+    this.${fieldName}.add(value);
+} else {
+    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);
+}
+""";
+            });
 
             if (parentBlock != null) {
                 parentBlock.appendTo(body);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -83,28 +83,28 @@ public class ParentAttachmentBlock extends CodeBlock {
      * Union attachment for setter (standard) - has full isEntity/isEntityList/isEntityMap/else dispatch.
      */
     private void appendUnionStandardAttachment(BodyBuilder body) {
-        body.addContext("quotedName", "\"" + propertyName + "\"");
+        body.addContext("propertyName", propertyName);
         body.appendBlock("""
                 if (value != null) {
                     if (value.isEntity()) {
                         ((NodeImpl) value)._setParent(this);
-                        ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                        ((NodeImpl) value)._setParentPropertyName("${propertyName}");
                         ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
                     } else if (value.isEntityList()) {
                         ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
                         ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
                         List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
                         for (Object entity : entityList) {
                             if (entity != null) {
                                 ((NodeImpl) entity)._setParent(this);
-                                ((NodeImpl) entity)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) entity)._setParentPropertyName("${propertyName}");
                                 ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
                             }
                         }
                     } else if (value.isEntityMap()) {
                         ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
                         ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
                         Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
                         Collection<String> keys = entityMap.keySet();
@@ -112,14 +112,14 @@ public class ParentAttachmentBlock extends CodeBlock {
                             NodeImpl entity = (NodeImpl) entityMap.get(key);
                             if (entity != null) {
                                 entity._setParent(this);
-                                entity._setParentPropertyName(${quotedName});
+                                entity._setParentPropertyName("${propertyName}");
                                 entity._setParentPropertyType(ParentPropertyType.map);
                                 entity._setMapPropertyName(key);
                             }
                         }
                     } else {
                         ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
                         ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
                     }
                 }
@@ -132,7 +132,7 @@ public class ParentAttachmentBlock extends CodeBlock {
     private void appendUnionCollectionAttachment(BodyBuilder body) {
         String parentPropertyType = kindToString();
         body.addContext(Map.of(
-                "quotedName", "\"" + propertyName + "\"",
+                "propertyName", propertyName,
                 "parentPropertyType", parentPropertyType
         ));
         body.ifElse(kind == ParentPropertyKind.MAP,
@@ -140,12 +140,12 @@ public class ParentAttachmentBlock extends CodeBlock {
                         if (value != null) {
                             if (value.isEntity()) {
                                 ((NodeImpl) value)._setParent(this);
-                                ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) value)._setParentPropertyName("${propertyName}");
                                 ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
                                 ((NodeImpl) value)._setMapPropertyName(name);
                             } else {
                                 ((UnionValueImpl<?>) value)._setParent(this);
-                                ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                                ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
                                 ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
                                 ((UnionValueImpl<?>) value)._setMapPropertyName(name);
                             }
@@ -155,11 +155,11 @@ public class ParentAttachmentBlock extends CodeBlock {
                         if (value != null) {
                             if (value.isEntity()) {
                                 ((NodeImpl) value)._setParent(this);
-                                ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) value)._setParentPropertyName("${propertyName}");
                                 ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
                             } else {
                                 ((UnionValueImpl<?>) value)._setParent(this);
-                                ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                                ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
                                 ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
                             }
                         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -57,59 +57,73 @@ public class ParentAttachmentBlock extends CodeBlock {
     private void appendEntityAttachment(BodyBuilder body) {
         String parentPropertyType = kindToString();
         String quotedName = propertyName != null ? "\"" + propertyName + "\"" : "null";
-        body.append("if (value != null) {");
-        body.append("    ((NodeImpl) value)._setParent(this);");
-        body.append("    ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("    ((NodeImpl) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
-        if (kind == ParentPropertyKind.MAP) {
-            body.append("    ((NodeImpl) value)._setMapPropertyName(name);");
-        }
-        body.append("}");
+        body.addContext(Map.of(
+                "quotedName", quotedName,
+                "parentPropertyType", parentPropertyType
+        ));
+        body.ifElse(kind == ParentPropertyKind.MAP,
+                () -> """
+                        if (value != null) {
+                            ((NodeImpl) value)._setParent(this);
+                            ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                            ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                            ((NodeImpl) value)._setMapPropertyName(name);
+                        }
+                        """,
+                () -> """
+                        if (value != null) {
+                            ((NodeImpl) value)._setParent(this);
+                            ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                            ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                        }
+                        """);
     }
 
     /**
      * Union attachment for setter (standard) - has full isEntity/isEntityList/isEntityMap/else dispatch.
      */
     private void appendUnionStandardAttachment(BodyBuilder body) {
-        String quotedName = "\"" + propertyName + "\"";
-        body.append("if (value != null) {");
-        body.append("    if (value.isEntity()) {");
-        body.append("        ((NodeImpl) value)._setParent(this);");
-        body.append("        ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);");
-        body.append("    } else if (value.isEntityList()) {");
-        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-        body.append("        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();");
-        body.append("        for (Object entity : entityList) {");
-        body.append("            if (entity != null) {");
-        body.append("                ((NodeImpl) entity)._setParent(this);");
-        body.append("                ((NodeImpl) entity)._setParentPropertyName(" + quotedName + ");");
-        body.append("                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);");
-        body.append("            }");
-        body.append("        }");
-        body.append("    } else if (value.isEntityMap()) {");
-        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-        body.append("        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();");
-        body.append("        Collection<String> keys = entityMap.keySet();");
-        body.append("        for (String key : keys) {");
-        body.append("            NodeImpl entity = (NodeImpl) entityMap.get(key);");
-        body.append("            if (entity != null) {");
-        body.append("                entity._setParent(this);");
-        body.append("                entity._setParentPropertyName(" + quotedName + ");");
-        body.append("                entity._setParentPropertyType(ParentPropertyType.map);");
-        body.append("                entity._setMapPropertyName(key);");
-        body.append("            }");
-        body.append("        }");
-        body.append("    } else {");
-        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);");
-        body.append("    }");
-        body.append("}");
+        body.addContext("quotedName", "\"" + propertyName + "\"");
+        body.appendBlock("""
+                if (value != null) {
+                    if (value.isEntity()) {
+                        ((NodeImpl) value)._setParent(this);
+                        ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+                    } else if (value.isEntityList()) {
+                        ((UnionValueImpl<?>) value)._setParent(this);
+                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
+                        for (Object entity : entityList) {
+                            if (entity != null) {
+                                ((NodeImpl) entity)._setParent(this);
+                                ((NodeImpl) entity)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+                            }
+                        }
+                    } else if (value.isEntityMap()) {
+                        ((UnionValueImpl<?>) value)._setParent(this);
+                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
+                        Collection<String> keys = entityMap.keySet();
+                        for (String key : keys) {
+                            NodeImpl entity = (NodeImpl) entityMap.get(key);
+                            if (entity != null) {
+                                entity._setParent(this);
+                                entity._setParentPropertyName(${quotedName});
+                                entity._setParentPropertyType(ParentPropertyType.map);
+                                entity._setMapPropertyName(key);
+                            }
+                        }
+                    } else {
+                        ((UnionValueImpl<?>) value)._setParent(this);
+                        ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                    }
+                }
+                """);
     }
 
     /**
@@ -117,24 +131,39 @@ public class ParentAttachmentBlock extends CodeBlock {
      */
     private void appendUnionCollectionAttachment(BodyBuilder body) {
         String parentPropertyType = kindToString();
-        String quotedName = "\"" + propertyName + "\"";
-        body.append("if (value != null) {");
-        body.append("    if (value.isEntity()) {");
-        body.append("        ((NodeImpl) value)._setParent(this);");
-        body.append("        ((NodeImpl) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
-        if (kind == ParentPropertyKind.MAP) {
-            body.append("        ((NodeImpl) value)._setMapPropertyName(name);");
-        }
-        body.append("    } else {");
-        body.append("        ((UnionValueImpl<?>) value)._setParent(this);");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyName(" + quotedName + ");");
-        body.append("        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType." + parentPropertyType + ");");
-        if (kind == ParentPropertyKind.MAP) {
-            body.append("        ((UnionValueImpl<?>) value)._setMapPropertyName(name);");
-        }
-        body.append("    }");
-        body.append("}");
+        body.addContext(Map.of(
+                "quotedName", "\"" + propertyName + "\"",
+                "parentPropertyType", parentPropertyType
+        ));
+        body.ifElse(kind == ParentPropertyKind.MAP,
+                () -> """
+                        if (value != null) {
+                            if (value.isEntity()) {
+                                ((NodeImpl) value)._setParent(this);
+                                ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                                ((NodeImpl) value)._setMapPropertyName(name);
+                            } else {
+                                ((UnionValueImpl<?>) value)._setParent(this);
+                                ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                                ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                                ((UnionValueImpl<?>) value)._setMapPropertyName(name);
+                            }
+                        }
+                        """,
+                () -> """
+                        if (value != null) {
+                            if (value.isEntity()) {
+                                ((NodeImpl) value)._setParent(this);
+                                ((NodeImpl) value)._setParentPropertyName(${quotedName});
+                                ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                            } else {
+                                ((UnionValueImpl<?>) value)._setParent(this);
+                                ((UnionValueImpl<?>) value)._setParentPropertyName(${quotedName});
+                                ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                            }
+                        }
+                        """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/RemoveMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/RemoveMethod.java
@@ -32,21 +32,27 @@ public class RemoveMethod implements CanAddImports {
         boolean needsDetach = resolvedValueType != null
                 && (resolvedValueType.isEntityType() || resolvedValueType.isUnionType());
 
-        if (resolvedType.isListType()) {
-            body.append("if (this.${fieldName} != null) {");
+        body.ifElse(resolvedType.isListType(), () -> {
             if (needsDetach) {
-                body.append("    if (value != null && this.${fieldName}.remove(value)) {");
-                body.append("        value.detach();");
-                body.append("    }");
+                return """
+if (this.${fieldName} != null) {
+    if (value != null && this.${fieldName}.remove(value)) {
+        value.detach();
+    }
+}
+""";
             } else {
-                body.append("    this.${fieldName}.remove(value);");
+                return """
+if (this.${fieldName} != null) {
+    this.${fieldName}.remove(value);
+}
+""";
             }
-            body.append("}");
-        } else {
-            body.append("if (this.${fieldName} != null) {");
-            body.append("    this.${fieldName}.remove(name);");
-            body.append("}");
-        }
+        }, () -> """
+if (this.${fieldName} != null) {
+    this.${fieldName}.remove(name);
+}
+""");
 
         method.setBody(body.toString());
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.cloner;
 
+import java.util.Map;
+
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
@@ -44,18 +46,22 @@ public class CloneEntityPropertyBlock extends CodeBlock {
         propertyTypeJavaEntity = resolved.javaInterface();
         clonerClassSource.addImport(propertyTypeJavaEntity);
 
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
-        body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
-        body.addContext("entityType", propertyTypeJavaEntity.getName());
+        body.addContext(Map.of(
+                "getterMethodName", ctx.getterMethodName(property),
+                "setterMethodName", ctx.setterMethodName(property),
+                "createMethodName", ctx.createMethodName(resolved.entityModel()),
+                "cloneMethodName", cloneMethodName(resolved.entityModel()),
+                "entityType", propertyTypeJavaEntity.getName()
+        ));
 
-        body.append("{");
-        body.append("    if (source.${getterMethodName}() != null) {");
-        body.append("        target.${setterMethodName}(target.${createMethodName}());");
-        body.append("        this.${cloneMethodName}((${entityType}) source.${getterMethodName}(), (${entityType}) target.${getterMethodName}());");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    if (source.${getterMethodName}() != null) {
+                        target.${setterMethodName}(target.${createMethodName}());
+                        this.${cloneMethodName}((${entityType}) source.${getterMethodName}(), (${entityType}) target.${getterMethodName}());
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -2,6 +2,7 @@ package io.apitomy.umg.pipe.java.method.cloner;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
@@ -40,20 +41,23 @@ public class CloneListPropertyBlock extends CodeBlock {
         PropertyModel property = propertyWithOrigin.getProperty();
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
 
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-
         if (listValueType.isPrimitiveType()) {
             clonerClassSource.addImport(List.class);
             clonerClassSource.addImport(ArrayList.class);
-            body.addContext("setterMethodName", ctx.setterMethodName(property));
-            body.addContext("valueType", PrimitiveTypeHelper.determineValueType(listValueType, ctx, clonerClassSource));
+            body.addContext(Map.of(
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "valueType", PrimitiveTypeHelper.determineValueType(listValueType, ctx, clonerClassSource)
+            ));
 
-            body.append("{");
-            body.append("    List<${valueType}> srcList = source.${getterMethodName}();");
-            body.append("    if (srcList != null) {");
-            body.append("        target.${setterMethodName}(new ArrayList<>(srcList));");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        List<${valueType}> srcList = source.${getterMethodName}();
+                        if (srcList != null) {
+                            target.${setterMethodName}(new ArrayList<>(srcList));
+                        }
+                    }
+                    """);
         } else if (listValueType.isEntityType()) {
             var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
             if (resolved == null) {
@@ -64,22 +68,27 @@ public class CloneListPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(commonEntityTypeJavaModel);
             clonerClassSource.addImport(List.class);
 
-            body.addContext("entityJavaType", resolved.javaInterface().getName());
-            body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-            body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
-            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(resolved.entityModel()));
-            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+            body.addContext(Map.of(
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "entityJavaType", resolved.javaInterface().getName(),
+                    "commonEntityType", commonEntityTypeJavaModel.getName(),
+                    "createMethodName", ctx.createMethodName(resolved.entityModel()),
+                    "cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(resolved.entityModel()),
+                    "addMethodName", ctx.addMethodName(ctx.singularize(property.getName()))
+            ));
 
-            body.append("{");
-            body.append("    List<? extends ${commonEntityType}> srcList = source.${getterMethodName}();");
-            body.append("    if (srcList != null && !srcList.isEmpty()) {");
-            body.append("        srcList.forEach(srcItem -> {");
-            body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-            body.append("            this.${cloneMethodName}((${entityJavaType}) srcItem, tgtItem);");
-            body.append("            target.${addMethodName}(tgtItem);");
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        List<? extends ${commonEntityType}> srcList = source.${getterMethodName}();
+                        if (srcList != null && !srcList.isEmpty()) {
+                            srcList.forEach(srcItem -> {
+                                ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
+                                this.${cloneMethodName}((${entityJavaType}) srcItem, tgtItem);
+                                target.${addMethodName}(tgtItem);
+                            });
+                        }
+                    }
+                    """);
         } else {
             ctx.warn("LIST Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -40,20 +40,23 @@ public class CloneMapPropertyBlock extends CodeBlock {
         PropertyModel property = propertyWithOrigin.getProperty();
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
 
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-
         if (mapValueType.isPrimitiveType()) {
             clonerClassSource.addImport(Map.class);
             clonerClassSource.addImport(LinkedHashMap.class);
-            body.addContext("setterMethodName", ctx.setterMethodName(property));
-            body.addContext("valueType", PrimitiveTypeHelper.determineValueType(mapValueType, ctx, clonerClassSource));
+            body.addContext(Map.of(
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "valueType", PrimitiveTypeHelper.determineValueType(mapValueType, ctx, clonerClassSource)
+            ));
 
-            body.append("{");
-            body.append("    Map<String, ${valueType}> srcMap = source.${getterMethodName}();");
-            body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-            body.append("        target.${setterMethodName}(new LinkedHashMap<>(srcMap));");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        Map<String, ${valueType}> srcMap = source.${getterMethodName}();
+                        if (srcMap != null && !srcMap.isEmpty()) {
+                            target.${setterMethodName}(new LinkedHashMap<>(srcMap));
+                        }
+                    }
+                    """);
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
             var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
@@ -66,22 +69,27 @@ public class CloneMapPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(resolved.javaInterface());
             clonerClassSource.addImport(commonEntityTypeJavaModel);
 
-            body.addContext("entityJavaType", resolved.javaInterface().getName());
-            body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-            body.addContext("createMethodName", "create" + entityTypeName);
-            body.addContext("cloneMethodName", "clone" + entityTypeName);
-            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+            body.addContext(Map.of(
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "entityJavaType", resolved.javaInterface().getName(),
+                    "commonEntityType", commonEntityTypeJavaModel.getName(),
+                    "createMethodName", "create" + entityTypeName,
+                    "cloneMethodName", "clone" + entityTypeName,
+                    "addMethodName", ctx.addMethodName(ctx.singularize(property.getName()))
+            ));
 
-            body.append("{");
-            body.append("    Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();");
-            body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-            body.append("        srcMap.keySet().forEach(name -> {");
-            body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-            body.append("            this.${cloneMethodName}((${entityJavaType}) srcMap.get(name), tgtItem);");
-            body.append("            target.${addMethodName}(name, tgtItem);");
-            body.append("        });");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();
+                        if (srcMap != null && !srcMap.isEmpty()) {
+                            srcMap.keySet().forEach(name -> {
+                                ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
+                                this.${cloneMethodName}((${entityJavaType}) srcMap.get(name), tgtItem);
+                                target.${addMethodName}(name, tgtItem);
+                            });
+                        }
+                    }
+                    """);
         } else {
             ctx.warn("MAP Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -3,6 +3,7 @@ package io.apitomy.umg.pipe.java.method.cloner;
 import io.apitomy.umg.pipe.java.AbstractJavaStage;
 
 import java.util.List;
+import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
@@ -46,9 +47,11 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
 
         var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);
-        body.addContext("unionJavaType", unionJavaType.getSimpleName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+        body.addContext(Map.of(
+                "unionJavaType", unionJavaType.getSimpleName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "addMethodName", ctx.addMethodName(ctx.singularize(property.getName()))
+        ));
 
         body.append("{");
         body.append("    List<${unionJavaType}> srcList = source.${getterMethodName}();");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -46,9 +46,11 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
 
         var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);
-        body.addContext("unionJavaType", unionJavaType.getSimpleName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
+        body.addContext(Map.of(
+                "unionJavaType", unionJavaType.getSimpleName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "addMethodName", ctx.addMethodName(ctx.singularize(property.getName()))
+        ));
 
         body.append("{");
         body.append("    Map<String, ${unionJavaType}> srcMap = source.${getterMethodName}();");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -4,6 +4,7 @@ import io.apitomy.umg.pipe.java.AbstractJavaStage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -44,9 +45,11 @@ public class CloneUnionPropertyBlock extends CodeBlock {
         NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
         io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = getEffectiveUnionType(property);
 
-        body.addContext("unionJavaType", getUnionJavaTypeName(property, effectiveUnionType));
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
+        body.addContext(Map.of(
+                "unionJavaType", getUnionJavaTypeName(property, effectiveUnionType),
+                "getterMethodName", ctx.getterMethodName(property),
+                "setterMethodName", ctx.setterMethodName(property)
+        ));
 
         body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -48,23 +48,23 @@ public class CloneUnionPropertyBlock extends CodeBlock {
         body.addContext("getterMethodName", ctx.getterMethodName(property));
         body.addContext("setterMethodName", ctx.setterMethodName(property));
 
-        body.append("{");
-        body.append("    ${unionJavaType} srcUnion = source.${getterMethodName}();");
-        body.append("    if (srcUnion != null) {");
+        body.appendBlock("""
+{
+    ${unionJavaType} srcUnion = source.${getterMethodName}();
+    if (srcUnion != null) {
+""");
 
         // Sort types alphabetically to match the old UnionPropertyType behavior
         List<Type> sortedTypes = effectiveUnionType.getTypes().stream()
                 .sorted(UnionVariantComparator.INSTANCE)
                 .collect(Collectors.toList());
-        sortedTypes.forEach(nestedType -> {
+        body.forEach(sortedTypes, (loopCtx, nestedType, isFirst) -> {
             String typeName = AbstractJavaStage.getTypeName(nestedType);
             String isMethodName = "is" + typeName;
             String asMethodName = "as" + typeName;
 
-            body.addContext("isMethodName", isMethodName);
-            body.addContext("asMethodName", asMethodName);
-
-            body.append("        if (srcUnion.${isMethodName}()) {");
+            loopCtx.set("isMethodName", isMethodName);
+            loopCtx.set("asMethodName", asMethodName);
 
             if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
                 String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
@@ -74,9 +74,13 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                 if (unionValueInterface != null && unionValueClass != null) {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
-                    body.addContext("unionValueInterfaceName", unionValueInterface.getName());
-                    body.addContext("unionValueClassName", unionValueClass.getName());
-                    body.append("            target.${setterMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
+                    loopCtx.set("unionValueInterfaceName", unionValueInterface.getName());
+                    loopCtx.set("unionValueClassName", unionValueClass.getName());
+                    return """
+        if (srcUnion.${isMethodName}()) {
+            target.${setterMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));
+        }
+""";
                 }
             } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isPrimitiveType()) {
                 String unionValueName = AbstractJavaStage.getTypeName(nestedType);
@@ -88,9 +92,13 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
                     clonerClassSource.addImport(ArrayList.class);
-                    body.addContext("unionValueInterfaceName", unionValueInterface.getName());
-                    body.addContext("unionValueClassName", unionValueClass.getName());
-                    body.append("            target.${setterMethodName}(new ${unionValueClassName}(new ArrayList<>(srcUnion.${asMethodName}())));");
+                    loopCtx.set("unionValueInterfaceName", unionValueInterface.getName());
+                    loopCtx.set("unionValueClassName", unionValueClass.getName());
+                    return """
+        if (srcUnion.${isMethodName}()) {
+            target.${setterMethodName}(new ${unionValueClassName}(new ArrayList<>(srcUnion.${asMethodName}())));
+        }
+""";
                 }
             } else if (nestedType.isEntityType()) {
                 NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
@@ -102,12 +110,16 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                     if (entityJavaSource != null && entityImplSource != null) {
                         clonerClassSource.addImport(entityJavaSource);
                         clonerClassSource.addImport(entityImplSource);
-                        body.addContext("entityType", entityJavaSource.getName());
-                        body.addContext("entityImplType", entityImplSource.getName());
-                        body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(nestedTypeEntity));
-                        body.append("            ${entityType} tgtEntity = new ${entityImplType}();");
-                        body.append("            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtEntity);");
-                        body.append("            target.${setterMethodName}(tgtEntity);");
+                        loopCtx.set("entityType", entityJavaSource.getName());
+                        loopCtx.set("entityImplType", entityImplSource.getName());
+                        loopCtx.set("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(nestedTypeEntity));
+                        return """
+        if (srcUnion.${isMethodName}()) {
+            ${entityType} tgtEntity = new ${entityImplType}();
+            this.${cloneMethodName}((${entityType}) srcUnion.${asMethodName}(), tgtEntity);
+            target.${setterMethodName}(tgtEntity);
+        }
+""";
                     }
                 }
             } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isEntityType()) {
@@ -134,19 +146,23 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                             clonerClassSource.addImport(unionValueClass);
                             clonerClassSource.addImport(List.class);
                             clonerClassSource.addImport(ArrayList.class);
-                            body.addContext("listItemType", listItemEntitySource.getName());
-                            body.addContext("createMethodName", ctx.createMethodName(listItemEntity));
-                            body.addContext("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(listItemEntity));
-                            body.addContext("unionValueClassName", unionValueClass.getName());
-                            body.append("            List<${listItemType}> clonedList = new ArrayList<>();");
-                            body.append("            srcUnion.${asMethodName}().forEach(srcItem -> {");
-                            body.append("                ${listItemType} tgtItem = (${listItemType}) target.${createMethodName}();");
-                            body.append("                this.${cloneMethodName}((${listItemType}) srcItem, tgtItem);");
-                            body.append("                clonedList.add(tgtItem);");
-                            body.append("            });");
-                            body.append("            @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
-                            body.append("            ${unionValueClassName} unionValue = new ${unionValueClassName}((List) clonedList);");
-                            body.append("            target.${setterMethodName}(unionValue);");
+                            loopCtx.set("listItemType", listItemEntitySource.getName());
+                            loopCtx.set("createMethodName", ctx.createMethodName(listItemEntity));
+                            loopCtx.set("cloneMethodName", CloneEntityPropertyBlock.cloneMethodName(listItemEntity));
+                            loopCtx.set("unionValueClassName", unionValueClass.getName());
+                            return """
+        if (srcUnion.${isMethodName}()) {
+            List<${listItemType}> clonedList = new ArrayList<>();
+            srcUnion.${asMethodName}().forEach(srcItem -> {
+                ${listItemType} tgtItem = (${listItemType}) target.${createMethodName}();
+                this.${cloneMethodName}((${listItemType}) srcItem, tgtItem);
+                clonedList.add(tgtItem);
+            });
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            ${unionValueClassName} unionValue = new ${unionValueClassName}((List) clonedList);
+            target.${setterMethodName}(unionValue);
+        }
+""";
                         }
                     }
                 }
@@ -154,11 +170,13 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                 ctx.warn("UNION property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
             }
 
-            body.append("        }");
+            return "";
         });
 
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+    }
+}
+""");
 
         var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -41,13 +43,15 @@ public class ReadEntityPropertyBlock extends CodeBlock {
         readerClassSource.addImport(resolved.javaInterface());
         readerClassSource.addImport(JsonNode.class);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
-        body.addContext("propertyEntityType", resolved.javaInterface().getName());
-        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "setterMethodName", ctx.setterMethodName(property),
+                "createMethodName", ctx.createMethodName(resolved.entityModel()),
+                "getterMethodName", ctx.getterMethodName(property),
+                "readMethodName", ctx.readMethodName(resolved.entityModel()),
+                "propertyEntityType", resolved.javaInterface().getName(),
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+        ));
 
         body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -49,14 +49,16 @@ public class ReadEntityPropertyBlock extends CodeBlock {
         body.addContext("propertyEntityType", resolved.javaInterface().getName());
         body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
-        body.append("{");
-        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-        body.append("    if (JsonUtil.isObject(${varName})) {");
-        body.append("        node.${setterMethodName}(node.${createMethodName}());");
-        body.append("        ${readMethodName}(JsonUtil.toObject(${varName}), (${propertyEntityType}) node.${getterMethodName}());");
-        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.isObject(${varName})) {
+        node.${setterMethodName}(node.${createMethodName}());
+        ${readMethodName}(JsonUtil.toObject(${varName}), (${propertyEntityType}) node.${getterMethodName}());
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -2,6 +2,7 @@ package io.apitomy.umg.pipe.java.method.reader;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -39,9 +40,6 @@ public class ReadListPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("propertyName", property.getName());
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
@@ -51,10 +49,14 @@ public class ReadListPropertyBlock extends CodeBlock {
             String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, ctx);
             String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, ctx, readerClassSource);
             String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, ctx, readerClassSource);
-            body.addContext("expectedType", expectedType);
-            body.addContext("toConversionMethod", toConversionMethod);
-            body.addContext("elementValueType", elementValueType);
-            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "expectedType", expectedType,
+                    "toConversionMethod", toConversionMethod,
+                    "elementValueType", elementValueType,
+                    "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+            ));
 
             body.appendBlock("""
 {
@@ -79,11 +81,15 @@ public class ReadListPropertyBlock extends CodeBlock {
             readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(List.class);
 
-            body.addContext("listValueJavaType", resolved.javaInterface().getName());
-            body.addContext("createMethodName", ctx.createMethodName(resolved.entityModel()));
-            body.addContext("readMethodName", ctx.readMethodName(resolved.entityModel()));
-            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
-            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "listValueJavaType", resolved.javaInterface().getName(),
+                    "createMethodName", ctx.createMethodName(resolved.entityModel()),
+                    "readMethodName", ctx.readMethodName(resolved.entityModel()),
+                    "addMethodName", ctx.addMethodName(ctx.singularize(property.getName())),
+                    "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+            ));
 
             body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -56,18 +56,20 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.addContext("elementValueType", elementValueType);
             body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
-            body.append("{");
-            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-            body.append("    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, \"${expectedType}\")) {");
-            body.append("        List<${elementValueType}> items = new ArrayList<>();");
-            body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
-            body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
-            body.append("            items.add(JsonUtil.${toConversionMethod}(_nodes.get(_i)));");
-            body.append("        }");
-            body.append("        node.${setterMethodName}(items);");
-            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, "${expectedType}")) {
+        List<${elementValueType}> items = new ArrayList<>();
+        List<JsonNode> _nodes = JsonUtil.toList(${varName});
+        for (int _i = 0; _i < _nodes.size(); _i++) {
+            items.add(JsonUtil.${toConversionMethod}(_nodes.get(_i)));
+        }
+        node.${setterMethodName}(items);
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
         } else if (listValueType.isEntityType()) {
             var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
             if (resolved == null) {
@@ -83,19 +85,21 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
             body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
-            body.append("{");
-            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-            body.append("    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, \"object\")) {");
-            body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
-            body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
-            body.append("            ObjectNode object = JsonUtil.toObject(_nodes.get(_i));");
-            body.append("            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();");
-            body.append("            node.${addMethodName}(model);");
-            body.append("            this.${readMethodName}(object, model);");
-            body.append("        }");
-            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, "object")) {
+        List<JsonNode> _nodes = JsonUtil.toList(${varName});
+        for (int _i = 0; _i < _nodes.size(); _i++) {
+            ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
+            ${listValueJavaType} model = (${listValueJavaType}) node.${createMethodName}();
+            node.${addMethodName}(model);
+            this.${readMethodName}(object, model);
+        }
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
         } else {
             ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
             ctx.warn("       property type: " + property.getResolvedType());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -41,9 +41,6 @@ public class ReadMapPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("propertyName", property.getName());
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
@@ -55,10 +52,14 @@ public class ReadMapPropertyBlock extends CodeBlock {
             String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, ctx);
             String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, ctx, readerClassSource);
             String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, ctx, readerClassSource);
-            body.addContext("expectedType", expectedType);
-            body.addContext("toConversionMethod", toConversionMethod);
-            body.addContext("elementValueType", elementValueType);
-            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "expectedType", expectedType,
+                    "toConversionMethod", toConversionMethod,
+                    "elementValueType", elementValueType,
+                    "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+            ));
 
             body.appendBlock("""
 {
@@ -86,11 +87,15 @@ public class ReadMapPropertyBlock extends CodeBlock {
             readerClassSource.addImport(ObjectNode.class);
             readerClassSource.addImport(List.class);
 
-            body.addContext("mapValueJavaType", resolved.javaInterface().getName());
-            body.addContext("createMethodName", "create" + entityTypeName);
-            body.addContext("readMethodName", "read" + entityTypeName);
-            body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
-            body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "setterMethodName", ctx.setterMethodName(property),
+                    "mapValueJavaType", resolved.javaInterface().getName(),
+                    "createMethodName", "create" + entityTypeName,
+                    "readMethodName", "read" + entityTypeName,
+                    "addMethodName", ctx.addMethodName(ctx.singularize(property.getName())),
+                    "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+            ));
 
             body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -60,19 +60,21 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.addContext("elementValueType", elementValueType);
             body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
-            body.append("{");
-            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-            body.append("    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch(JsonUtil.toObject(${varName}), \"${expectedType}\")) {");
-            body.append("        Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
-            body.append("        List<String> _keys = JsonUtil.keys(JsonUtil.toObject(${varName}));");
-            body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-            body.append("            String _key = _keys.get(_i);");
-            body.append("            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty(JsonUtil.toObject(${varName}), _key)));");
-            body.append("        }");
-            body.append("        node.${setterMethodName}(items);");
-            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch(JsonUtil.toObject(${varName}), "${expectedType}")) {
+        Map<String, ${elementValueType}> items = new LinkedHashMap<>();
+        List<String> _keys = JsonUtil.keys(JsonUtil.toObject(${varName}));
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String _key = _keys.get(_i);
+            items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty(JsonUtil.toObject(${varName}), _key)));
+        }
+        node.${setterMethodName}(items);
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
             var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
@@ -90,23 +92,25 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
             body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
 
-            body.append("{");
-            body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-            body.append("    if (JsonUtil.isObject(${varName})) {");
-            body.append("        ObjectNode _obj = JsonUtil.toObject(${varName});");
-            body.append("        List<String> _keys = JsonUtil.keys(_obj);");
-            body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-            body.append("            String _key = _keys.get(_i);");
-            body.append("            JsonNode _val = JsonUtil.getProperty(_obj, _key);");
-            body.append("            if (JsonUtil.isObject(_val)) {");
-            body.append("                ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();");
-            body.append("                node.${addMethodName}(_key, model);");
-            body.append("                this.${readMethodName}(JsonUtil.toObject(_val), model);");
-            body.append("            }");
-            body.append("        }");
-            body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.isObject(${varName})) {
+        ObjectNode _obj = JsonUtil.toObject(${varName});
+        List<String> _keys = JsonUtil.keys(_obj);
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String _key = _keys.get(_i);
+            JsonNode _val = JsonUtil.getProperty(_obj, _key);
+            if (JsonUtil.isObject(_val)) {
+                ${mapValueJavaType} model = (${mapValueJavaType}) node.${createMethodName}();
+                node.${addMethodName}(_key, model);
+                this.${readMethodName}(JsonUtil.toObject(_val), model);
+            }
+        }
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
         } else {
             ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
             ctx.warn("       property type: " + property.getResolvedType());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -31,16 +33,17 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = propertyWithOrigin.getProperty();
-        body.addContext("propertyName", property.getName());
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
-
         readerClassSource.addImport(JsonNode.class);
 
         String isCheckMethod = PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), ctx, readerClassSource);
         String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), ctx, readerClassSource);
-        body.addContext("isCheckMethod", isCheckMethod);
-        body.addContext("toConversionMethod", toConversionMethod);
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "setterMethodName", ctx.setterMethodName(property),
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"),
+                "isCheckMethod", isCheckMethod,
+                "toConversionMethod", toConversionMethod
+        ));
 
         body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -42,13 +42,15 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
         body.addContext("isCheckMethod", isCheckMethod);
         body.addContext("toConversionMethod", toConversionMethod);
 
-        body.append("{");
-        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-        body.append("    if (JsonUtil.${isCheckMethod}(${varName})) {");
-        body.append("        node.${setterMethodName}(JsonUtil.${toConversionMethod}(${varName}));");
-        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+{
+    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+    if (JsonUtil.${isCheckMethod}(${varName})) {
+        node.${setterMethodName}(JsonUtil.${toConversionMethod}(${varName}));
+        JsonUtil.removeProperty(json, "${propertyName}");
+    }
+}
+""");
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -2,6 +2,7 @@ package io.apitomy.umg.pipe.java.method.reader;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -44,32 +45,35 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
         readerClassSource.addImport(ArrayList.class);
         valueJt.addImportsTo(readerClassSource);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
-        body.addContext("readMethodName", readMethodName);
-        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "addMethodName", ctx.addMethodName(ctx.singularize(property.getName())),
+                "readMethodName", readMethodName,
+                "unionJavaType", valueJt.toJavaTypeString(),
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+        ));
 
-        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
-
-        body.append("{");
-        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-        body.append("    if (JsonUtil.isArray(${varName})) {");
-        body.append("        List<JsonNode> _nodes = JsonUtil.toList(${varName});");
-        body.append("        List<${unionJavaType}> _items = new ArrayList<>();");
-        body.append("        boolean _valid = true;");
-        body.append("        for (int _i = 0; _i < _nodes.size(); _i++) {");
-        body.append("            ${unionJavaType} _result = this.${readMethodName}(_nodes.get(_i), null);");
-        body.append("            if (_result == null) { _valid = false; break; }");
-        body.append("            _items.add(_result);");
-        body.append("        }");
-        body.append("        if (_valid) {");
-        body.append("            for (int _i = 0; _i < _items.size(); _i++) {");
-        body.append("                node.${addMethodName}(_items.get(_i));");
-        body.append("            }");
-        body.append("            JsonUtil.removeProperty(json, \"${propertyName}\");");
-        body.append("        }");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+                    if (JsonUtil.isArray(${varName})) {
+                        List<JsonNode> _nodes = JsonUtil.toList(${varName});
+                        List<${unionJavaType}> _items = new ArrayList<>();
+                        boolean _valid = true;
+                        for (int _i = 0; _i < _nodes.size(); _i++) {
+                            ${unionJavaType} _result = this.${readMethodName}(_nodes.get(_i), null);
+                            if (_result == null) { _valid = false; break; }
+                            _items.add(_result);
+                        }
+                        if (_valid) {
+                            for (int _i = 0; _i < _items.size(); _i++) {
+                                node.${addMethodName}(_items.get(_i));
+                            }
+                            JsonUtil.removeProperty(json, "${propertyName}");
+                        }
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -1,6 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -44,29 +45,32 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
         readerClassSource.addImport(List.class);
         valueJt.addImportsTo(readerClassSource);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("addMethodName", ctx.addMethodName(ctx.singularize(property.getName())));
-        body.addContext("readMethodName", readMethodName);
-        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "addMethodName", ctx.addMethodName(ctx.singularize(property.getName())),
+                "readMethodName", readMethodName,
+                "unionJavaType", valueJt.toJavaTypeString(),
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+        ));
 
-        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
-
-        body.append("{");
-        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-        body.append("    if (JsonUtil.isObject(${varName})) {");
-        body.append("        ObjectNode _obj = JsonUtil.toObject(${varName});");
-        body.append("        List<String> _keys = JsonUtil.keys(_obj);");
-        body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-        body.append("            String _key = _keys.get(_i);");
-        body.append("            JsonNode _val = JsonUtil.getProperty(_obj, _key);");
-        body.append("            if (JsonUtil.isJsonNode(_val)) {");
-        body.append("                ${unionJavaType} model = this.${readMethodName}(_val, null);");
-        body.append("                if (model != null) node.${addMethodName}(_key, model);");
-        body.append("            }");
-        body.append("        }");
-        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+                    if (JsonUtil.isObject(${varName})) {
+                        ObjectNode _obj = JsonUtil.toObject(${varName});
+                        List<String> _keys = JsonUtil.keys(_obj);
+                        for (int _i = 0; _i < _keys.size(); _i++) {
+                            String _key = _keys.get(_i);
+                            JsonNode _val = JsonUtil.getProperty(_obj, _key);
+                            if (JsonUtil.isJsonNode(_val)) {
+                                ${unionJavaType} model = this.${readMethodName}(_val, null);
+                                if (model != null) node.${addMethodName}(_key, model);
+                            }
+                        }
+                        JsonUtil.removeProperty(json, "${propertyName}");
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.reader;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -39,19 +41,22 @@ public class ReadUnionPropertyBlock extends CodeBlock {
         readerClassSource.addImport(JsonNode.class);
         jt.addImportsTo(readerClassSource);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("setterMethodName", ctx.setterMethodName(property));
-        body.addContext("readMethodName", readMethodName);
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "setterMethodName", ctx.setterMethodName(property),
+                "readMethodName", readMethodName,
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+        ));
 
-        body.addContext("varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"));
-
-        body.append("{");
-        body.append("    JsonNode ${varName} = JsonUtil.getProperty(json, \"${propertyName}\");");
-        body.append("    if (JsonUtil.isJsonNode(${varName})) {");
-        body.append("        node.${setterMethodName}(this.${readMethodName}(${varName}, null));");
-        body.append("        JsonUtil.removeProperty(json, \"${propertyName}\");");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
+                    if (JsonUtil.isJsonNode(${varName})) {
+                        node.${setterMethodName}(this.${readMethodName}(${varName}, null));
+                        JsonUtil.removeProperty(json, "${propertyName}");
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -44,13 +44,15 @@ public class WriteEntityPropertyBlock extends CodeBlock {
         body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
         body.addContext("propertyTypeJavaEntity", resolved.javaInterface().getName());
 
-        body.append("{");
-        body.append("    if (node.${getterMethodName}() != null) {");
-        body.append("        ObjectNode object = JsonUtil.objectNode();");
-        body.append("        this.${writeMethodName}((${propertyTypeJavaEntity}) node.${getterMethodName}(), object);");
-        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", object);");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+{
+    if (node.${getterMethodName}() != null) {
+        ObjectNode object = JsonUtil.objectNode();
+        this.${writeMethodName}((${propertyTypeJavaEntity}) node.${getterMethodName}(), object);
+        JsonUtil.setProperty(json, "${propertyName}", object);
+    }
+}
+""");
     }
 
     static String writeMethodName(EntityModel entityModel) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
@@ -39,10 +41,12 @@ public class WriteEntityPropertyBlock extends CodeBlock {
         }
         writerClassSource.addImport(resolved.javaInterface());
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
-        body.addContext("propertyTypeJavaEntity", resolved.javaInterface().getName());
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "writeMethodName", writeMethodName(resolved.entityModel()),
+                "propertyTypeJavaEntity", resolved.javaInterface().getName()
+        ));
 
         body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -1,6 +1,7 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
@@ -57,23 +58,28 @@ public class WriteListPropertyBlock extends CodeBlock {
             writerClassSource.addImport(List.class);
             writerClassSource.addImport(ArrayNode.class);
 
-            body.addContext("propertyName", property.getName());
-            body.addContext("listValueJavaType", resolved.javaInterface().getName());
-            body.addContext("writeMethodName", WriteEntityPropertyBlock.writeMethodName(resolved.entityModel()));
-            body.addContext("listValueCommonJavaType", commonEntityTypeJavaModel.getName());
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "listValueJavaType", resolved.javaInterface().getName(),
+                    "writeMethodName", WriteEntityPropertyBlock.writeMethodName(resolved.entityModel()),
+                    "listValueCommonJavaType", commonEntityTypeJavaModel.getName()
+            ));
 
-            body.append("{");
-            body.append("    List<? extends ${listValueCommonJavaType}> models = node.${getterMethodName}();");
-            body.append("    if (models != null && !models.isEmpty()) {");
-            body.append("        ArrayNode array = JsonUtil.arrayNode();");
-            body.append("        models.forEach(model -> {");
-            body.append("            ObjectNode object = JsonUtil.objectNode();");
-            body.append("            this.${writeMethodName}((${listValueJavaType}) model, object);");
-            body.append("            JsonUtil.addToArray(array, object);");
-            body.append("        });");
-            body.append("        JsonUtil.setProperty(json, \"${propertyName}\", array);");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        List<? extends ${listValueCommonJavaType}> models = node.${getterMethodName}();
+                        if (models != null && !models.isEmpty()) {
+                            ArrayNode array = JsonUtil.arrayNode();
+                            models.forEach(model -> {
+                                ObjectNode object = JsonUtil.objectNode();
+                                this.${writeMethodName}((${listValueJavaType}) model, object);
+                                JsonUtil.addToArray(array, object);
+                            });
+                            JsonUtil.setProperty(json, "${propertyName}", array);
+                        }
+                    }
+                    """);
         } else {
             ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
             ctx.warn("       property type: " + property.getResolvedType());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -56,22 +56,28 @@ public class WriteMapPropertyBlock extends CodeBlock {
             writerClassSource.addImport(resolved.javaInterface());
             writerClassSource.addImport(commonEntityTypeJavaModel);
 
-            body.addContext("mapValueJavaType", resolved.javaInterface().getName());
-            body.addContext("writeMethodName", "write" + entityTypeName);
-            body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
+            body.addContext(Map.of(
+                    "propertyName", property.getName(),
+                    "getterMethodName", ctx.getterMethodName(property),
+                    "mapValueJavaType", resolved.javaInterface().getName(),
+                    "writeMethodName", "write" + entityTypeName,
+                    "mapValueCommonJavaType", commonEntityTypeJavaModel.getName()
+            ));
 
-            body.append("{");
-            body.append("    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();");
-            body.append("    if (models != null && !models.isEmpty()) {");
-            body.append("        ObjectNode object = JsonUtil.objectNode();");
-            body.append("        models.keySet().forEach(jsonName -> {");
-            body.append("            ObjectNode jsonValue = JsonUtil.objectNode();");
-            body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);");
-            body.append("            JsonUtil.setProperty(object, jsonName, jsonValue);");
-            body.append("        });");
-            body.append("        JsonUtil.setProperty(json, \"${propertyName}\", object);");
-            body.append("    }");
-            body.append("}");
+            body.appendBlock("""
+                    {
+                        Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();
+                        if (models != null && !models.isEmpty()) {
+                            ObjectNode object = JsonUtil.objectNode();
+                            models.keySet().forEach(jsonName -> {
+                                ObjectNode jsonValue = JsonUtil.objectNode();
+                                this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);
+                                JsonUtil.setProperty(object, jsonName, jsonValue);
+                            });
+                            JsonUtil.setProperty(json, "${propertyName}", object);
+                        }
+                    }
+                    """);
         } else {
             ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
             ctx.warn("       property type: " + property.getResolvedType());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -32,12 +32,10 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", ctx.getterMethodName(property));
 
-        if (PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), ctx)) {
-            // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly
-            body.append("JsonUtil.setProperty(json, \"${propertyName}\", node.${getterMethodName}());");
-        } else {
-            body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toJsonNode(node.${getterMethodName}()));");
-        }
+        body.ifElse(PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), ctx),
+                // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly
+                () -> "JsonUtil.setProperty(json, \"${propertyName}\", node.${getterMethodName}());",
+                () -> "JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toJsonNode(node.${getterMethodName}()));");
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -1,6 +1,7 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -44,22 +45,26 @@ public class WriteUnionListPropertyBlock extends CodeBlock {
         writerClassSource.addImport(ArrayNode.class);
         writerClassSource.addImport(List.class);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("writeMethodName", writeMethodName);
-        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "writeMethodName", writeMethodName,
+                "unionJavaType", valueJt.toJavaTypeString()
+        ));
 
-        body.append("{");
-        body.append("    List<${unionJavaType}> items = node.${getterMethodName}();");
-        body.append("    if (items != null && !items.isEmpty()) {");
-        body.append("        ArrayNode array = JsonUtil.arrayNode();");
-        body.append("        items.forEach(item -> {");
-        body.append("            JsonNode value = this.${writeMethodName}(item);");
-        body.append("            if (value != null) array.add(value);");
-        body.append("        });");
-        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", array);");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    List<${unionJavaType}> items = node.${getterMethodName}();
+                    if (items != null && !items.isEmpty()) {
+                        ArrayNode array = JsonUtil.arrayNode();
+                        items.forEach(item -> {
+                            JsonNode value = this.${writeMethodName}(item);
+                            if (value != null) array.add(value);
+                        });
+                        JsonUtil.setProperty(json, "${propertyName}", array);
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -45,25 +45,29 @@ public class WriteUnionMapPropertyBlock extends CodeBlock {
         writerClassSource.addImport(ObjectNode.class);
         writerClassSource.addImport(Map.class);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("writeMethodName", writeMethodName);
-        body.addContext("unionJavaType", valueJt.toJavaTypeString());
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "writeMethodName", writeMethodName,
+                "unionJavaType", valueJt.toJavaTypeString()
+        ));
 
         writerClassSource.addImport(Collection.class);
 
-        body.append("{");
-        body.append("    Map<String, ${unionJavaType}> items = node.${getterMethodName}();");
-        body.append("    if (items != null && !items.isEmpty()) {");
-        body.append("        ObjectNode mapJson = JsonUtil.objectNode();");
-        body.append("        Collection<String> keys = items.keySet();");
-        body.append("        keys.forEach(key -> {");
-        body.append("            JsonNode value = this.${writeMethodName}(items.get(key));");
-        body.append("            if (value != null) JsonUtil.setProperty(mapJson, key, value);");
-        body.append("        });");
-        body.append("        JsonUtil.setProperty(json, \"${propertyName}\", mapJson);");
-        body.append("    }");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    Map<String, ${unionJavaType}> items = node.${getterMethodName}();
+                    if (items != null && !items.isEmpty()) {
+                        ObjectNode mapJson = JsonUtil.objectNode();
+                        Collection<String> keys = items.keySet();
+                        keys.forEach(key -> {
+                            JsonNode value = this.${writeMethodName}(items.get(key));
+                            if (value != null) JsonUtil.setProperty(mapJson, key, value);
+                        });
+                        JsonUtil.setProperty(json, "${propertyName}", mapJson);
+                    }
+                }
+                """);
     }
 
     @Override

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
@@ -1,5 +1,7 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -39,14 +41,18 @@ public class WriteUnionPropertyBlock extends CodeBlock {
         jt.addImportsTo(writerClassSource);
         writerClassSource.addImport(JsonNode.class);
 
-        body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", ctx.getterMethodName(property));
-        body.addContext("writeMethodName", writeMethodName);
+        body.addContext(Map.of(
+                "propertyName", property.getName(),
+                "getterMethodName", ctx.getterMethodName(property),
+                "writeMethodName", writeMethodName
+        ));
 
-        body.append("{");
-        body.append("    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());");
-        body.append("    if (value != null) JsonUtil.setProperty(json, \"${propertyName}\", value);");
-        body.append("}");
+        body.appendBlock("""
+                {
+                    JsonNode value = this.${writeMethodName}(node.${getterMethodName}());
+                    if (value != null) JsonUtil.setProperty(json, "${propertyName}", value);
+                }
+                """);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Add three new methods to `BodyBuilder` and apply them across 11 code block classes:

**`appendBlock(String textBlock)`** — multi-line text blocks with `${var}` substitution. Replaces 3-7 consecutive `append()` calls with a single readable text block.

**`ifElse(condition, thenSupplier, elseSupplier)`** — conditional code generation. Suppliers can perform side effects (imports) and return code strings. Replaces nested Java if/else around append calls.

**`forEach(items, callback)`** — loop with scoped context + `isFirst` flag. Loop-local variables are discarded between iterations. Replaces Java forEach loops interleaved with append calls.

**`addContext(Map)`** — batch context variable setup via `Map.of(...)`.

Applied to: ReadPrimitivePropertyBlock, ReadEntityPropertyBlock, WriteEntityPropertyBlock, WritePrimitivePropertyBlock, AddMethod, InsertMethod, ClearMethod, RemoveMethod, ReadListPropertyBlock, ReadMapPropertyBlock, CloneUnionPropertyBlock.

## Context

C34b in #1042. Analysis showed template files aren't needed — 44% of code gen involves interleaved Java logic that can't be templated. BodyBuilder improvements handle the other 56% effectively.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged