### PR TITLE
refactor(generator): ReaderMethod/WriterMethod.writeTo() for union methods (C32d Step 2)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -19,8 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apitomy.umg.pipe.java.Util;
 import io.apitomy.umg.beans.SpecificationVersion;
-import io.apitomy.umg.beans.UnionRule;
-import io.apitomy.umg.beans.UnionRuleType;
+
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
@@ -34,7 +33,7 @@ import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-import io.apitomy.umg.pipe.java.method.UnionIsMethod;
+
 import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadMapPropertyBlock;
@@ -121,176 +120,14 @@ public class CreateReadersStage extends AbstractJavaStage {
         getState().getConceptIndex().findTypes(namespace).stream()
                 .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
                 .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
-                .forEach(unionType -> createUnionReaderMethod(specVersion, readerClassSource, unionType));
+                .forEach(unionType -> {
+                    var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+                    var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+                    new ReaderMethod(jt.getSimpleName()).writeTo(readerClassSource, specVersion, unionType, ctx);
+                });
     }
 
-    private void createUnionReaderMethod(SpecificationVersion specVersion, JavaClassSource readerClassSource,
-                                          io.apitomy.umg.models.concept.type.UnionType unionType) {
-        var namespace = specVersion.getNamespace();
-        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
-        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
-        String unionTypeName = jt.getSimpleName();
-        String methodName = ReaderMethod.methodName(unionTypeName);
 
-        // Skip if already created
-        if (readerClassSource.getMethod(methodName, JsonNode.class.getSimpleName(), "ModelType") != null) {
-            return;
-        }
-
-        debug("Creating union reader method: %s", methodName);
-
-        readerClassSource.addImport(JsonNode.class);
-        readerClassSource.addImport(ObjectNode.class);
-        jt.addImportsTo(readerClassSource);
-
-        JavaEnumSource modelTypeEnum = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeEnum);
-
-        MethodSource<JavaClassSource> method = readerClassSource.addMethod()
-                .setName(methodName)
-                .setReturnType(jt.toJavaTypeString())
-                .setPrivate();
-        method.addParameter("JsonNode", "json");
-        method.addParameter("ModelType", "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("if (json == null) return null;");
-
-        // Generate dispatch for each variant
-        boolean first = true;
-        for (var variantType : unionType.getTypes()) {
-            if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
-                var entity = entityType.getEntity();
-                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
-                if (entity == null) continue;
-
-                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-                JavaClassSource entityImplSource = lookupJavaEntityImpl(entity);
-                readerClassSource.addImport(entitySource);
-                readerClassSource.addImport(entityImplSource);
-
-                body.addContext("entityType", entitySource.getName());
-                body.addContext("entityImplType", entityImplSource.getName());
-                body.addContext("readMethodName", ReaderMethod.methodName(entity.getName()));
-
-                var rule = unionType.getRuleFor(entityType.getName());
-                String condition;
-                if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYEXISTS) {
-                    body.addContext("rulePropName", rule.getPropertyName());
-                    condition = "JsonUtil.isObjectWithProperty(json, \"${rulePropName}\")";
-                } else if (rule != null && rule.getRuleType() == io.apitomy.umg.beans.UnionRuleType.PROPERTYVALUE) {
-                    body.addContext("rulePropName", rule.getPropertyName());
-                    body.addContext("rulePropValue", rule.getPropertyValue());
-                    condition = "JsonUtil.isObjectWithStringPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
-                } else {
-                    condition = "JsonUtil.isObject(json)";
-                }
-
-                if (!first) body.append(" else ");
-                first = false;
-
-                body.append("if (" + condition + ") {");
-                body.append("    ${entityType} node = new ${entityImplType}();");
-                body.append("    this.${readMethodName}((ObjectNode) json, node);");
-                body.append("    return node;");
-                body.append("}");
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType puv) {
-                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
-                if (javaClass == null) continue;
-
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
-                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                if (unionValueClass == null) continue;
-
-                readerClassSource.addImport(unionValueClass);
-
-                body.addContext("isMethod", UnionIsMethod.methodName(javaClass.getSimpleName()));
-                body.addContext("toMethod", "to" + javaClass.getSimpleName());
-                body.addContext("unionValueClass", unionValueClass.getName());
-
-                if (!first) body.append(" else ");
-                first = false;
-
-                body.append("if (JsonUtil.${isMethod}(json)) {");
-                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json), modelType);");
-                body.append("}");
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType
-                    && listType.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType listEntityType) {
-                var entity = listEntityType.getEntity();
-                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, listEntityType.getName());
-                if (entity == null) continue;
-
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
-                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                if (unionValueClass == null) {
-                    unionValueClass = getState().getJavaIndex().lookupClass(
-                            resolveUnionPackage(unionType) + "." + typeName + "UnionValueImpl");
-                }
-                if (unionValueClass == null) continue;
-
-                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-                readerClassSource.addImport(entitySource);
-                readerClassSource.addImport(unionValueClass);
-                readerClassSource.addImport(java.util.List.class);
-                readerClassSource.addImport(java.util.ArrayList.class);
-
-                body.addContext("listValueType", entitySource.getName());
-                body.addContext("readMethodName", ReaderMethod.methodName(entity.getName()));
-                body.addContext("unionValueClass", unionValueClass.getName());
-
-                if (!first) body.append(" else ");
-                first = false;
-
-                body.append("if (JsonUtil.isArray(json)) {");
-                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
-                body.append("    List<${listValueType}> models = new ArrayList<>();");
-                body.append("    array.forEach(item -> {");
-                body.append("        ObjectNode object = JsonUtil.toObject(item);");
-                body.append("        ${listValueType} model = new ${listValueType}Impl();");
-                body.append("        this.${readMethodName}(object, model);");
-                body.append("        models.add(model);");
-                body.append("    });");
-                body.append("    @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
-                body.append("    ${unionValueClass} unionValue = new ${unionValueClass}((List) models);");
-                body.append("    return unionValue;");
-                body.append("}");
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType
-                    && listType.getValueType() instanceof io.apitomy.umg.models.concept.type.PrimitiveType primType) {
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                String unionValueClassFQN = getUnionTypeFQN(typeName + "UnionValueImpl");
-                JavaClassSource unionValueClass = getState().getJavaIndex().lookupClass(unionValueClassFQN);
-                if (unionValueClass == null) continue;
-
-                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
-                if (javaClass == null) continue;
-
-                readerClassSource.addImport(unionValueClass);
-                readerClassSource.addImport(java.util.List.class);
-                readerClassSource.addImport(java.util.ArrayList.class);
-                readerClassSource.addImport(javaClass);
-
-                body.addContext("primType", javaClass.getSimpleName());
-                body.addContext("toMethod", "to" + javaClass.getSimpleName());
-                body.addContext("unionValueClass", unionValueClass.getName());
-
-                if (!first) body.append(" else ");
-                first = false;
-
-                body.append("if (JsonUtil.isArray(json)) {");
-                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
-                body.append("    List<${primType}> items = new ArrayList<>();");
-                body.append("    array.forEach(item -> {");
-                body.append("        items.add(JsonUtil.${toMethod}(item));");
-                body.append("    });");
-                body.append("    return new ${unionValueClass}(items);");
-                body.append("}");
-            }
-        }
-        body.append("return null;");
-        method.setBody(body.toString());
-    }
 
     private void createReadRootFromSpec(SpecificationVersion specVersion, JavaClassSource readerClassSource) {
         if (specVersion.getRoot() == null) return;

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -11,7 +11,6 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apitomy.umg.beans.SpecificationVersion;
@@ -26,8 +25,7 @@ import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
 import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-import io.apitomy.umg.pipe.java.method.UnionAsMethod;
-import io.apitomy.umg.pipe.java.method.UnionIsMethod;
+
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 import io.apitomy.umg.pipe.java.method.writer.WriteEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteListPropertyBlock;
@@ -112,121 +110,14 @@ public class CreateWritersStage extends AbstractJavaStage {
         getState().getConceptIndex().findTypes(namespace).stream()
                 .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
                 .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
-                .forEach(unionType -> createUnionWriterMethod(specVersion, writerClassSource, unionType));
+                .forEach(unionType -> {
+                    var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+                    var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
+                    new WriterMethod(jt.getSimpleName()).writeTo(writerClassSource, specVersion, unionType, ctx);
+                });
     }
 
-    private void createUnionWriterMethod(SpecificationVersion specVersion, JavaClassSource writerClassSource,
-                                          io.apitomy.umg.models.concept.type.UnionType unionType) {
-        var namespace = specVersion.getNamespace();
-        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
-        var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
-        String unionTypeName = jt.getSimpleName();
-        String methodName = WriterMethod.methodName(unionTypeName);
 
-        if (hasMethod(writerClassSource, methodName)) {
-            return;
-        }
-
-        debug("Creating union writer method: %s", methodName);
-
-        writerClassSource.addImport(ObjectNode.class);
-        writerClassSource.addImport(JsonNode.class);
-        jt.addImportsTo(writerClassSource);
-
-        MethodSource<JavaClassSource> method = writerClassSource.addMethod()
-                .setName(methodName)
-                .setReturnType("JsonNode")
-                .setPrivate();
-        method.addParameter(jt.toJavaTypeString(), "union");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("if (union == null) return null;");
-
-        for (var variantType : unionType.getTypes()) {
-            if (variantType instanceof io.apitomy.umg.models.concept.type.EntityType entityType) {
-                var entity = entityType.getEntity();
-                if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, entityType.getName());
-                if (entity == null) continue;
-
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-                writerClassSource.addImport(entitySource);
-
-                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
-                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
-                body.addContext("entityType", entitySource.getName());
-                body.addContext("writeMethodName", writeMethodName(entity));
-
-                body.append("if (union.${isMethod}()) {");
-                body.append("    ObjectNode jsonValue = JsonUtil.objectNode();");
-                body.append("    this.${writeMethodName}((${entityType}) union.${asMethod}(), jsonValue);");
-                body.append("    return jsonValue;");
-                body.append("}");
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType puv) {
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
-                if (javaClass == null) continue;
-
-                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
-                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
-
-                if (JsonNode.class.isAssignableFrom(javaClass)) {
-                    body.append("if (union.${isMethod}()) {");
-                    body.append("    return union.${asMethod}();");
-                    body.append("}");
-                } else {
-                    body.append("if (union.${isMethod}()) {");
-                    body.append("    return JsonUtil.toJsonNode(union.${asMethod}());");
-                    body.append("}");
-                }
-            } else if (variantType instanceof io.apitomy.umg.models.concept.type.ListType listType) {
-                String typeName = io.apitomy.umg.models.java.type.JavaTypeFactory.getUnionComponentName(variantType);
-
-                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
-                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
-
-                writerClassSource.addImport(ArrayNode.class);
-
-                if (listType.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType listEntityType) {
-                    var entity = listEntityType.getEntity();
-                    if (entity == null) entity = getState().getConceptIndex().lookupEntity(namespace, listEntityType.getName());
-                    if (entity == null) continue;
-
-                    JavaInterfaceSource entitySource = lookupJavaEntity(entity);
-                    writerClassSource.addImport(entitySource);
-                    body.addContext("entityType", entitySource.getName());
-                    body.addContext("writeMethodName", writeMethodName(entity));
-
-                    body.append("if (union.${isMethod}()) {");
-                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
-                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
-                    body.append("        ObjectNode itemNode = JsonUtil.objectNode();");
-                    body.append("        this.${writeMethodName}((${entityType}) item, itemNode);");
-                    body.append("        array.add(itemNode);");
-                    body.append("    }");
-                    body.append("    return array;");
-                    body.append("}");
-                } else if (listType.getValueType() instanceof io.apitomy.umg.models.concept.type.PrimitiveType primType) {
-                    Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
-                    if (javaClass == null) continue;
-
-                    writerClassSource.addImport(javaClass);
-                    body.addContext("primType", javaClass.getSimpleName());
-
-                    body.addContext("addExpr", "array.add(JsonUtil.toJsonNode(item))");
-                    body.append("if (union.${isMethod}()) {");
-                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
-                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
-                    body.append("        ${addExpr};");
-                    body.append("    }");
-                    body.append("    return array;");
-                    body.append("}");
-                }
-            }
-        }
-        body.append("return null;");
-        method.setBody(body.toString());
-    }
 
     private boolean hasMethod(JavaClassSource source, String name) {
         return source.getMethods().stream().anyMatch(m -> m.getName().equals(name));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -86,6 +86,37 @@ public class CodeGenContext {
         return getUnionTypesPackageName() + "." + name;
     }
 
+    public String getModelTypeEnumFQN() {
+        return rootNamespace + ".ModelType";
+    }
+
+    /**
+     * Resolves the package for union value impl classes, preferring the common-entity
+     * namespace when a variant references a common entity.
+     */
+    public String resolveUnionPackage(io.apitomy.umg.models.concept.type.UnionType unionType) {
+        for (var variant : unionType.getTypes()) {
+            io.apitomy.umg.models.concept.type.EntityType entityType = null;
+            if (variant instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+                entityType = et;
+            } else if (variant instanceof io.apitomy.umg.models.concept.type.ListType lt
+                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+                entityType = et;
+            } else if (variant instanceof io.apitomy.umg.models.concept.type.MapType mt
+                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+                entityType = et;
+            }
+            if (entityType != null) {
+                EntityModel common = conceptIndex.lookupCommonEntity(
+                        unionType.getNamespace(), entityType.getName());
+                if (common != null) {
+                    return common.getNamespace().fullName();
+                }
+            }
+        }
+        return getUnionTypesPackageName();
+    }
+
     // --- Naming helpers ---
 
     private String getJavaEntityInterfaceName(EntityModel entity) {
@@ -142,7 +173,7 @@ public class CodeGenContext {
         return lookupJavaEntity(commonEntity);
     }
 
-    private JavaInterfaceSource lookupJavaEntity(EntityModel entity) {
+    public JavaInterfaceSource lookupJavaEntity(EntityModel entity) {
         return lookupJavaEntity(getJavaEntityInterfaceFQN(entity));
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -1,10 +1,31 @@
 package io.apitomy.umg.pipe.java.method;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.beans.UnionRuleType;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.models.java.type.JavaType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
+import io.apitomy.umg.pipe.java.Util;
 
 /**
  * Naming class for reader methods: {@code read${EntityName}}.
+ * Also generates full union reader dispatch methods via {@link #writeTo}.
  */
 public class ReaderMethod implements Method {
 
@@ -28,7 +49,177 @@ public class ReaderMethod implements Method {
 
     @Override
     public void addImportsTo(JavaSource<?> source) {
-        // No imports needed
+        // No imports needed for the naming-only use case
     }
 
+    /**
+     * Generates the full union reader dispatch method on the given reader class.
+     * Creates a method {@code readUnionName(JsonNode json, ModelType modelType)} that
+     * dispatches to the correct variant based on JSON shape.
+     */
+    public void writeTo(JavaClassSource readerClassSource, SpecificationVersion specVersion,
+                        UnionType unionType, CodeGenContext ctx) {
+        String namespace = specVersion.getNamespace();
+        NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(namespace);
+        JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String unionTypeName = jt.getSimpleName();
+        String methodName = methodName(unionTypeName);
+
+        // Skip if already created
+        if (readerClassSource.getMethod(methodName, JsonNode.class.getSimpleName(), "ModelType") != null) {
+            return;
+        }
+
+        readerClassSource.addImport(JsonNode.class);
+        readerClassSource.addImport(ObjectNode.class);
+        jt.addImportsTo(readerClassSource);
+
+        JavaEnumSource modelTypeEnum = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        readerClassSource.addImport(modelTypeEnum);
+
+        MethodSource<JavaClassSource> method = readerClassSource.addMethod()
+                .setName(methodName)
+                .setReturnType(jt.toJavaTypeString())
+                .setPrivate();
+        method.addParameter("JsonNode", "json");
+        method.addParameter("ModelType", "modelType");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (json == null) return null;");
+
+        // Generate dispatch for each variant
+        boolean first = true;
+        for (var variantType : unionType.getTypes()) {
+            if (variantType instanceof EntityType entityType) {
+                var entity = entityType.getEntity();
+                if (entity == null) entity = ctx.getConceptIndex().lookupEntity(namespace, entityType.getName());
+                if (entity == null) continue;
+
+                JavaInterfaceSource entitySource = ctx.lookupJavaEntity(entity);
+                JavaClassSource entityImplSource = ctx.lookupJavaEntityImpl(entity);
+                readerClassSource.addImport(entitySource);
+                readerClassSource.addImport(entityImplSource);
+
+                body.addContext("entityType", entitySource.getName());
+                body.addContext("entityImplType", entityImplSource.getName());
+                body.addContext("readMethodName", methodName(entity.getName()));
+
+                var rule = unionType.getRuleFor(entityType.getName());
+                String condition;
+                if (rule != null && rule.getRuleType() == UnionRuleType.PROPERTYEXISTS) {
+                    body.addContext("rulePropName", rule.getPropertyName());
+                    condition = "JsonUtil.isObjectWithProperty(json, \"${rulePropName}\")";
+                } else if (rule != null && rule.getRuleType() == UnionRuleType.PROPERTYVALUE) {
+                    body.addContext("rulePropName", rule.getPropertyName());
+                    body.addContext("rulePropValue", rule.getPropertyValue());
+                    condition = "JsonUtil.isObjectWithStringPropertyValue(json, \"${rulePropName}\", \"${rulePropValue}\")";
+                } else {
+                    condition = "JsonUtil.isObject(json)";
+                }
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (" + condition + ") {");
+                body.append("    ${entityType} node = new ${entityImplType}();");
+                body.append("    this.${readMethodName}((ObjectNode) json, node);");
+                body.append("    return node;");
+                body.append("}");
+            } else if (variantType instanceof PrimitiveUnionVariantType puv) {
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                if (javaClass == null) continue;
+
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = ctx.getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) continue;
+
+                readerClassSource.addImport(unionValueClass);
+
+                body.addContext("isMethod", UnionIsMethod.methodName(javaClass.getSimpleName()));
+                body.addContext("toMethod", "to" + javaClass.getSimpleName());
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.${isMethod}(json)) {");
+                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json), modelType);");
+                body.append("}");
+            } else if (variantType instanceof ListType listType
+                    && listType.getValueType() instanceof EntityType listEntityType) {
+                var entity = listEntityType.getEntity();
+                if (entity == null) entity = ctx.getConceptIndex().lookupEntity(namespace, listEntityType.getName());
+                if (entity == null) continue;
+
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = ctx.getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) {
+                    unionValueClass = ctx.getJavaIndex().lookupClass(
+                            ctx.resolveUnionPackage(unionType) + "." + typeName + "UnionValueImpl");
+                }
+                if (unionValueClass == null) continue;
+
+                JavaInterfaceSource entitySource = ctx.lookupJavaEntity(entity);
+                readerClassSource.addImport(entitySource);
+                readerClassSource.addImport(unionValueClass);
+                readerClassSource.addImport(java.util.List.class);
+                readerClassSource.addImport(java.util.ArrayList.class);
+
+                body.addContext("listValueType", entitySource.getName());
+                body.addContext("readMethodName", methodName(entity.getName()));
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.isArray(json)) {");
+                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
+                body.append("    List<${listValueType}> models = new ArrayList<>();");
+                body.append("    array.forEach(item -> {");
+                body.append("        ObjectNode object = JsonUtil.toObject(item);");
+                body.append("        ${listValueType} model = new ${listValueType}Impl();");
+                body.append("        this.${readMethodName}(object, model);");
+                body.append("        models.add(model);");
+                body.append("    });");
+                body.append("    @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
+                body.append("    ${unionValueClass} unionValue = new ${unionValueClass}((List) models);");
+                body.append("    return unionValue;");
+                body.append("}");
+            } else if (variantType instanceof ListType listType
+                    && listType.getValueType() instanceof PrimitiveType primType) {
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                String unionValueClassFQN = ctx.getUnionTypeFQN(typeName + "UnionValueImpl");
+                JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
+                if (unionValueClass == null) continue;
+
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                if (javaClass == null) continue;
+
+                readerClassSource.addImport(unionValueClass);
+                readerClassSource.addImport(java.util.List.class);
+                readerClassSource.addImport(java.util.ArrayList.class);
+                readerClassSource.addImport(javaClass);
+
+                body.addContext("primType", javaClass.getSimpleName());
+                body.addContext("toMethod", "to" + javaClass.getSimpleName());
+                body.addContext("unionValueClass", unionValueClass.getName());
+
+                if (!first) body.append(" else ");
+                first = false;
+
+                body.append("if (JsonUtil.isArray(json)) {");
+                body.append("    List<JsonNode> array = JsonUtil.toList(json);");
+                body.append("    List<${primType}> items = new ArrayList<>();");
+                body.append("    array.forEach(item -> {");
+                body.append("        items.add(JsonUtil.${toMethod}(item));");
+                body.append("    });");
+                body.append("    return new ${unionValueClass}(items);");
+                body.append("}");
+            }
+        }
+        body.append("return null;");
+        method.setBody(body.toString());
+    }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
@@ -1,10 +1,30 @@
 package io.apitomy.umg.pipe.java.method;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.PrimitiveType;
+import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.models.java.type.JavaType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
+import io.apitomy.umg.pipe.java.Util;
 
 /**
  * Naming class for writer methods: {@code write${EntityName}}.
+ * Also generates full union writer dispatch methods via {@link #writeTo}.
  */
 public class WriterMethod implements Method {
 
@@ -28,7 +48,123 @@ public class WriterMethod implements Method {
 
     @Override
     public void addImportsTo(JavaSource<?> source) {
-        // No imports needed
+        // No imports needed for the naming-only use case
     }
 
+    /**
+     * Generates the full union writer dispatch method on the given writer class.
+     * Creates a method {@code writeUnionName(UnionType union)} that dispatches
+     * to the correct variant writer based on is/as methods.
+     */
+    public void writeTo(JavaClassSource writerClassSource, SpecificationVersion specVersion,
+                        UnionType unionType, CodeGenContext ctx) {
+        String namespace = specVersion.getNamespace();
+        NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(namespace);
+        JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        String unionTypeName = jt.getSimpleName();
+        String methodName = methodName(unionTypeName);
+
+        // Skip if already created
+        if (writerClassSource.getMethods().stream().anyMatch(m -> m.getName().equals(methodName))) {
+            return;
+        }
+
+        writerClassSource.addImport(ObjectNode.class);
+        writerClassSource.addImport(JsonNode.class);
+        jt.addImportsTo(writerClassSource);
+
+        MethodSource<JavaClassSource> method = writerClassSource.addMethod()
+                .setName(methodName)
+                .setReturnType("JsonNode")
+                .setPrivate();
+        method.addParameter(jt.toJavaTypeString(), "union");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (union == null) return null;");
+
+        for (var variantType : unionType.getTypes()) {
+            if (variantType instanceof EntityType entityType) {
+                var entity = entityType.getEntity();
+                if (entity == null) entity = ctx.getConceptIndex().lookupEntity(namespace, entityType.getName());
+                if (entity == null) continue;
+
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                JavaInterfaceSource entitySource = ctx.lookupJavaEntity(entity);
+                writerClassSource.addImport(entitySource);
+
+                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
+                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
+                body.addContext("entityType", entitySource.getName());
+                body.addContext("writeMethodName", methodName(entity.getName()));
+
+                body.append("if (union.${isMethod}()) {");
+                body.append("    ObjectNode jsonValue = JsonUtil.objectNode();");
+                body.append("    this.${writeMethodName}((${entityType}) union.${asMethod}(), jsonValue);");
+                body.append("    return jsonValue;");
+                body.append("}");
+            } else if (variantType instanceof PrimitiveUnionVariantType puv) {
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+                Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                if (javaClass == null) continue;
+
+                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
+                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
+
+                if (JsonNode.class.isAssignableFrom(javaClass)) {
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    return union.${asMethod}();");
+                    body.append("}");
+                } else {
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    return JsonUtil.toJsonNode(union.${asMethod}());");
+                    body.append("}");
+                }
+            } else if (variantType instanceof ListType listType) {
+                String typeName = JavaTypeFactory.getUnionComponentName(variantType);
+
+                body.addContext("isMethod", UnionIsMethod.methodName(typeName));
+                body.addContext("asMethod", UnionAsMethod.methodName(typeName));
+
+                writerClassSource.addImport(ArrayNode.class);
+
+                if (listType.getValueType() instanceof EntityType listEntityType) {
+                    var entity = listEntityType.getEntity();
+                    if (entity == null) entity = ctx.getConceptIndex().lookupEntity(namespace, listEntityType.getName());
+                    if (entity == null) continue;
+
+                    JavaInterfaceSource entitySource = ctx.lookupJavaEntity(entity);
+                    writerClassSource.addImport(entitySource);
+                    body.addContext("entityType", entitySource.getName());
+                    body.addContext("writeMethodName", methodName(entity.getName()));
+
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
+                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("        ObjectNode itemNode = JsonUtil.objectNode();");
+                    body.append("        this.${writeMethodName}((${entityType}) item, itemNode);");
+                    body.append("        array.add(itemNode);");
+                    body.append("    }");
+                    body.append("    return array;");
+                    body.append("}");
+                } else if (listType.getValueType() instanceof PrimitiveType primType) {
+                    Class<?> javaClass = Util.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                    if (javaClass == null) continue;
+
+                    writerClassSource.addImport(javaClass);
+                    body.addContext("primType", javaClass.getSimpleName());
+
+                    body.addContext("addExpr", "array.add(JsonUtil.toJsonNode(item))");
+                    body.append("if (union.${isMethod}()) {");
+                    body.append("    ArrayNode array = JsonUtil.arrayNode();");
+                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("        ${addExpr};");
+                    body.append("    }");
+                    body.append("    return array;");
+                    body.append("}");
+                }
+            }
+        }
+        body.append("return null;");
+        method.setBody(body.toString());
+    }
 }


### PR DESCRIPTION
## Summary

Move union reader/writer method generation from stages into method classes:

- **`ReaderMethod.writeTo()`** — generates `readUnionName(JsonNode, ModelType)` with full variant dispatch
- **`WriterMethod.writeTo()`** — generates `writeUnionName(Union)` with same pattern

Method classes now own both naming (`getName()`) AND code generation (`writeTo()`).

**Stage reductions:** Reader 578→415, Writer 513→404. **Total: -272 lines.**

## Context

C32d Step 2 in #1042. Follows Step 1 (#1128) which extracted star/regex handlers. Now the stages are primarily orchestration — the heavy code generation logic lives in method classes and code blocks.

## Cumulative Phase 4 stage reductions

| Stage | Original | After Step 1 | After Step 2 |
|-------|----------|-------------|-------------|
| Reader | 1421 | 578 | **415** |
| Writer | 1152 | 513 | **404** |
| Cloner | 789 | 277 | 277 |

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged