### PR TITLE
refactor(generator): extract star/regex handlers to code blocks (C32d Step 1)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -35,6 +35,8 @@ import io.apitomy.umg.pipe.java.method.cloner.CloneEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.ClonePrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneRegexPropertyBlock;
+import io.apitomy.umg.pipe.java.method.cloner.CloneStarPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneUnionMapPropertyBlock;
@@ -236,101 +238,13 @@ public class CreateClonersStage extends AbstractJavaStage {
         }
 
         private void handleStarProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "STAR");
-                if (resolved == null) {
-                    return;
-                }
-                clonerClassSource.addImport(resolved.javaInterface());
-                clonerClassSource.addImport(List.class);
-
-                body.addContext("entityJavaType", resolved.javaInterface().getName());
-                body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
-
-                body.append("{");
-                body.append("    List<String> itemNames = source.getItemNames();");
-                body.append("    if (itemNames != null) {");
-                body.append("        itemNames.forEach(name -> {");
-                body.append("            ${entityJavaType} srcItem = (${entityJavaType}) source.getItem(name);");
-                body.append("            if (srcItem != null) {");
-                body.append("                ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-                body.append("                this.${cloneMethodName}(srcItem, tgtItem);");
-                body.append("                target.addItem(name, tgtItem);");
-                body.append("            }");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
-                clonerClassSource.addImport(List.class);
-
-                body.append("{");
-                body.append("    List<String> itemNames = source.getItemNames();");
-                body.append("    if (itemNames != null) {");
-                body.append("        itemNames.forEach(name -> {");
-                body.append("            target.addItem(name, source.getItem(name));");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("STAR Entity property '" + property.getName() + "' not cloned (unhandled) for entity: " + entityModel.fullyQualifiedName());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneStarPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleRegexProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "REGEX");
-                if (resolved == null) {
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(resolved.entityModel());
-
-                clonerClassSource.addImport(resolved.javaInterface());
-                clonerClassSource.addImport(commonEntityTypeJavaModel);
-                clonerClassSource.addImport(Map.class);
-
-                body.addContext("entityJavaType", resolved.javaInterface().getName());
-                body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-                body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("cloneMethodName", cloneMethodName(resolved.entityModel()));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-
-                body.append("{");
-                body.append("    Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();");
-                body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-                body.append("        srcMap.keySet().forEach(name -> {");
-                body.append("            ${entityJavaType} srcItem = (${entityJavaType}) srcMap.get(name);");
-                body.append("            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();");
-                body.append("            this.${cloneMethodName}(srcItem, tgtItem);");
-                body.append("            target.${addMethodName}(name, tgtItem);");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
-                clonerClassSource.addImport(Map.class);
-
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, clonerClassSource));
-
-                clonerClassSource.addImport(List.class);
-                body.append("{");
-                body.append("    Map<String, ${valueType}> srcMap = source.${getterMethodName}();");
-                body.append("    if (srcMap != null && !srcMap.isEmpty()) {");
-                body.append("        List<String> keys = new java.util.ArrayList<>(srcMap.keySet());");
-                body.append("        keys.forEach(name -> {");
-                body.append("            target.${addMethodName}(name, srcMap.get(name));");
-                body.append("        });");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("REGEX Entity property '" + property.getName() + "' not cloned (unhandled) for entity: " + entityModel.fullyQualifiedName());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new CloneRegexPropertyBlock(prop, clonerClassSource).appendTo(body);
         }
 
         private void handleListProperty(BodyBuilder body) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -39,6 +39,8 @@ import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadPrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadRegexPropertyBlock;
+import io.apitomy.umg.pipe.java.method.reader.ReadStarPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadUnionMapPropertyBlock;
@@ -543,238 +545,13 @@ public class CreateReadersStage extends AbstractJavaStage {
         }
 
         private void handleStarProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "STAR");
-                if (resolved == null) {
-                    return;
-                }
-                readerClassSource.addImport(resolved.javaInterface());
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                body.addContext("entityJavaType", resolved.javaInterface().getName());
-                body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("addMethodName", "addItem");
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isObject(_val)) {");
-                body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
-                body.append("            node.${addMethodName}(name, model);");
-                body.append("            this.${readMethodName}((ObjectNode) _val, model);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), ctx, readerClassSource));
-                body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), ctx, readerClassSource));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
-                body.append("            node.addItem(name, JsonUtil.${toConversionMethod}(_val));");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveList(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(ArrayList.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, ctx);
-                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, ctx, readerClassSource);
-                String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, ctx, readerClassSource);
-                body.addContext("expectedType", expectedType);
-                body.addContext("toConversionMethod", toConversionMethod);
-                body.addContext("elementValueType", elementValueType);
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, \"${expectedType}\")) {");
-                body.append("            List<${elementValueType}> items = new ArrayList<>();");
-                body.append("            List<JsonNode> _nodes = JsonUtil.toList(_val);");
-                body.append("            for (int _j = 0; _j < _nodes.size(); _j++) {");
-                body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
-                body.append("            }");
-                body.append("            node.addItem(name, items);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveMap(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-                readerClassSource.addImport(Map.class);
-                readerClassSource.addImport(java.util.LinkedHashMap.class);
-
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, ctx);
-                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, ctx, readerClassSource);
-                String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, ctx, readerClassSource);
-                body.addContext("expectedType", expectedType);
-                body.addContext("toConversionMethod", toConversionMethod);
-                body.addContext("elementValueType", elementValueType);
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.keys(json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, \"${expectedType}\")) {");
-                body.append("            Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
-                body.append("            List<String> _keys = JsonUtil.keys((ObjectNode) _val);");
-                body.append("            for (int _j = 0; _j < _keys.size(); _j++) {");
-                body.append("                String _key = _keys.get(_j);");
-                body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
-                body.append("            }");
-                body.append("            node.addItem(name, items);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("STAR Entity property '" + property.getName() + "' not read (unhandled) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadStarPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleRegexProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "REGEX");
-                if (resolved == null) {
-                    return;
-                }
-                readerClassSource.addImport(resolved.javaInterface());
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("entityJavaType", resolved.javaInterface().getName());
-                body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isObject(_val)) {");
-                body.append("            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();");
-                body.append("            node.${addMethodName}(name, model);");
-                body.append("            this.${readMethodName}((ObjectNode) _val, model);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), ctx, readerClassSource));
-                body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), ctx, readerClassSource));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.${isCheckMethod}(_val)) {");
-                body.append("            node.${addMethodName}(name, JsonUtil.${toConversionMethod}(_val));");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveList(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(ArrayList.class);
-                readerClassSource.addImport(JsonNode.class);
-
-                Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
-                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, ctx);
-                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, ctx, readerClassSource);
-                String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, ctx, readerClassSource);
-                body.addContext("expectedType", expectedType);
-                body.addContext("toConversionMethod", toConversionMethod);
-                body.addContext("elementValueType", elementValueType);
-                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, \"${expectedType}\")) {");
-                body.append("            List<${elementValueType}> items = new ArrayList<>();");
-                body.append("            List<JsonNode> _nodes = JsonUtil.toList(_val);");
-                body.append("            for (int _j = 0; _j < _nodes.size(); _j++) {");
-                body.append("                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));");
-                body.append("            }");
-                body.append("            node.${addMethodName}(name, items);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveMap(property)) {
-                readerClassSource.addImport(List.class);
-                readerClassSource.addImport(JsonNode.class);
-                readerClassSource.addImport(Map.class);
-                readerClassSource.addImport(java.util.LinkedHashMap.class);
-
-                Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
-                String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, ctx);
-                String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, ctx, readerClassSource);
-                String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, ctx, readerClassSource);
-                body.addContext("expectedType", expectedType);
-                body.addContext("toConversionMethod", toConversionMethod);
-                body.addContext("elementValueType", elementValueType);
-                body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
-                body.addContext("addMethodName", AddMethod.methodName(singularize(property.getCollection())));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = JsonUtil.matchingKeys(\"${propertyRegex}\", json);");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String name = propertyNames.get(_i);");
-                body.append("        JsonNode _val = JsonUtil.getProperty(json, name);");
-                body.append("        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, \"${expectedType}\")) {");
-                body.append("            Map<String, ${elementValueType}> items = new LinkedHashMap<>();");
-                body.append("            List<String> _keys = JsonUtil.keys((ObjectNode) _val);");
-                body.append("            for (int _j = 0; _j < _keys.size(); _j++) {");
-                body.append("                String _key = _keys.get(_j);");
-                body.append("                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));");
-                body.append("            }");
-                body.append("            node.${addMethodName}(name, items);");
-                body.append("            JsonUtil.removeProperty(json, name);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("REGEX Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new ReadRegexPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
         private void handleEntityProperty(BodyBuilder body) {
@@ -797,11 +574,5 @@ public class CreateReadersStage extends AbstractJavaStage {
             new ReadMapPropertyBlock(prop, readerClassSource).appendTo(body);
         }
 
-
-
-
-        private String encodeRegex(String regex) {
-            return regex.replace("\\", "\\\\");
-        }
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -33,6 +33,8 @@ import io.apitomy.umg.pipe.java.method.writer.WriteEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WritePrimitivePropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteRegexPropertyBlock;
+import io.apitomy.umg.pipe.java.method.writer.WriteStarPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteUnionMapPropertyBlock;
@@ -475,165 +477,13 @@ public class CreateWritersStage extends AbstractJavaStage {
         }
 
         private void handleStarProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "STAR");
-                if (resolved == null) {
-                    return;
-                }
-
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(resolved.javaInterface());
-
-                body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
-                body.addContext("entityJavaType", resolved.javaInterface().getName());
-
-                body.append("{");
-                body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String propertyName = propertyNames.get(_i);");
-                body.append("        ObjectNode object = JsonUtil.objectNode();");
-                body.append("        this.${writeMethodName}((${entityJavaType}) node.getItem(propertyName), object);");
-                body.append("        JsonUtil.setProperty(json, propertyName, object);");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property)) {
-                writerClassSource.addImport(List.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String propertyName = propertyNames.get(_i);");
-                body.append("        ${valueType} value = node.getItem(propertyName);");
-                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveList(property)) {
-                writerClassSource.addImport(List.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String propertyName = propertyNames.get(_i);");
-                body.append("        ${valueType} value = node.getItem(propertyName);");
-                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveMap(property)) {
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(Map.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-
-                body.append("{");
-                body.append("    List<String> propertyNames = node.getItemNames();");
-                body.append("    for (int _i = 0; _i < propertyNames.size(); _i++) {");
-                body.append("        String propertyName = propertyNames.get(_i);");
-                body.append("        ${valueType} value = node.getItem(propertyName);");
-                body.append("        JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("STAR Entity property '" + property.getName() + "' not written (unhandled) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteStarPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleRegexProperty(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isEntity(property)) {
-                var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
-                        entityModel, ctx, "REGEX");
-                if (resolved == null) {
-                    return;
-                }
-                JavaInterfaceSource commonEntityTypeJavaModel = resolveCommonJavaEntity(resolved.entityModel());
-
-                writerClassSource.addImport(Map.class);
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(resolved.javaInterface());
-                writerClassSource.addImport(commonEntityTypeJavaModel);
-
-                body.addContext("mapValueJavaType", resolved.javaInterface().getName());
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-                body.addContext("writeMethodName", writeMethodName(resolved.entityModel()));
-                body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
-
-                body.append("{");
-                body.append("    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();");
-                body.append("    if (models != null && !models.isEmpty()) {");
-                body.append("        List<String> _keys = new java.util.ArrayList<>(models.keySet());");
-                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-                body.append("            String propertyName = _keys.get(_i);");
-                body.append("            ObjectNode object = JsonUtil.objectNode();");
-                body.append("            this.${writeMethodName}((${mapValueJavaType}) models.get(propertyName), object);");
-                body.append("            JsonUtil.setProperty(json, propertyName, object);");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitive(property)) {
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(Map.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-
-                body.append("{");
-                body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
-                body.append("    if (values != null && !values.isEmpty()) {");
-                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
-                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-                body.append("            String propertyName = _keys.get(_i);");
-                body.append("            ${valueType} value = values.get(propertyName);");
-                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveList(property)) {
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(Map.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-
-                body.append("{");
-                body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
-                body.append("    if (values != null && !values.isEmpty()) {");
-                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
-                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-                body.append("            String propertyName = _keys.get(_i);");
-                body.append("            ${valueType} value = values.get(propertyName);");
-                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else if (isPrimitiveMap(property)) {
-                writerClassSource.addImport(List.class);
-                writerClassSource.addImport(Map.class);
-
-                body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), ctx, writerClassSource));
-                body.addContext("getterMethodName", GetterMethod.methodName(property));
-
-                body.append("{");
-                body.append("    Map<String, ${valueType}> values = node.${getterMethodName}();");
-                body.append("    if (values != null && !values.isEmpty()) {");
-                body.append("        List<String> _keys = new java.util.ArrayList<>(values.keySet());");
-                body.append("        for (int _i = 0; _i < _keys.size(); _i++) {");
-                body.append("            String propertyName = _keys.get(_i);");
-                body.append("            ${valueType} value = values.get(propertyName);");
-                body.append("            JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));");
-                body.append("        }");
-                body.append("    }");
-                body.append("}");
-            } else {
-                warn("REGEX Entity property '" + property.getName() + "' not written (unhandled) for entity: " + entityModel.fullyQualifiedName());
-                warn("       property type: " + property.getResolvedType());
-            }
+            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+            new WriteRegexPropertyBlock(prop, writerClassSource).appendTo(body);
         }
 
         private void handleEntityProperty(BodyBuilder body) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
@@ -1,0 +1,110 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.AddMethod;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.ClonerMethod;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.FactoryMethod;
+import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+
+/**
+ * Generates code to clone a regex-patterned property.
+ * Handles entity and primitive/primitiveList/primitiveMap subcases.
+ */
+public class CloneRegexPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource clonerClassSource;
+
+    public CloneRegexPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
+        this.clonerClassSource = clonerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType() || resolvedType.isPrimitiveListType() || resolvedType.isPrimitiveMapType()) {
+            appendPrimitive(body, property);
+        } else {
+            prop.getCtx().warn("REGEX Entity property '" + property.getName()
+                    + "' not cloned (unhandled) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "REGEX");
+        if (resolved == null) {
+            return;
+        }
+        JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
+
+        clonerClassSource.addImport(resolved.javaInterface());
+        clonerClassSource.addImport(commonEntityTypeJavaModel);
+        clonerClassSource.addImport(Map.class);
+
+        body.addContext("entityJavaType", resolved.javaInterface().getName());
+        body.addContext("commonEntityType", commonEntityTypeJavaModel.getName());
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("cloneMethodName", ClonerMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+
+        body.appendBlock("""
+{
+    Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();
+    if (srcMap != null && !srcMap.isEmpty()) {
+        srcMap.keySet().forEach(name -> {
+            ${entityJavaType} srcItem = (${entityJavaType}) srcMap.get(name);
+            ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
+            this.${cloneMethodName}(srcItem, tgtItem);
+            target.${addMethodName}(name, tgtItem);
+        });
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body, PropertyModel property) {
+        clonerClassSource.addImport(Map.class);
+        clonerClassSource.addImport(List.class);
+
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), clonerClassSource));
+
+        body.appendBlock("""
+{
+    Map<String, ${valueType}> srcMap = source.${getterMethodName}();
+    if (srcMap != null && !srcMap.isEmpty()) {
+        List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
+        keys.forEach(name -> {
+            target.${addMethodName}(name, srcMap.get(name));
+        });
+    }
+}
+""");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneStarPropertyBlock.java
@@ -1,0 +1,95 @@
+package io.apitomy.umg.pipe.java.method.cloner;
+
+import java.util.List;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.ClonerMethod;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.FactoryMethod;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+
+/**
+ * Generates code to clone a star (*) property.
+ * Handles entity and primitive/primitiveList/primitiveMap subcases.
+ */
+public class CloneStarPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource clonerClassSource;
+
+    public CloneStarPropertyBlock(PropertyCodeGen prop, JavaClassSource clonerClassSource) {
+        this.prop = prop;
+        this.clonerClassSource = clonerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType() || resolvedType.isPrimitiveListType() || resolvedType.isPrimitiveMapType()) {
+            appendPrimitive(body);
+        } else {
+            prop.getCtx().warn("STAR Entity property '" + property.getName()
+                    + "' not cloned (unhandled) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "STAR");
+        if (resolved == null) {
+            return;
+        }
+        clonerClassSource.addImport(resolved.javaInterface());
+        clonerClassSource.addImport(List.class);
+
+        body.addContext("entityJavaType", resolved.javaInterface().getName());
+        body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("cloneMethodName", ClonerMethod.methodName(resolved.entityModel().getName()));
+
+        body.appendBlock("""
+{
+    List<String> itemNames = source.getItemNames();
+    if (itemNames != null) {
+        itemNames.forEach(name -> {
+            ${entityJavaType} srcItem = (${entityJavaType}) source.getItem(name);
+            if (srcItem != null) {
+                ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
+                this.${cloneMethodName}(srcItem, tgtItem);
+                target.addItem(name, tgtItem);
+            }
+        });
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body) {
+        clonerClassSource.addImport(List.class);
+
+        body.appendBlock("""
+{
+    List<String> itemNames = source.getItemNames();
+    if (itemNames != null) {
+        itemNames.forEach(name -> {
+            target.addItem(name, source.getItem(name));
+        });
+    }
+}
+""");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to clonerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
@@ -1,0 +1,199 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.AddMethod;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.FactoryMethod;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+import io.apitomy.umg.pipe.java.method.ReaderMethod;
+
+/**
+ * Generates code to read a regex-patterned property from JSON.
+ * Handles entity, primitive, primitive-list, and primitive-map subcases.
+ */
+public class ReadRegexPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource readerClassSource;
+
+    public ReadRegexPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
+        this.readerClassSource = readerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType()) {
+            appendPrimitive(body, property);
+        } else if (resolvedType.isPrimitiveListType()) {
+            appendPrimitiveList(body, property);
+        } else if (resolvedType.isPrimitiveMapType()) {
+            appendPrimitiveMap(body, property);
+        } else {
+            prop.getCtx().warn("REGEX Entity property '" + property.getName()
+                    + "' not read (unsupported) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + resolvedType);
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "REGEX");
+        if (resolved == null) {
+            return;
+        }
+        readerClassSource.addImport(resolved.javaInterface());
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+        body.addContext("entityJavaType", resolved.javaInterface().getName());
+        body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.matchingKeys("${propertyRegex}", json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isObject(_val)) {
+            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();
+            node.${addMethodName}(name, model);
+            this.${readMethodName}((ObjectNode) _val, model);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+        body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.matchingKeys("${propertyRegex}", json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.${isCheckMethod}(_val)) {
+            node.${addMethodName}(name, JsonUtil.${toConversionMethod}(_val));
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveList(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(ArrayList.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        body.addContext("expectedType", PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx()));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource));
+        body.addContext("elementValueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource));
+        body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.matchingKeys("${propertyRegex}", json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, "${expectedType}")) {
+            List<${elementValueType}> items = new ArrayList<>();
+            List<JsonNode> _nodes = JsonUtil.toList(_val);
+            for (int _j = 0; _j < _nodes.size(); _j++) {
+                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));
+            }
+            node.${addMethodName}(name, items);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveMap(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(Map.class);
+        readerClassSource.addImport(LinkedHashMap.class);
+
+        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        body.addContext("expectedType", PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx()));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource));
+        body.addContext("elementValueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource));
+        body.addContext("propertyRegex", encodeRegex(extractRegex(property.getName())));
+        body.addContext("addMethodName", AddMethod.methodName(prop.getCtx().singularize(property.getCollection())));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.matchingKeys("${propertyRegex}", json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, "${expectedType}")) {
+            Map<String, ${elementValueType}> items = new LinkedHashMap<>();
+            List<String> _keys = JsonUtil.keys((ObjectNode) _val);
+            for (int _j = 0; _j < _keys.size(); _j++) {
+                String _key = _keys.get(_j);
+                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));
+            }
+            node.${addMethodName}(name, items);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    /**
+     * Encodes backslashes in a regex pattern for embedding in generated Java source.
+     */
+    public static String encodeRegex(String regex) {
+        return regex.replace("\\", "\\\\");
+    }
+
+    /**
+     * Extracts the regex pattern from a property name (strips the leading and trailing slashes).
+     */
+    static String extractRegex(String propertyName) {
+        return propertyName.substring(1, propertyName.length() - 1);
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
@@ -1,0 +1,177 @@
+package io.apitomy.umg.pipe.java.method.reader;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.FactoryMethod;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+import io.apitomy.umg.pipe.java.method.ReaderMethod;
+
+/**
+ * Generates code to read a star (*) property from JSON.
+ * Handles entity, primitive, primitive-list, and primitive-map subcases.
+ */
+public class ReadStarPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource readerClassSource;
+
+    public ReadStarPropertyBlock(PropertyCodeGen prop, JavaClassSource readerClassSource) {
+        this.prop = prop;
+        this.readerClassSource = readerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType()) {
+            appendPrimitive(body, property);
+        } else if (resolvedType.isPrimitiveListType()) {
+            appendPrimitiveList(body, property);
+        } else if (resolvedType.isPrimitiveMapType()) {
+            appendPrimitiveMap(body, property);
+        } else {
+            prop.getCtx().warn("STAR Entity property '" + property.getName()
+                    + "' not read (unhandled) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + resolvedType);
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "STAR");
+        if (resolved == null) {
+            return;
+        }
+        readerClassSource.addImport(resolved.javaInterface());
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        body.addContext("entityJavaType", resolved.javaInterface().getName());
+        body.addContext("createMethodName", FactoryMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("readMethodName", ReaderMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("addMethodName", "addItem");
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.keys(json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isObject(_val)) {
+            ${entityJavaType} model = (${entityJavaType}) node.${createMethodName}();
+            node.${addMethodName}(name, model);
+            this.${readMethodName}((ObjectNode) _val, model);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.keys(json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.${isCheckMethod}(_val)) {
+            node.addItem(name, JsonUtil.${toConversionMethod}(_val));
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveList(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(ArrayList.class);
+        readerClassSource.addImport(JsonNode.class);
+
+        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        body.addContext("expectedType", PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx()));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource));
+        body.addContext("elementValueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.keys(json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, "${expectedType}")) {
+            List<${elementValueType}> items = new ArrayList<>();
+            List<JsonNode> _nodes = JsonUtil.toList(_val);
+            for (int _j = 0; _j < _nodes.size(); _j++) {
+                items.add(JsonUtil.${toConversionMethod}(_nodes.get(_j)));
+            }
+            node.addItem(name, items);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveMap(BodyBuilder body, PropertyModel property) {
+        readerClassSource.addImport(List.class);
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(Map.class);
+        readerClassSource.addImport(LinkedHashMap.class);
+
+        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        body.addContext("expectedType", PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx()));
+        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource));
+        body.addContext("elementValueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = JsonUtil.keys(json);
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String name = propertyNames.get(_i);
+        JsonNode _val = JsonUtil.getProperty(json, name);
+        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, "${expectedType}")) {
+            Map<String, ${elementValueType}> items = new LinkedHashMap<>();
+            List<String> _keys = JsonUtil.keys((ObjectNode) _val);
+            for (int _j = 0; _j < _keys.size(); _j++) {
+                String _key = _keys.get(_j);
+                items.put(_key, JsonUtil.${toConversionMethod}(JsonUtil.getProperty((ObjectNode) _val, _key)));
+            }
+            node.addItem(name, items);
+            JsonUtil.removeProperty(json, name);
+        }
+    }
+}
+""");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to readerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteRegexPropertyBlock.java
@@ -1,0 +1,158 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.GetterMethod;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+import io.apitomy.umg.pipe.java.method.WriterMethod;
+
+/**
+ * Generates code to write a regex-patterned property to JSON.
+ * Handles entity, primitive, primitive-list, and primitive-map subcases.
+ */
+public class WriteRegexPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource writerClassSource;
+
+    public WriteRegexPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
+        this.writerClassSource = writerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType()) {
+            appendPrimitive(body, property);
+        } else if (resolvedType.isPrimitiveListType()) {
+            appendPrimitiveList(body, property);
+        } else if (resolvedType.isPrimitiveMapType()) {
+            appendPrimitiveMap(body, property);
+        } else {
+            prop.getCtx().warn("REGEX Entity property '" + property.getName()
+                    + "' not written (unhandled) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + resolvedType);
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "REGEX");
+        if (resolved == null) {
+            return;
+        }
+        JavaInterfaceSource commonEntityTypeJavaModel = prop.getCtx().resolveCommonJavaEntity(resolved.entityModel());
+
+        writerClassSource.addImport(Map.class);
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(resolved.javaInterface());
+        writerClassSource.addImport(commonEntityTypeJavaModel);
+
+        body.addContext("mapValueJavaType", resolved.javaInterface().getName());
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+        body.addContext("writeMethodName", WriterMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("mapValueCommonJavaType", commonEntityTypeJavaModel.getName());
+
+        body.appendBlock("""
+{
+    Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();
+    if (models != null && !models.isEmpty()) {
+        List<String> _keys = new java.util.ArrayList<>(models.keySet());
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String propertyName = _keys.get(_i);
+            ObjectNode object = JsonUtil.objectNode();
+            this.${writeMethodName}((${mapValueJavaType}) models.get(propertyName), object);
+            JsonUtil.setProperty(json, propertyName, object);
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(Map.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+
+        body.appendBlock("""
+{
+    Map<String, ${valueType}> values = node.${getterMethodName}();
+    if (values != null && !values.isEmpty()) {
+        List<String> _keys = new java.util.ArrayList<>(values.keySet());
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String propertyName = _keys.get(_i);
+            ${valueType} value = values.get(propertyName);
+            JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveList(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(Map.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+
+        body.appendBlock("""
+{
+    Map<String, ${valueType}> values = node.${getterMethodName}();
+    if (values != null && !values.isEmpty()) {
+        List<String> _keys = new java.util.ArrayList<>(values.keySet());
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String propertyName = _keys.get(_i);
+            ${valueType} value = values.get(propertyName);
+            JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));
+        }
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveMap(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(Map.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("getterMethodName", GetterMethod.methodName(property));
+
+        body.appendBlock("""
+{
+    Map<String, ${valueType}> values = node.${getterMethodName}();
+    if (values != null && !values.isEmpty()) {
+        List<String> _keys = new java.util.ArrayList<>(values.keySet());
+        for (int _i = 0; _i < _keys.size(); _i++) {
+            String propertyName = _keys.get(_i);
+            ${valueType} value = values.get(propertyName);
+            JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));
+        }
+    }
+}
+""");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteStarPropertyBlock.java
@@ -1,0 +1,134 @@
+package io.apitomy.umg.pipe.java.method.writer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.EntityResolver;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+import io.apitomy.umg.pipe.java.method.WriterMethod;
+
+/**
+ * Generates code to write a star (*) property to JSON.
+ * Handles entity, primitive, primitive-list, and primitive-map subcases.
+ */
+public class WriteStarPropertyBlock extends CodeBlock {
+
+    private final PropertyCodeGen prop;
+    private final JavaClassSource writerClassSource;
+
+    public WriteStarPropertyBlock(PropertyCodeGen prop, JavaClassSource writerClassSource) {
+        this.prop = prop;
+        this.writerClassSource = writerClassSource;
+    }
+
+    @Override
+    public void appendTo(BodyBuilder body) {
+        PropertyModel property = prop.getProperty();
+        Type resolvedType = property.getResolvedType();
+
+        if (resolvedType.isEntityType()) {
+            appendEntity(body, property);
+        } else if (resolvedType.isPrimitiveType()) {
+            appendPrimitive(body, property);
+        } else if (resolvedType.isPrimitiveListType()) {
+            appendPrimitiveList(body, property);
+        } else if (resolvedType.isPrimitiveMapType()) {
+            appendPrimitiveMap(body, property);
+        } else {
+            prop.getCtx().warn("STAR Entity property '" + property.getName()
+                    + "' not written (unhandled) for entity: " + prop.getOwningEntity().fullyQualifiedName());
+            prop.getCtx().warn("       property type: " + resolvedType);
+        }
+    }
+
+    private void appendEntity(BodyBuilder body, PropertyModel property) {
+        var resolved = EntityResolver.resolveEntityInterface(property, property.getResolvedType().getName(),
+                prop.getOwningEntity(), prop.getCtx(), "STAR");
+        if (resolved == null) {
+            return;
+        }
+
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(resolved.javaInterface());
+
+        body.addContext("writeMethodName", WriterMethod.methodName(resolved.entityModel().getName()));
+        body.addContext("entityJavaType", resolved.javaInterface().getName());
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = node.getItemNames();
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String propertyName = propertyNames.get(_i);
+        ObjectNode object = JsonUtil.objectNode();
+        this.${writeMethodName}((${entityJavaType}) node.getItem(propertyName), object);
+        JsonUtil.setProperty(json, propertyName, object);
+    }
+}
+""");
+    }
+
+    private void appendPrimitive(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = node.getItemNames();
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String propertyName = propertyNames.get(_i);
+        ${valueType} value = node.getItem(propertyName);
+        JsonUtil.setProperty(json, propertyName, JsonUtil.toJsonNode(value));
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveList(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = node.getItemNames();
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String propertyName = propertyNames.get(_i);
+        ${valueType} value = node.getItem(propertyName);
+        JsonUtil.setProperty(json, propertyName, JsonUtil.toArrayNode(value));
+    }
+}
+""");
+    }
+
+    private void appendPrimitiveMap(BodyBuilder body, PropertyModel property) {
+        writerClassSource.addImport(List.class);
+        writerClassSource.addImport(Map.class);
+
+        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+
+        body.appendBlock("""
+{
+    List<String> propertyNames = node.getItemNames();
+    for (int _i = 0; _i < propertyNames.size(); _i++) {
+        String propertyName = propertyNames.get(_i);
+        ${valueType} value = node.getItem(propertyName);
+        JsonUtil.setProperty(json, propertyName, JsonUtil.toObject(value));
+    }
+}
+""");
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added directly to writerClassSource during appendTo
+    }
+}


### PR DESCRIPTION
## Summary

Extract star (`*`) and regex (`/pattern/`) property handlers from stage inner classes into 6 new code blocks:

| Code Block | Replaces inline in |
|------------|-------------------|
| `ReadStarPropertyBlock` | CreateReadersStage (112 lines) |
| `ReadRegexPropertyBlock` | CreateReadersStage (120 lines) |
| `WriteStarPropertyBlock` | CreateWritersStage (69 lines) |
| `WriteRegexPropertyBlock` | CreateWritersStage (91 lines) |
| `CloneStarPropertyBlock` | CreateClonersStage (49 lines) |
| `CloneRegexPropertyBlock` | CreateClonersStage (53 lines) |

**Stage reductions:** Reader 808→578, Writer 664→513, Cloner 363→277. **Total: -467 lines.**

## Context

C32d Step 1 in #1042. Star/regex handlers were the last inline BodyBuilder code in the stage inner classes (besides the `writeTo`/`handleViaResolvedType` dispatch which is minimal). All property handling is now in code blocks.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged