### PR TITLE
refactor(generator): introduce PropertyCodeGen wrapper (C33c Phase 2)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -30,6 +30,7 @@ import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.cloner.CloneEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneMapPropertyBlock;
@@ -225,11 +226,13 @@ public class CreateClonersStage extends AbstractJavaStage {
         }
 
         private void handlePrimitiveProperty(BodyBuilder body) {
-            new ClonePrimitivePropertyBlock(propertyWithOrigin, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ClonePrimitivePropertyBlock(prop).appendTo(body);
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            new CloneEntityPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneEntityPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -331,23 +334,28 @@ public class CreateClonersStage extends AbstractJavaStage {
         }
 
         private void handleListProperty(BodyBuilder body) {
-            new CloneListPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneListPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            new CloneMapPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneMapPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleUnionProperty(BodyBuilder body) {
-            new CloneUnionPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneUnionPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleUnionListProperty(BodyBuilder body) {
-            new CloneUnionListPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneUnionListPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleUnionMapProperty(BodyBuilder body) {
-            new CloneUnionMapPropertyBlock(propertyWithOrigin, entityModel, clonerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneUnionMapPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -32,6 +32,7 @@ import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
 import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
@@ -525,17 +526,20 @@ public class CreateReadersStage extends AbstractJavaStage {
         }
 
         private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            new ReadUnionPropertyBlock(propertyWithOrigin, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadUnionPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleResolvedUnionListProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.ListType listType) {
-            new ReadUnionListPropertyBlock(propertyWithOrigin, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadUnionListPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleResolvedUnionMapProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.MapType mapType) {
-            new ReadUnionMapPropertyBlock(propertyWithOrigin, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadUnionMapPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -774,19 +778,23 @@ public class CreateReadersStage extends AbstractJavaStage {
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            new ReadEntityPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadEntityPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            new ReadPrimitivePropertyBlock(propertyWithOrigin, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadPrimitivePropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleListProperty(BodyBuilder body) {
-            new ReadListPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadListPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            new ReadMapPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadMapPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -25,6 +25,7 @@ import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
@@ -457,17 +458,20 @@ public class CreateWritersStage extends AbstractJavaStage {
         }
 
         private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            new WriteUnionPropertyBlock(propertyWithOrigin, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteUnionPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleResolvedUnionListProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.ListType listType) {
-            new WriteUnionListPropertyBlock(propertyWithOrigin, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteUnionListPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleResolvedUnionMapProperty(BodyBuilder body,
                 io.apitomy.umg.models.concept.type.MapType mapType) {
-            new WriteUnionMapPropertyBlock(propertyWithOrigin, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteUnionMapPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleStarProperty(BodyBuilder body) {
@@ -633,19 +637,23 @@ public class CreateWritersStage extends AbstractJavaStage {
         }
 
         private void handleEntityProperty(BodyBuilder body) {
-            new WriteEntityPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteEntityPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            new WritePrimitivePropertyBlock(propertyWithOrigin, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WritePrimitivePropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleListProperty(BodyBuilder body) {
-            new WriteListPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteListPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleMapProperty(BodyBuilder body) {
-            new WriteMapPropertyBlock(propertyWithOrigin, entityModel, writerClassSource, ctx).appendTo(body);
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteMapPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/AddMethod.java
@@ -74,19 +74,19 @@ public class AddMethod implements Method {
             body.ifElse(resolvedType.isMapType(), () -> {
                 javaEntity.addImport(LinkedHashMap.class);
                 return """
-if (this.${fieldName} == null) {
-    this.${fieldName} = new LinkedHashMap<>();
-}
-this.${fieldName}.put(name, value);
-""";
+                    if (this.${fieldName} == null) {
+                        this.${fieldName} = new LinkedHashMap<>();
+                    }
+                    this.${fieldName}.put(name, value);
+                    """;
             }, () -> {
                 javaEntity.addImport(ArrayList.class);
                 return """
-if (this.${fieldName} == null) {
-    this.${fieldName} = new ArrayList<>();
-}
-this.${fieldName}.add(value);
-""";
+                    if (this.${fieldName} == null) {
+                        this.${fieldName} = new ArrayList<>();
+                    }
+                    this.${fieldName}.add(value);
+                    """;
             });
 
             if (parentBlock != null) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PropertyCodeGen.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PropertyCodeGen.java
@@ -66,4 +66,12 @@ public class PropertyCodeGen {
     public String getFieldName() {
         return ctx.getFieldName(getProperty());
     }
+
+    public String getGetterName() {
+        return GetterMethod.methodName(getProperty());
+    }
+
+    public String getSetterName() {
+        return SetterMethod.methodName(getProperty());
+    }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PropertyCodeGen.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PropertyCodeGen.java
@@ -1,0 +1,69 @@
+package io.apitomy.umg.pipe.java.method;
+
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+
+/**
+ * Bundles property-level data and code-generation context needed by code blocks.
+ * <p>
+ * This wrapper replaces the repeated {@code (PropertyModelWithOrigin, EntityModel, CodeGenContext)}
+ * parameter triple, reducing code-block constructors from 3-4 parameters to 1-2.
+ * <p>
+ * The stage-specific {@code JavaClassSource} (reader/writer/cloner) is <em>not</em>
+ * included here because it varies per stage; code blocks receive it as a separate parameter.
+ */
+public class PropertyCodeGen {
+
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final EntityModel owningEntity;
+    private final CodeGenContext ctx;
+
+    /**
+     * Creates a PropertyCodeGen for a property that belongs to an entity.
+     *
+     * @param propertyWithOrigin the property with its origin entity
+     * @param owningEntity       the entity that owns this property
+     * @param ctx                code-generation context for lookups and naming
+     */
+    public PropertyCodeGen(PropertyModelWithOrigin propertyWithOrigin, EntityModel owningEntity,
+            CodeGenContext ctx) {
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.owningEntity = owningEntity;
+        this.ctx = ctx;
+    }
+
+    /**
+     * Creates a PropertyCodeGen without an owning entity. Used for blocks that
+     * don't need entity resolution (e.g. primitive blocks, union blocks that
+     * resolve types via the property's namespace).
+     *
+     * @param propertyWithOrigin the property with its origin entity
+     * @param ctx                code-generation context for lookups and naming
+     */
+    public PropertyCodeGen(PropertyModelWithOrigin propertyWithOrigin, CodeGenContext ctx) {
+        this(propertyWithOrigin, null, ctx);
+    }
+
+    // --- Accessors ---
+
+    public PropertyModelWithOrigin getPropertyWithOrigin() {
+        return propertyWithOrigin;
+    }
+
+    public PropertyModel getProperty() {
+        return propertyWithOrigin.getProperty();
+    }
+
+    public EntityModel getOwningEntity() {
+        return owningEntity;
+    }
+
+    public CodeGenContext getCtx() {
+        return ctx;
+    }
+
+    public String getFieldName() {
+        return ctx.getFieldName(getProperty());
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
@@ -8,14 +8,13 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
@@ -24,26 +23,21 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class CloneEntityPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
     // resolved during appendTo
     private JavaInterfaceSource propertyTypeJavaEntity;
 
-    public CloneEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneEntityPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        PropertyModel property = prop.getProperty();
+        var resolved = EntityResolver.resolveEntityInterface(prop.getPropertyWithOrigin(), prop.getOwningEntity(), prop.getCtx(), "");
         if (resolved == null) {
             return;
         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneEntityPropertyBlock.java
@@ -13,9 +13,7 @@ import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to clone an entity-typed property: creates the target entity,
@@ -45,8 +43,8 @@ public class CloneEntityPropertyBlock extends CodeBlock {
         clonerClassSource.addImport(propertyTypeJavaEntity);
 
         body.addContext(Map.of(
-                "getterMethodName", GetterMethod.methodName(property),
-                "setterMethodName", SetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
+                "setterMethodName", prop.getSetterName(),
                 "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),
                 "cloneMethodName", cloneMethodName(resolved.entityModel()),
                 "entityType", propertyTypeJavaEntity.getName()

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -16,10 +16,8 @@ import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to clone a list property (primitive list or entity list).
@@ -43,8 +41,8 @@ public class CloneListPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(List.class);
             clonerClassSource.addImport(ArrayList.class);
             body.addContext(Map.of(
-                    "getterMethodName", GetterMethod.methodName(property),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
+                    "setterMethodName", prop.getSetterName(),
                     "valueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), clonerClassSource)
             ));
 
@@ -67,7 +65,7 @@ public class CloneListPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(List.class);
 
             body.addContext(Map.of(
-                    "getterMethodName", GetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
                     "entityJavaType", resolved.javaInterface().getName(),
                     "commonEntityType", commonEntityTypeJavaModel.getName(),
                     "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -8,19 +8,17 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
@@ -28,22 +26,17 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class CloneListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
-    public CloneListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneListPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
 
         if (listValueType.isPrimitiveType()) {
@@ -52,7 +45,7 @@ public class CloneListPropertyBlock extends CodeBlock {
             body.addContext(Map.of(
                     "getterMethodName", GetterMethod.methodName(property),
                     "setterMethodName", SetterMethod.methodName(property),
-                    "valueType", PrimitiveTypeHelper.determineValueType(listValueType, ctx, clonerClassSource)
+                    "valueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), clonerClassSource)
             ));
 
             body.appendBlock("""
@@ -64,11 +57,11 @@ public class CloneListPropertyBlock extends CodeBlock {
                     }
                     """);
         } else if (listValueType.isEntityType()) {
-            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), prop.getOwningEntity(), prop.getCtx(), "LIST");
             if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
+            JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
             clonerClassSource.addImport(resolved.javaInterface());
             clonerClassSource.addImport(commonEntityTypeJavaModel);
             clonerClassSource.addImport(List.class);
@@ -79,7 +72,7 @@ public class CloneListPropertyBlock extends CodeBlock {
                     "commonEntityType", commonEntityTypeJavaModel.getName(),
                     "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),
                     "cloneMethodName", ClonerMethod.methodName(resolved.entityModel().getName()),
-                    "addMethodName", AddMethod.methodName(ctx.singularize(property.getName()))
+                    "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
             ));
 
             body.appendBlock("""
@@ -95,11 +88,11 @@ public class CloneListPropertyBlock extends CodeBlock {
                     }
                     """);
         } else {
-            ctx.warn("LIST Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            prop.getCtx().warn("LIST Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
         }
     }
 
-    
+
 
     @Override
     public void addImportsTo(JavaSource<?> source) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -15,10 +15,8 @@ import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to clone a map property (primitive map or entity map).
@@ -42,8 +40,8 @@ public class CloneMapPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(Map.class);
             clonerClassSource.addImport(LinkedHashMap.class);
             body.addContext(Map.of(
-                    "getterMethodName", GetterMethod.methodName(property),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
+                    "setterMethodName", prop.getSetterName(),
                     "valueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), clonerClassSource)
             ));
 
@@ -68,7 +66,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
             clonerClassSource.addImport(commonEntityTypeJavaModel);
 
             body.addContext(Map.of(
-                    "getterMethodName", GetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
                     "entityJavaType", resolved.javaInterface().getName(),
                     "commonEntityType", commonEntityTypeJavaModel.getName(),
                     "createMethodName", FactoryMethod.methodName(entityTypeName),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -7,19 +7,17 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
@@ -27,22 +25,17 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class CloneMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
-    public CloneMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneMapPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
 
         if (mapValueType.isPrimitiveType()) {
@@ -51,7 +44,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
             body.addContext(Map.of(
                     "getterMethodName", GetterMethod.methodName(property),
                     "setterMethodName", SetterMethod.methodName(property),
-                    "valueType", PrimitiveTypeHelper.determineValueType(mapValueType, ctx, clonerClassSource)
+                    "valueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), clonerClassSource)
             ));
 
             body.appendBlock("""
@@ -64,11 +57,11 @@ public class CloneMapPropertyBlock extends CodeBlock {
                     """);
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, prop.getOwningEntity(), prop.getCtx(), "MAP");
             if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
+            JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
 
             clonerClassSource.addImport(Map.class);
             clonerClassSource.addImport(resolved.javaInterface());
@@ -80,7 +73,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
                     "commonEntityType", commonEntityTypeJavaModel.getName(),
                     "createMethodName", FactoryMethod.methodName(entityTypeName),
                     "cloneMethodName", ClonerMethod.methodName(entityTypeName),
-                    "addMethodName", AddMethod.methodName(ctx.singularize(property.getName()))
+                    "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
             ));
 
             body.appendBlock("""
@@ -96,11 +89,11 @@ public class CloneMapPropertyBlock extends CodeBlock {
                     }
                     """);
         } else {
-            ctx.warn("MAP Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
+            prop.getCtx().warn("MAP Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
         }
     }
 
-    
+
 
     @Override
     public void addImportsTo(JavaSource<?> source) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
@@ -3,11 +3,10 @@ package io.apitomy.umg.pipe.java.method.cloner;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
@@ -16,17 +15,15 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ClonePrimitivePropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final CodeGenContext ctx;
+    private final PropertyCodeGen prop;
 
-    public ClonePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.ctx = ctx;
+    public ClonePrimitivePropertyBlock(PropertyCodeGen prop) {
+        this.prop = prop;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         body.addContext("getterMethodName", GetterMethod.methodName(property));
         body.addContext("setterMethodName", SetterMethod.methodName(property));
         body.append("target.${setterMethodName}(source.${getterMethodName}());");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/ClonePrimitivePropertyBlock.java
@@ -5,9 +5,7 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to clone a primitive property from source to target:
@@ -24,8 +22,8 @@ public class ClonePrimitivePropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        body.addContext("getterMethodName", GetterMethod.methodName(property));
-        body.addContext("setterMethodName", SetterMethod.methodName(property));
+        body.addContext("getterMethodName", prop.getGetterName());
+        body.addContext("setterMethodName", prop.getSetterName());
         body.append("target.${setterMethodName}(source.${getterMethodName}());");
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -12,14 +12,12 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
 
@@ -28,33 +26,28 @@ import io.apitomy.umg.pipe.java.method.UnionIsMethod;
  */
 public class CloneUnionListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
-    public CloneUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneUnionListPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        PropertyModel property = prop.getProperty();
+        NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
 
         clonerClassSource.addImport(List.class);
 
-        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        var unionJavaType = prop.getCtx().getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);
         body.addContext(Map.of(
                 "unionJavaType", unionJavaType.getSimpleName(),
                 "getterMethodName", GetterMethod.methodName(property),
-                "addMethodName", AddMethod.methodName(ctx.singularize(property.getName()))
+                "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
         ));
 
         body.append("{");
@@ -75,10 +68,10 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
             body.append("            if (srcUnion.${isMethodName}()) {");
 
             if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(typeName + "UnionValue");
                 String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueInterface != null && unionValueClass != null) {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
@@ -86,12 +79,12 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
                     body.append("                target.${addMethodName}(new ${unionValueClassName}(srcUnion.${asMethodName}()));");
                 }
             } else if (nestedType.isEntityType()) {
-                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                NamespaceModel nestedTypeEntityNS = prop.getOwningEntity().getNamespace();
                 String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                EntityModel nestedTypeEntity = prop.getCtx().getConceptIndex().lookupEntity(nestedTypeEntityName);
                 if (nestedTypeEntity != null) {
-                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    JavaInterfaceSource entityJavaSource = prop.getCtx().resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = prop.getCtx().lookupJavaEntityImpl(prop.getCtx().getJavaEntityClassFQN(nestedTypeEntity));
                     if (entityJavaSource != null && entityImplSource != null) {
                         clonerClassSource.addImport(entityJavaSource);
                         clonerClassSource.addImport(entityImplSource);
@@ -104,7 +97,7 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
                     }
                 }
             } else {
-                ctx.warn("UNION LIST property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+                prop.getCtx().warn("UNION LIST property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
             }
 
             body.append("            }");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -16,7 +16,6 @@ import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
@@ -46,7 +45,7 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
         unionJavaType.addImportsTo(clonerClassSource);
         body.addContext(Map.of(
                 "unionJavaType", unionJavaType.getSimpleName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
         ));
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -16,7 +16,6 @@ import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
@@ -46,7 +45,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
         unionJavaType.addImportsTo(clonerClassSource);
         body.addContext(Map.of(
                 "unionJavaType", unionJavaType.getSimpleName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
         ));
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -11,14 +11,13 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
 
@@ -27,33 +26,28 @@ import io.apitomy.umg.pipe.java.method.UnionIsMethod;
  */
 public class CloneUnionMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
-    public CloneUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneUnionMapPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        PropertyModel property = prop.getProperty();
+        NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
 
         clonerClassSource.addImport(Map.class);
 
-        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        var unionJavaType = prop.getCtx().getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);
         body.addContext(Map.of(
                 "unionJavaType", unionJavaType.getSimpleName(),
                 "getterMethodName", GetterMethod.methodName(property),
-                "addMethodName", AddMethod.methodName(ctx.singularize(property.getName()))
+                "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName()))
         ));
 
         body.append("{");
@@ -75,10 +69,10 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
             body.append("            if (srcUnion.${isMethodName}()) {");
 
             if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(typeName + "UnionValue");
                 String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueInterface != null && unionValueClass != null) {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
@@ -86,12 +80,12 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
                     body.append("                target.${addMethodName}(key, new ${unionValueClassName}(srcUnion.${asMethodName}()));");
                 }
             } else if (nestedType.isEntityType()) {
-                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                NamespaceModel nestedTypeEntityNS = prop.getOwningEntity().getNamespace();
                 String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                EntityModel nestedTypeEntity = prop.getCtx().getConceptIndex().lookupEntity(nestedTypeEntityName);
                 if (nestedTypeEntity != null) {
-                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    JavaInterfaceSource entityJavaSource = prop.getCtx().resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = prop.getCtx().lookupJavaEntityImpl(prop.getCtx().getJavaEntityClassFQN(nestedTypeEntity));
                     if (entityJavaSource != null && entityImplSource != null) {
                         clonerClassSource.addImport(entityJavaSource);
                         clonerClassSource.addImport(entityImplSource);
@@ -104,8 +98,8 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
                     }
                 }
             } else if (nestedType.isListType()) {
-                String unionValueClassFQN = ctx.getUnionTypeFQN(typeName + "UnionValueImpl");
-                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                String unionValueClassFQN = prop.getCtx().getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueClass != null) {
                     clonerClassSource.addImport(unionValueClass);
                     clonerClassSource.addImport(java.util.ArrayList.class);
@@ -113,7 +107,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
                     body.append("                target.${addMethodName}(key, new ${unionValueClassName}(new java.util.ArrayList<>(srcUnion.${asMethodName}())));");
                 }
             } else {
-                ctx.warn("UNION MAP property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+                prop.getCtx().warn("UNION MAP property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
             }
 
             body.append("            }");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -14,14 +14,13 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
@@ -31,23 +30,18 @@ import io.apitomy.umg.pipe.java.method.UnionIsMethod;
  */
 public class CloneUnionPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource clonerClassSource;
-    private final CodeGenContext ctx;
 
-    public CloneUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource clonerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public CloneUnionPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
         this.clonerClassSource = clonerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        NamespaceModel nsContext = propertyWithOrigin.getOrigin().getNamespace();
+        PropertyModel property = prop.getProperty();
+        NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = getEffectiveUnionType(property);
 
         body.addContext(Map.of(
@@ -75,10 +69,10 @@ public class CloneUnionPropertyBlock extends CodeBlock {
             loopCtx.set("asMethodName", asMethodName);
 
             if (nestedType.isPrimitiveType() || nestedType.isPrimitiveUnionVariantType()) {
-                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(typeName + "UnionValue");
+                String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(typeName + "UnionValue");
                 String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueInterface != null && unionValueClass != null) {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
@@ -92,10 +86,10 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                 }
             } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isPrimitiveType()) {
                 String unionValueName = AbstractJavaStage.getTypeName(nestedType);
-                String unionValueInterfaceFQN = ctx.getUnionTypeFQN(unionValueName + "UnionValue");
+                String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(unionValueName + "UnionValue");
                 String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueInterface != null && unionValueClass != null) {
                     clonerClassSource.addImport(unionValueInterface);
                     clonerClassSource.addImport(unionValueClass);
@@ -109,12 +103,12 @@ public class CloneUnionPropertyBlock extends CodeBlock {
 """;
                 }
             } else if (nestedType.isEntityType()) {
-                NamespaceModel nestedTypeEntityNS = entityModel.getNamespace();
+                NamespaceModel nestedTypeEntityNS = prop.getOwningEntity().getNamespace();
                 String nestedTypeEntityName = nestedTypeEntityNS.fullName() + "." + nestedType.getName();
-                EntityModel nestedTypeEntity = ctx.getConceptIndex().lookupEntity(nestedTypeEntityName);
+                EntityModel nestedTypeEntity = prop.getCtx().getConceptIndex().lookupEntity(nestedTypeEntityName);
                 if (nestedTypeEntity != null) {
-                    JavaInterfaceSource entityJavaSource = ctx.resolveJavaEntityType(nestedTypeEntityNS, nestedType);
-                    JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(ctx.getJavaEntityClassFQN(nestedTypeEntity));
+                    JavaInterfaceSource entityJavaSource = prop.getCtx().resolveJavaEntityType(nestedTypeEntityNS, nestedType);
+                    JavaClassSource entityImplSource = prop.getCtx().lookupJavaEntityImpl(prop.getCtx().getJavaEntityClassFQN(nestedTypeEntity));
                     if (entityJavaSource != null && entityImplSource != null) {
                         clonerClassSource.addImport(entityJavaSource);
                         clonerClassSource.addImport(entityImplSource);
@@ -132,21 +126,21 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                 }
             } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isEntityType()) {
                 Type listItemType = ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType();
-                String listItemEntityName = entityModel.getNamespace().fullName() + "." + listItemType.getName();
-                EntityModel listItemEntity = ctx.getConceptIndex().lookupEntity(listItemEntityName);
+                String listItemEntityName = prop.getOwningEntity().getNamespace().fullName() + "." + listItemType.getName();
+                EntityModel listItemEntity = prop.getCtx().getConceptIndex().lookupEntity(listItemEntityName);
                 if (listItemEntity != null) {
-                    JavaInterfaceSource listItemEntitySource = ctx.getJavaIndex().lookupInterface(ctx.getJavaEntityInterfaceFQN(listItemEntity));
+                    JavaInterfaceSource listItemEntitySource = prop.getCtx().getJavaIndex().lookupInterface(prop.getCtx().getJavaEntityInterfaceFQN(listItemEntity));
                     if (listItemEntitySource != null) {
                         String unionValueName = AbstractJavaStage.getTypeName(nestedType);
-                        String unionValueInterfaceFQN = ctx.getUnionTypeFQN(unionValueName + "UnionValue");
+                        String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(unionValueName + "UnionValue");
                         String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
-                        JavaInterfaceSource unionValueInterface = ctx.getJavaIndex().lookupInterface(unionValueInterfaceFQN);
-                        JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                        JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
+                        JavaClassSource unionValueClass = prop.getCtx().getJavaIndex().lookupClass(unionValueClassFQN);
                         if (unionValueInterface == null) {
-                            unionValueInterface = ctx.getJavaIndex().findInterfaceBySimpleName(unionValueName + "UnionValue");
+                            unionValueInterface = prop.getCtx().getJavaIndex().findInterfaceBySimpleName(unionValueName + "UnionValue");
                         }
                         if (unionValueClass == null) {
-                            unionValueClass = ctx.getJavaIndex().findClassBySimpleName(unionValueName + "UnionValueImpl");
+                            unionValueClass = prop.getCtx().getJavaIndex().findClassBySimpleName(unionValueName + "UnionValueImpl");
                         }
                         if (unionValueInterface != null && unionValueClass != null) {
                             clonerClassSource.addImport(listItemEntitySource);
@@ -175,7 +169,7 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                     }
                 }
             } else {
-                ctx.warn("UNION property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
+                prop.getCtx().warn("UNION property '" + property.getName() + "' nested type not cloned (unsupported): " + nestedType);
             }
 
             return "";
@@ -186,7 +180,7 @@ public class CloneUnionPropertyBlock extends CodeBlock {
 }
 """);
 
-        var unionJavaType = ctx.getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
+        var unionJavaType = prop.getCtx().getJavaTypeFactory().createJavaType(effectiveUnionType, nsContext);
         unionJavaType.addImportsTo(clonerClassSource);
     }
 
@@ -205,8 +199,8 @@ public class CloneUnionPropertyBlock extends CodeBlock {
     }
 
     private String getUnionJavaTypeName(PropertyModel property, io.apitomy.umg.models.concept.type.UnionType unionType) {
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var jt = prop.getCtx().getJavaTypeFactory().createJavaType(unionType, nsModel);
         jt.addImportsTo(clonerClassSource);
         return jt.getSimpleName();
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -19,9 +19,7 @@ import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 import io.apitomy.umg.pipe.java.method.UnionAsMethod;
 import io.apitomy.umg.pipe.java.method.UnionIsMethod;
 
@@ -46,8 +44,8 @@ public class CloneUnionPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "unionJavaType", getUnionJavaTypeName(property, effectiveUnionType),
-                "getterMethodName", GetterMethod.methodName(property),
-                "setterMethodName", SetterMethod.methodName(property)
+                "getterMethodName", prop.getGetterName(),
+                "setterMethodName", prop.getSetterName()
         ));
 
         body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -12,10 +12,8 @@ import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to read an entity-typed property from JSON.
@@ -42,9 +40,9 @@ public class ReadEntityPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "setterMethodName", SetterMethod.methodName(property),
+                "setterMethodName", prop.getSetterName(),
                 "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()),
                 "propertyEntityType", resolved.javaInterface().getName(),
                 "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadEntityPropertyBlock.java
@@ -7,15 +7,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
@@ -24,23 +22,18 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ReadEntityPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public ReadEntityPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        PropertyModel property = prop.getProperty();
+        var resolved = EntityResolver.resolveEntityInterface(prop.getPropertyWithOrigin(), prop.getOwningEntity(), prop.getCtx(), "");
         if (resolved == null) {
             return;
         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -19,7 +19,6 @@ import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to read a list property from JSON (primitive list or entity list).
@@ -48,7 +47,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "setterMethodName", prop.getSetterName(),
                     "expectedType", expectedType,
                     "toConversionMethod", toConversionMethod,
                     "elementValueType", elementValueType,
@@ -80,7 +79,7 @@ public class ReadListPropertyBlock extends CodeBlock {
 
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "setterMethodName", prop.getSetterName(),
                     "listValueJavaType", resolved.javaInterface().getName(),
                     "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),
                     "readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -9,17 +9,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
@@ -28,31 +26,26 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ReadListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public ReadListPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(List.class);
             readerClassSource.addImport(ArrayList.class);
 
-            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, ctx);
-            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, ctx, readerClassSource);
-            String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, ctx, readerClassSource);
+            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx());
+            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource);
+            String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
                     "setterMethodName", SetterMethod.methodName(property),
@@ -77,7 +70,7 @@ public class ReadListPropertyBlock extends CodeBlock {
 }
 """);
         } else if (listValueType.isEntityType()) {
-            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), prop.getOwningEntity(), prop.getCtx(), "LIST");
             if (resolved == null) {
                 return;
             }
@@ -91,7 +84,7 @@ public class ReadListPropertyBlock extends CodeBlock {
                     "listValueJavaType", resolved.javaInterface().getName(),
                     "createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()),
                     "readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()),
-                    "addMethodName", AddMethod.methodName(ctx.singularize(property.getName())),
+                    "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName())),
                     "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
             ));
 
@@ -111,8 +104,8 @@ public class ReadListPropertyBlock extends CodeBlock {
 }
 """);
         } else {
-            ctx.warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+            prop.getCtx().warn("LIST Entity property '" + property.getName() + "' not read (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + property.getResolvedType());
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -20,7 +20,6 @@ import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to read a map property from JSON (primitive map or entity map).
@@ -51,7 +50,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "setterMethodName", prop.getSetterName(),
                     "expectedType", expectedType,
                     "toConversionMethod", toConversionMethod,
                     "elementValueType", elementValueType,
@@ -86,7 +85,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
 
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "setterMethodName", SetterMethod.methodName(property),
+                    "setterMethodName", prop.getSetterName(),
                     "mapValueJavaType", resolved.javaInterface().getName(),
                     "createMethodName", FactoryMethod.methodName(entityTypeName),
                     "readMethodName", ReaderMethod.methodName(entityTypeName),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -10,17 +10,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
@@ -29,22 +27,17 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ReadMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public ReadMapPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
@@ -53,9 +46,9 @@ public class ReadMapPropertyBlock extends CodeBlock {
             readerClassSource.addImport(LinkedHashMap.class);
             readerClassSource.addImport(List.class);
 
-            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, ctx);
-            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, ctx, readerClassSource);
-            String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, ctx, readerClassSource);
+            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx());
+            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource);
+            String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
                     "setterMethodName", SetterMethod.methodName(property),
@@ -82,7 +75,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
 """);
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, prop.getOwningEntity(), prop.getCtx(), "MAP");
             if (resolved == null) {
                 return;
             }
@@ -97,7 +90,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
                     "mapValueJavaType", resolved.javaInterface().getName(),
                     "createMethodName", FactoryMethod.methodName(entityTypeName),
                     "readMethodName", ReaderMethod.methodName(entityTypeName),
-                    "addMethodName", AddMethod.methodName(ctx.singularize(property.getName())),
+                    "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName())),
                     "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
             ));
 
@@ -121,8 +114,8 @@ public class ReadMapPropertyBlock extends CodeBlock {
 }
 """);
         } else {
-            ctx.warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+            prop.getCtx().warn("MAP Entity property '" + property.getName() + "' not read (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + property.getResolvedType());
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -12,7 +12,6 @@ import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to read a primitive-typed property from JSON.
@@ -36,7 +35,7 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
         String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "setterMethodName", SetterMethod.methodName(property),
+                "setterMethodName", prop.getSetterName(),
                 "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"),
                 "isCheckMethod", isCheckMethod,
                 "toConversionMethod", toConversionMethod

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -8,11 +8,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
@@ -20,24 +19,21 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ReadPrimitivePropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadPrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, JavaClassSource readerClassSource,
-            CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public ReadPrimitivePropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         readerClassSource.addImport(JsonNode.class);
 
-        String isCheckMethod = PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), ctx, readerClassSource);
-        String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), ctx, readerClassSource);
+        String isCheckMethod = PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
+        String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
         body.addContext(Map.of(
                 "propertyName", property.getName(),
                 "setterMethodName", SetterMethod.methodName(property),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -10,11 +10,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
 /**
@@ -22,24 +21,21 @@ import io.apitomy.umg.pipe.java.method.ReaderMethod;
  */
 public class ReadUnionListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public ReadUnionListPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         io.apitomy.umg.models.concept.type.ListType listType =
                 (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var valueJt = ctx.getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
         String readMethodName = ReaderMethod.methodName(valueJt.getSimpleName());
 
         readerClassSource.addImport(JsonNode.class);
@@ -49,7 +45,7 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "addMethodName", AddMethod.methodName(ctx.singularize(property.getName())),
+                "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName())),
                 "readMethodName", readMethodName,
                 "unionJavaType", valueJt.toJavaTypeString(),
                 "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -10,11 +10,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
 /**
@@ -22,24 +21,21 @@ import io.apitomy.umg.pipe.java.method.ReaderMethod;
  */
 public class ReadUnionMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public ReadUnionMapPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         io.apitomy.umg.models.concept.type.MapType mapType =
                 (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var valueJt = ctx.getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
         String readMethodName = ReaderMethod.methodName(valueJt.getSimpleName());
 
         readerClassSource.addImport(JsonNode.class);
@@ -49,7 +45,7 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "addMethodName", AddMethod.methodName(ctx.singularize(property.getName())),
+                "addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getName())),
                 "readMethodName", readMethodName,
                 "unionJavaType", valueJt.toJavaTypeString(),
                 "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -13,7 +13,6 @@ import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-import io.apitomy.umg.pipe.java.method.SetterMethod;
 
 /**
  * Generates code to read a union-typed property from JSON using the type-based reader method.
@@ -41,7 +40,7 @@ public class ReadUnionPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "setterMethodName", SetterMethod.methodName(property),
+                "setterMethodName", prop.getSetterName(),
                 "readMethodName", readMethodName,
                 "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
         ));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -8,11 +8,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 import io.apitomy.umg.pipe.java.method.SetterMethod;
 
@@ -21,23 +20,20 @@ import io.apitomy.umg.pipe.java.method.SetterMethod;
  */
 public class ReadUnionPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource readerClassSource;
-    private final CodeGenContext ctx;
 
-    public ReadUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource readerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public ReadUnionPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
         this.readerClassSource = readerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type resolved = property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var jt = ctx.getJavaTypeFactory().createJavaType(resolved, nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var jt = prop.getCtx().getJavaTypeFactory().createJavaType(resolved, nsModel);
         String readMethodName = ReaderMethod.methodName(jt.getSimpleName());
 
         readerClassSource.addImport(JsonNode.class);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -10,7 +10,6 @@ import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -38,7 +37,7 @@ public class WriteEntityPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "writeMethodName", writeMethodName(resolved.entityModel()),
                 "propertyTypeJavaEntity", resolved.javaInterface().getName()
         ));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteEntityPropertyBlock.java
@@ -7,12 +7,11 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
 /**
@@ -20,23 +19,18 @@ import io.apitomy.umg.pipe.java.method.WriterMethod;
  */
 public class WriteEntityPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteEntityPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public WriteEntityPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-        var resolved = EntityResolver.resolveEntityInterface(propertyWithOrigin, entityModel, ctx, "");
+        PropertyModel property = prop.getProperty();
+        var resolved = EntityResolver.resolveEntityInterface(prop.getPropertyWithOrigin(), prop.getOwningEntity(), prop.getCtx(), "");
         if (resolved == null) {
             return;
         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -14,7 +14,6 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -34,7 +33,7 @@ public class WriteListPropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("getterMethodName", prop.getGetterName());
 
         Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
@@ -53,7 +52,7 @@ public class WriteListPropertyBlock extends CodeBlock {
 
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "getterMethodName", GetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
                     "listValueJavaType", resolved.javaInterface().getName(),
                     "writeMethodName", WriteEntityPropertyBlock.writeMethodName(resolved.entityModel()),
                     "listValueCommonJavaType", commonEntityTypeJavaModel.getName()

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -9,38 +9,30 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
  * Generates code to write a list property to JSON (primitive list or entity list).
  */
 public class WriteListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public WriteListPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", GetterMethod.methodName(property));
 
@@ -48,11 +40,11 @@ public class WriteListPropertyBlock extends CodeBlock {
         if (listValueType.isPrimitiveType()) {
             body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toArrayNode(node.${getterMethodName}()));");
         } else if (listValueType.isEntityType()) {
-            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), entityModel, ctx, "LIST");
+            var resolved = EntityResolver.resolveEntityInterface(property, listValueType.getName(), prop.getOwningEntity(), prop.getCtx(), "LIST");
             if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
+            JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
 
             writerClassSource.addImport(resolved.javaInterface());
             writerClassSource.addImport(commonEntityTypeJavaModel);
@@ -82,8 +74,8 @@ public class WriteListPropertyBlock extends CodeBlock {
                     }
                     """);
         } else {
-            ctx.warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+            prop.getCtx().warn("LIST Entity property '" + property.getName() + "' not written (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + property.getResolvedType());
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -1,22 +1,19 @@
 package io.apitomy.umg.pipe.java.method.writer;
 
-import java.util.List;
 import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
 /**
@@ -24,22 +21,17 @@ import io.apitomy.umg.pipe.java.method.WriterMethod;
  */
 public class WriteMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
-    private final EntityModel entityModel;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
-        this.entityModel = entityModel;
+    public WriteMapPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", GetterMethod.methodName(property));
 
@@ -48,11 +40,11 @@ public class WriteMapPropertyBlock extends CodeBlock {
             body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toObjectNode(node.${getterMethodName}()));");
         } else if (mapValueType.isEntityType()) {
             String entityTypeName = mapValueType.getName();
-            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, entityModel, ctx, "MAP");
+            var resolved = EntityResolver.resolveEntityInterface(property, entityTypeName, prop.getOwningEntity(), prop.getCtx(), "MAP");
             if (resolved == null) {
                 return;
             }
-            JavaInterfaceSource commonEntityTypeJavaModel = ctx.resolveCommonJavaEntity(resolved.entityModel());
+            JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
 
             writerClassSource.addImport(Map.class);
             writerClassSource.addImport(resolved.javaInterface());
@@ -81,8 +73,8 @@ public class WriteMapPropertyBlock extends CodeBlock {
                     }
                     """);
         } else {
-            ctx.warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            ctx.warn("       property type: " + property.getResolvedType());
+            prop.getCtx().warn("MAP Entity property '" + property.getName() + "' not written (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + property.getResolvedType());
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -11,7 +11,6 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
@@ -33,7 +32,7 @@ public class WriteMapPropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("getterMethodName", prop.getGetterName());
 
         Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
@@ -52,7 +51,7 @@ public class WriteMapPropertyBlock extends CodeBlock {
 
             body.addContext(Map.of(
                     "propertyName", property.getName(),
-                    "getterMethodName", GetterMethod.methodName(property),
+                    "getterMethodName", prop.getGetterName(),
                     "mapValueJavaType", resolved.javaInterface().getName(),
                     "writeMethodName", WriterMethod.methodName(entityTypeName),
                     "mapValueCommonJavaType", commonEntityTypeJavaModel.getName()

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -6,7 +6,6 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
@@ -27,7 +26,7 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
-        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("getterMethodName", prop.getGetterName());
 
         body.ifElse(PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), prop.getCtx()),
                 // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -4,36 +4,32 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
  * Generates code to write a primitive-typed property to JSON.
  */
 public class WritePrimitivePropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WritePrimitivePropertyBlock(PropertyModelWithOrigin propertyWithOrigin, JavaClassSource writerClassSource,
-            CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public WritePrimitivePropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", GetterMethod.methodName(property));
 
-        body.ifElse(PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), ctx),
+        body.ifElse(PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), prop.getCtx()),
                 // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly
                 () -> "JsonUtil.setProperty(json, \"${propertyName}\", node.${getterMethodName}());",
                 () -> "JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toJsonNode(node.${getterMethodName}()));");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -12,7 +12,6 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -45,7 +44,7 @@ public class WriteUnionListPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "writeMethodName", writeMethodName,
                 "unionJavaType", valueJt.toJavaTypeString()
         ));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -10,11 +10,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
 /**
@@ -22,24 +21,21 @@ import io.apitomy.umg.pipe.java.method.WriterMethod;
  */
 public class WriteUnionListPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteUnionListPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public WriteUnionListPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         io.apitomy.umg.models.concept.type.ListType listType =
                 (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var valueJt = ctx.getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
         String writeMethodName = WriterMethod.methodName(valueJt.getSimpleName());
 
         valueJt.addImportsTo(writerClassSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -10,11 +10,10 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
 /**
@@ -22,24 +21,21 @@ import io.apitomy.umg.pipe.java.method.WriterMethod;
  */
 public class WriteUnionMapPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteUnionMapPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public WriteUnionMapPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         io.apitomy.umg.models.concept.type.MapType mapType =
                 (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var valueJt = ctx.getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
         String writeMethodName = WriterMethod.methodName(valueJt.getSimpleName());
 
         valueJt.addImportsTo(writerClassSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -12,7 +12,6 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -45,7 +44,7 @@ public class WriteUnionMapPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "writeMethodName", writeMethodName,
                 "unionJavaType", valueJt.toJavaTypeString()
         ));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
@@ -11,7 +11,6 @@ import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -41,7 +40,7 @@ public class WriteUnionPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyName", property.getName(),
-                "getterMethodName", GetterMethod.methodName(property),
+                "getterMethodName", prop.getGetterName(),
                 "writeMethodName", writeMethodName
         ));
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionPropertyBlock.java
@@ -8,12 +8,11 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
 /**
@@ -21,23 +20,20 @@ import io.apitomy.umg.pipe.java.method.WriterMethod;
  */
 public class WriteUnionPropertyBlock extends CodeBlock {
 
-    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final PropertyCodeGen prop;
     private final JavaClassSource writerClassSource;
-    private final CodeGenContext ctx;
 
-    public WriteUnionPropertyBlock(PropertyModelWithOrigin propertyWithOrigin,
-            JavaClassSource writerClassSource, CodeGenContext ctx) {
-        this.propertyWithOrigin = propertyWithOrigin;
+    public WriteUnionPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
         this.writerClassSource = writerClassSource;
-        this.ctx = ctx;
     }
 
     @Override
     public void appendTo(BodyBuilder body) {
-        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyModel property = prop.getProperty();
         Type resolved = property.getResolvedType();
-        var nsModel = propertyWithOrigin.getOrigin().getNamespace();
-        var jt = ctx.getJavaTypeFactory().createJavaType(resolved, nsModel);
+        var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
+        var jt = prop.getCtx().getJavaTypeFactory().createJavaType(resolved, nsModel);
         String writeMethodName = WriterMethod.methodName(jt.getSimpleName());
 
         jt.addImportsTo(writerClassSource);


### PR DESCRIPTION
## Summary

Bundle property-level data into `PropertyCodeGen` wrapper. Code blocks now take 1-2 params instead of 3-4.

**New:** `PropertyCodeGen` class — wraps `PropertyModelWithOrigin`, `EntityModel`, `CodeGenContext` with convenience accessors (`getProperty()`, `getFieldName()`, etc.)

**Before:** `new ReadEntityPropertyBlock(propertyWithOrigin, entityModel, readerClassSource, ctx)`
**After:** `new ReadEntityPropertyBlock(prop, readerClassSource)`

Updated all 21 code blocks (7 reader, 7 writer, 7 cloner) and 3 stage inner classes.

## Context

C33c Phase 2 in #1042. Follows Phase 1 (#1126) which created Method interface + naming classes. Static `methodName()` utilities remain for now — will be removed when method instances are passed through PropertyCodeGen in a future iteration.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged
- [x] Net -93 lines