### PR TITLE
refactor(generator): new method classes — EmptyClone, Accept, UnionIs/As, MappedNode (C32d Step 2c)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAcceptMethodStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAcceptMethodStage.java
@@ -2,11 +2,10 @@ package io.apitomy.umg.pipe.java;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.VisitorModel;
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.AcceptMethod;
 
 /**
  * Creates the "accept" method for all entity implementations.  This is required by the
@@ -25,35 +24,13 @@ public class CreateAcceptMethodStage extends AbstractJavaStage {
 
     private void createAcceptMethod(EntityModel entity) {
         JavaClassSource javaEntity = lookupJavaEntityImpl(entity);
-        createAcceptMethod(entity, javaEntity);
-    }
 
-    /**
-     * Creates the "accept" method, needed by the Visitable interface that all nodes must
-     * implement.
-     * @param entity
-     * @param javaEntity
-     */
-    private void createAcceptMethod(EntityModel entity, JavaClassSource javaEntity) {
         VisitorModel visitorModel = getState().getConceptIndex().lookupVisitor(entity.getNamespace().fullName());
         JavaInterfaceSource javaVisitor = lookupJavaVisitor(visitorModel);
         String visitorInterfaceFQN = getRootVisitorInterfaceFQN();
         JavaInterfaceSource javaRootVisitorInterface = getState().getJavaIndex().lookupInterface(visitorInterfaceFQN);
 
-        String methodName = "accept";
-
-        javaEntity.addImport(javaVisitor);
-        javaEntity.addImport(javaRootVisitorInterface);
-        MethodSource<JavaClassSource> method = javaEntity.addMethod().setPublic().setName(methodName).setReturnTypeVoid();
-        method.addParameter(javaRootVisitorInterface.getName(), "visitor");
-        method.addAnnotation(Override.class);
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("visitorClass", javaVisitor.getName());
-        body.addContext("entityType", entity.getName());
-        body.append("${visitorClass} viz = (${visitorClass}) visitor;");
-        body.append("viz.visit${entityType}(this);");
-        method.setBody(body.toString());
+        new AcceptMethod(entity.getName(), javaVisitor, javaRootVisitorInterface).writeTo(javaEntity);
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateEmptyCloneMethodStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateEmptyCloneMethodStage.java
@@ -2,10 +2,9 @@ package io.apitomy.umg.pipe.java;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.EmptyCloneMethod;
 
 /**
  * Creates the "emptyClone" method for all entity implementations.  This is required by the
@@ -24,29 +23,11 @@ public class CreateEmptyCloneMethodStage extends AbstractJavaStage {
 
     private void createEmptyCloneMethod(EntityModel entity) {
         JavaClassSource javaEntity = lookupJavaEntityImpl(entity);
-        createEmptyCloneMethod(entity, javaEntity);
-    }
 
-    /**
-     * Creates the "emptyClone" method, needed by the Node interface that all nodes must
-     * implement.
-     * @param entity
-     * @param javaEntity
-     */
-    private void createEmptyCloneMethod(EntityModel entity, JavaClassSource javaEntity) {
         String nodeFQN = getNodeEntityInterfaceFQN();
         JavaInterfaceSource nodeInterfaceSource = getState().getJavaIndex().lookupInterface(nodeFQN);
 
-        String methodName = "emptyClone";
-
-        MethodSource<JavaClassSource> method = javaEntity.addMethod().setPublic().setName(methodName).setReturnType(nodeInterfaceSource);
-        method.addAnnotation(Override.class);
-        javaEntity.addImport(nodeInterfaceSource);
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("implClassName", javaEntity.getName());
-        body.append("return new ${implClassName}();");
-        method.setBody(body.toString());
+        new EmptyCloneMethod(javaEntity.getName(), nodeInterfaceSource).writeTo(javaEntity);
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -1,19 +1,13 @@
 package io.apitomy.umg.pipe.java;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
-import org.jboss.forge.roaster.model.source.MethodHolderSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.models.concept.EntityModel;
-import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.MappedNodeMethods;
 
 /**
  * Creates methods on all entity implementation classes.  This follows the same algorithm
@@ -55,136 +49,7 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
      */
     @Override
     protected void createMappedNodeMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {
-        PropertyModel property = propertyWithOrigin.getProperty();
-
-        String mappedNodeType;
-        javaEntity.addImport(List.class);
-        javaEntity.addImport(ArrayList.class);
-
-        var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
-        jt.addImportsTo(javaEntity);
-        mappedNodeType = jt.toJavaTypeString();
-
-        // T getItem(String name)
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItem").setPublic();
-            method.addAnnotation(Override.class);
-            method.addParameter("String", "name");
-            method.setReturnType(mappedNodeType);
-            BodyBuilder body = new BodyBuilder();
-            body.append("return this._items.get(name);");
-            method.setBody(body.toString());
-        }
-
-        // List<T> getItems()
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItems").setPublic();
-            method.addAnnotation(Override.class);
-            method.setReturnType("List<" + mappedNodeType + ">");
-            BodyBuilder body = new BodyBuilder();
-            body.addContext("itemType", mappedNodeType);
-            body.append("List<${itemType}> rval = new ArrayList<>();");
-            body.append("rval.addAll(this._items.values());");
-            body.append("return rval;");
-            method.setBody(body.toString());
-        }
-
-        // List<String> getItemNames()
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItemNames").setPublic();
-            method.addAnnotation(Override.class);
-            method.setReturnType("List<String>");
-            BodyBuilder body = new BodyBuilder();
-            body.addContext("itemType", mappedNodeType);
-            body.append("List<String> rval = new ArrayList<>();");
-            body.append("rval.addAll(this._items.keySet());");
-            body.append("return rval;");
-            method.setBody(body.toString());
-        }
-
-        // void addItem(String name, T item)
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("addItem").setPublic().setReturnTypeVoid();
-            method.addAnnotation(Override.class);
-            method.addParameter("String", "name");
-            method.addParameter(mappedNodeType, "item");
-            BodyBuilder body = new BodyBuilder();
-            body.append("this._items.put(name, item);");
-            if (isEntity(property)) {
-                JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                javaEntity.addImport(parentPropertyTypeSource);
-                JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                javaEntity.addImport(nodeImplSource);
-
-                body.append("if (item != null) {");
-                body.append("    ((NodeImpl) item)._setParent(this);");
-                body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
-                body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
-                body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
-                body.append("}");
-            }
-            method.setBody(body.toString());
-        }
-
-        // void insertItem(String name, T item, int atIndex)
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("insertItem").setPublic().setReturnTypeVoid();
-            method.addAnnotation(Override.class);
-            method.addParameter("String", "name");
-            method.addParameter(mappedNodeType, "item");
-            method.addParameter("int", "atIndex");
-
-            JavaClassSource dataModelUtilSource = getState().getJavaIndex().lookupClass(getDataModelUtilFQCN());
-            javaEntity.addImport(dataModelUtilSource);
-
-            BodyBuilder body = new BodyBuilder();
-            body.append("this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);");
-            if (isEntity(property)) {
-                JavaEnumSource parentPropertyTypeSource = getState().getJavaIndex().lookupEnum(getParentPropertyTypeEnumFQN());
-                javaEntity.addImport(parentPropertyTypeSource);
-                JavaClassSource nodeImplSource = getState().getJavaIndex().lookupClass(getNodeEntityClassFQN());
-                javaEntity.addImport(nodeImplSource);
-
-                body.append("if (item != null) {");
-                body.append("    ((NodeImpl) item)._setParent(this);");
-                body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
-                body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
-                body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
-                body.append("}");
-            }
-            method.setBody(body.toString());
-        }
-
-        // T removeItem(String name)
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("removeItem").setPublic();
-            method.addAnnotation(Override.class);
-            method.addParameter("String", "name");
-            method.setReturnType(mappedNodeType);
-            BodyBuilder body = new BodyBuilder();
-            body.addContext("mappedNodeType", mappedNodeType);
-            body.append("${mappedNodeType} removed = this._items.remove(name);");
-            if (isEntity(property)) {
-                body.append("if (removed != null) removed.detach();");
-            }
-            body.append("return removed;");
-            method.setBody(body.toString());
-        }
-
-        // void clearItems()
-        {
-            MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("clearItems").setPublic();
-            method.addAnnotation(Override.class);
-            method.setReturnTypeVoid();
-            BodyBuilder body = new BodyBuilder();
-            if (isEntity(property)) {
-                body.append("this._items.values().forEach(item -> {");
-                body.append("    if (item != null) item.detach();");
-                body.append("});");
-            }
-            body.append("this._items.clear();");
-            method.setBody(body.toString());
-        }
+        new MappedNodeMethods(propertyWithOrigin.getProperty(), propertyWithOrigin, getCtx()).writeTo(javaEntity);
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
@@ -9,6 +9,7 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.TraitModel;
+import io.apitomy.umg.pipe.java.method.MappedNodeMethods;
 
 /**
  * Adds methods to all entity interfaces. This works by finding all the properties for the entity and then
@@ -70,17 +71,6 @@ public class CreateInterfaceMethodsStage extends AbstractCreateMethodsStage {
      */
     @Override
     protected void createMappedNodeMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {
-        var property = propertyWithOrigin.getProperty();
-
-        String mappedNodeFQN = getMappedNodeInterfaceFQN();
-        JavaInterfaceSource mappedNodeInterface = getState().getJavaIndex().lookupInterface(mappedNodeFQN);
-
-        javaEntity.addImport(mappedNodeInterface);
-
-        var jt = getJavaTypeFactory().createJavaType(property.getResolvedType(), propertyWithOrigin.getOrigin().getNamespace());
-        jt.addImportsTo(javaEntity);
-        String mappedNodeInterfaceWithType = mappedNodeInterface.getName() + "<" + jt.toJavaTypeString() + ">";
-
-        ((JavaInterfaceSource) javaEntity).addInterface(mappedNodeInterfaceWithType);
+        new MappedNodeMethods(propertyWithOrigin.getProperty(), propertyWithOrigin, getCtx()).writeTo(javaEntity);
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionMethodImplementationsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateUnionMethodImplementationsStage.java
@@ -1,6 +1,5 @@
 package io.apitomy.umg.pipe.java;
 
-import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.type.EntityType;
 import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.models.concept.type.MapType;
@@ -17,7 +16,6 @@ import org.jboss.forge.roaster.model.source.MethodSource;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Generates is/as method implementations on union value classes and entity impl classes.
@@ -84,7 +82,6 @@ public class CreateUnionMethodImplementationsStage extends AbstractJavaStage {
         for (Type variantType : allVariants) {
             String typeName = JavaTypeFactory.getUnionComponentName(variantType);
             String isMethodName = UnionIsMethod.methodName(typeName);
-            String asMethodName = UnionAsMethod.methodName(typeName);
 
             if (implSource.hasMethodSignature(isMethodName)) {
                 continue;
@@ -95,26 +92,11 @@ public class CreateUnionMethodImplementationsStage extends AbstractJavaStage {
             boolean isActive = isSameVariant(activeVariant, variantType);
 
             // isXxx method
-            MethodSource<JavaClassSource> isMethod = implSource.addMethod()
-                    .setName(isMethodName).setReturnType(boolean.class).setPublic();
-            isMethod.addAnnotation(Override.class);
-            isMethod.setBody(isActive ? "return true;" : "return false;");
+            new UnionIsMethod(typeName, isActive).writeTo(implSource);
 
             // asXxx method
-            MethodSource<JavaClassSource> asMethod = implSource.addMethod()
-                    .setName(asMethodName).setReturnType(asMethodReturnType).setPublic();
-            asMethod.addAnnotation(Override.class);
-            jt.addImportsTo(implSource);
-
-            if (isActive) {
-                if (activeVariant instanceof EntityType) {
-                    asMethod.setBody("return this;");
-                } else {
-                    asMethod.setBody("return getValue();");
-                }
-            } else {
-                asMethod.setBody("throw new ClassCastException();");
-            }
+            boolean entityVariant = variantType instanceof EntityType;
+            new UnionAsMethod(typeName, asMethodReturnType, isActive, entityVariant, jt).writeTo(implSource);
         }
 
         // Add unionValue() for entity impls

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/AcceptMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/AcceptMethod.java
@@ -1,0 +1,57 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodHolderSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+/**
+ * Generates the {@code accept(Visitor)} method on entity impl classes.
+ * The method casts the visitor to the namespace-specific visitor interface
+ * and calls the appropriate visit method for the entity.
+ */
+public class AcceptMethod implements Method {
+
+    private final String entityName;
+    private final JavaInterfaceSource javaVisitor;
+    private final JavaInterfaceSource javaRootVisitorInterface;
+
+    public AcceptMethod(String entityName, JavaInterfaceSource javaVisitor,
+                        JavaInterfaceSource javaRootVisitorInterface) {
+        this.entityName = entityName;
+        this.javaVisitor = javaVisitor;
+        this.javaRootVisitorInterface = javaRootVisitorInterface;
+    }
+
+    @Override
+    public String getName() {
+        return "accept";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        target.addImport(javaVisitor);
+        target.addImport(javaRootVisitorInterface);
+
+        MethodSource<?> method = ((MethodHolderSource<?>) target).addMethod()
+                .setPublic()
+                .setName(getName())
+                .setReturnTypeVoid();
+        method.addParameter(javaRootVisitorInterface.getName(), "visitor");
+        method.addAnnotation(Override.class);
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("visitorClass", javaVisitor.getName());
+        body.addContext("entityType", entityName);
+        body.append("${visitorClass} viz = (${visitorClass}) visitor;");
+        body.append("viz.visit${entityType}(this);");
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        source.addImport(javaVisitor);
+        source.addImport(javaRootVisitorInterface);
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -89,6 +89,10 @@ public class CodeGenContext {
         return rootNamespace + ".ParentPropertyType";
     }
 
+    public String getMappedNodeInterfaceFQN() {
+        return rootNamespace + ".MappedNode";
+    }
+
     public String getUnionValueInterfaceFQN() {
         return getUnionTypesPackageName() + ".UnionValue";
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/EmptyCloneMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/EmptyCloneMethod.java
@@ -1,0 +1,50 @@
+package io.apitomy.umg.pipe.java.method;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodHolderSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+/**
+ * Generates the {@code emptyClone()} method on entity impl classes.
+ * Returns a new empty instance of the same implementation class, typed as
+ * the {@code Node} interface.
+ */
+public class EmptyCloneMethod implements Method {
+
+    private final String implClassName;
+    private final JavaInterfaceSource nodeInterfaceSource;
+
+    public EmptyCloneMethod(String implClassName, JavaInterfaceSource nodeInterfaceSource) {
+        this.implClassName = implClassName;
+        this.nodeInterfaceSource = nodeInterfaceSource;
+    }
+
+    @Override
+    public String getName() {
+        return "emptyClone";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        target.addImport(nodeInterfaceSource);
+
+        MethodSource<?> method = ((MethodHolderSource<?>) target).addMethod()
+                .setPublic()
+                .setName(getName())
+                .setReturnType(nodeInterfaceSource);
+        method.addAnnotation(Override.class);
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("implClassName", implClassName);
+        body.append("return new ${implClassName}();");
+        method.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        source.addImport(nodeInterfaceSource);
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
@@ -1,0 +1,192 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodHolderSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+
+/**
+ * Generates all 7 MappedNode methods on entity implementation classes:
+ * {@code getItem}, {@code getItems}, {@code getItemNames}, {@code addItem},
+ * {@code insertItem}, {@code removeItem}, and {@code clearItems}.
+ * <p>
+ * For interface targets, adds the {@code MappedNode<T>} superinterface instead.
+ */
+public class MappedNodeMethods {
+
+    private final PropertyModel property;
+    private final PropertyModelWithOrigin propertyWithOrigin;
+    private final CodeGenContext ctx;
+
+    public MappedNodeMethods(PropertyModel property, PropertyModelWithOrigin propertyWithOrigin,
+                             CodeGenContext ctx) {
+        this.property = property;
+        this.propertyWithOrigin = propertyWithOrigin;
+        this.ctx = ctx;
+    }
+
+    public void writeTo(JavaSource<?> target) {
+        if (target instanceof JavaInterfaceSource) {
+            writeInterfaceMethods((JavaInterfaceSource) target);
+        } else {
+            writeImplMethods(target);
+        }
+    }
+
+    private void writeInterfaceMethods(JavaInterfaceSource javaEntity) {
+        String mappedNodeFQN = ctx.getMappedNodeInterfaceFQN();
+        JavaInterfaceSource mappedNodeInterface = ctx.getJavaIndex().lookupInterface(mappedNodeFQN);
+
+        javaEntity.addImport(mappedNodeInterface);
+
+        var jt = ctx.getJavaTypeFactory().createJavaType(
+                property.getResolvedType(),
+                propertyWithOrigin.getOrigin().getNamespace());
+        jt.addImportsTo(javaEntity);
+        String mappedNodeInterfaceWithType = mappedNodeInterface.getName() + "<" + jt.toJavaTypeString() + ">";
+
+        javaEntity.addInterface(mappedNodeInterfaceWithType);
+    }
+
+    private void writeImplMethods(JavaSource<?> javaEntity) {
+        javaEntity.addImport(List.class);
+        javaEntity.addImport(ArrayList.class);
+
+        var jt = ctx.getJavaTypeFactory().createJavaType(
+                property.getResolvedType(),
+                propertyWithOrigin.getOrigin().getNamespace());
+        jt.addImportsTo(javaEntity);
+        String mappedNodeType = jt.toJavaTypeString();
+
+        boolean entityProperty = property.getResolvedType().isEntityType();
+
+        writeGetItem(javaEntity, mappedNodeType);
+        writeGetItems(javaEntity, mappedNodeType);
+        writeGetItemNames(javaEntity);
+        writeAddItem(javaEntity, mappedNodeType, entityProperty);
+        writeInsertItem(javaEntity, mappedNodeType, entityProperty);
+        writeRemoveItem(javaEntity, mappedNodeType, entityProperty);
+        writeClearItems(javaEntity, entityProperty);
+    }
+
+    private void writeGetItem(JavaSource<?> javaEntity, String mappedNodeType) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItem").setPublic();
+        method.addAnnotation(Override.class);
+        method.addParameter("String", "name");
+        method.setReturnType(mappedNodeType);
+        BodyBuilder body = new BodyBuilder();
+        body.append("return this._items.get(name);");
+        method.setBody(body.toString());
+    }
+
+    private void writeGetItems(JavaSource<?> javaEntity, String mappedNodeType) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItems").setPublic();
+        method.addAnnotation(Override.class);
+        method.setReturnType("List<" + mappedNodeType + ">");
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("itemType", mappedNodeType);
+        body.append("List<${itemType}> rval = new ArrayList<>();");
+        body.append("rval.addAll(this._items.values());");
+        body.append("return rval;");
+        method.setBody(body.toString());
+    }
+
+    private void writeGetItemNames(JavaSource<?> javaEntity) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("getItemNames").setPublic();
+        method.addAnnotation(Override.class);
+        method.setReturnType("List<String>");
+        BodyBuilder body = new BodyBuilder();
+        body.append("List<String> rval = new ArrayList<>();");
+        body.append("rval.addAll(this._items.keySet());");
+        body.append("return rval;");
+        method.setBody(body.toString());
+    }
+
+    private void writeAddItem(JavaSource<?> javaEntity, String mappedNodeType, boolean entityProperty) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("addItem").setPublic().setReturnTypeVoid();
+        method.addAnnotation(Override.class);
+        method.addParameter("String", "name");
+        method.addParameter(mappedNodeType, "item");
+        BodyBuilder body = new BodyBuilder();
+        body.append("this._items.put(name, item);");
+        if (entityProperty) {
+            addParentTrackingImports(javaEntity);
+            body.append("if (item != null) {");
+            body.append("    ((NodeImpl) item)._setParent(this);");
+            body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
+            body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
+            body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
+            body.append("}");
+        }
+        method.setBody(body.toString());
+    }
+
+    private void writeInsertItem(JavaSource<?> javaEntity, String mappedNodeType, boolean entityProperty) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("insertItem").setPublic().setReturnTypeVoid();
+        method.addAnnotation(Override.class);
+        method.addParameter("String", "name");
+        method.addParameter(mappedNodeType, "item");
+        method.addParameter("int", "atIndex");
+
+        JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+        javaEntity.addImport(dataModelUtilSource);
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);");
+        if (entityProperty) {
+            addParentTrackingImports(javaEntity);
+            body.append("if (item != null) {");
+            body.append("    ((NodeImpl) item)._setParent(this);");
+            body.append("    ((NodeImpl) item)._setParentPropertyName(null);");
+            body.append("    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);");
+            body.append("    ((NodeImpl) item)._setMapPropertyName(name);");
+            body.append("}");
+        }
+        method.setBody(body.toString());
+    }
+
+    private void writeRemoveItem(JavaSource<?> javaEntity, String mappedNodeType, boolean entityProperty) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("removeItem").setPublic();
+        method.addAnnotation(Override.class);
+        method.addParameter("String", "name");
+        method.setReturnType(mappedNodeType);
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("mappedNodeType", mappedNodeType);
+        body.append("${mappedNodeType} removed = this._items.remove(name);");
+        if (entityProperty) {
+            body.append("if (removed != null) removed.detach();");
+        }
+        body.append("return removed;");
+        method.setBody(body.toString());
+    }
+
+    private void writeClearItems(JavaSource<?> javaEntity, boolean entityProperty) {
+        MethodSource<?> method = ((MethodHolderSource<?>) javaEntity).addMethod().setName("clearItems").setPublic();
+        method.addAnnotation(Override.class);
+        method.setReturnTypeVoid();
+        BodyBuilder body = new BodyBuilder();
+        if (entityProperty) {
+            body.append("this._items.values().forEach(item -> {");
+            body.append("    if (item != null) item.detach();");
+            body.append("});");
+        }
+        body.append("this._items.clear();");
+        method.setBody(body.toString());
+    }
+
+    private void addParentTrackingImports(JavaSource<?> javaEntity) {
+        JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
+        javaEntity.addImport(parentPropertyTypeSource);
+        JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
+        javaEntity.addImport(nodeImplSource);
+    }
+
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/UnionAsMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/UnionAsMethod.java
@@ -1,23 +1,51 @@
 package io.apitomy.umg.pipe.java.method;
 
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodHolderSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.java.type.JavaType;
 import io.apitomy.umg.models.java.type.JavaTypeFactory;
 
 /**
- * Naming class for union "as" methods: {@code as${ComponentName}}.
+ * Generates union "as" methods: {@code as${ComponentName}}.
+ * <p>
+ * When constructed with just a component name or variant type, this is a
+ * naming-only helper (calling {@link #writeTo} will throw). Supply return type
+ * info and active/entity flags via the full constructor to enable code generation.
  */
 public class UnionAsMethod implements Method {
 
     private final String componentName;
+    private final String returnType;
+    private final Boolean active;
+    private final boolean entityVariant;
+    private final JavaType javaType;
 
     public UnionAsMethod(Type variantType) {
         this.componentName = JavaTypeFactory.getUnionComponentName(variantType);
+        this.returnType = null;
+        this.active = null;
+        this.entityVariant = false;
+        this.javaType = null;
     }
 
     public UnionAsMethod(String componentName) {
         this.componentName = componentName;
+        this.returnType = null;
+        this.active = null;
+        this.entityVariant = false;
+        this.javaType = null;
+    }
+
+    public UnionAsMethod(String componentName, String returnType, boolean active, boolean entityVariant,
+                         JavaType javaType) {
+        this.componentName = componentName;
+        this.returnType = returnType;
+        this.active = active;
+        this.entityVariant = entityVariant;
+        this.javaType = javaType;
     }
 
     /**
@@ -41,13 +69,32 @@ public class UnionAsMethod implements Method {
 
     @Override
     public void writeTo(JavaSource<?> target) {
-        throw new UnsupportedOperationException(
-                "UnionAsMethod is a naming-only helper and does not support writeTo(JavaSource)");
+        if (active == null) {
+            throw new UnsupportedOperationException(
+                    "UnionAsMethod requires the active/returnType flags to support writeTo(JavaSource)");
+        }
+
+        MethodSource<?> method = ((MethodHolderSource<?>) target).addMethod()
+                .setName(getName()).setReturnType(returnType).setPublic();
+        method.addAnnotation(Override.class);
+        javaType.addImportsTo(target);
+
+        if (active) {
+            if (entityVariant) {
+                method.setBody("return this;");
+            } else {
+                method.setBody("return getValue();");
+            }
+        } else {
+            method.setBody("throw new ClassCastException();");
+        }
     }
 
     @Override
     public void addImportsTo(JavaSource<?> source) {
-        // No imports needed
+        if (javaType != null) {
+            javaType.addImportsTo(source);
+        }
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/UnionIsMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/UnionIsMethod.java
@@ -1,23 +1,37 @@
 package io.apitomy.umg.pipe.java.method;
 
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodHolderSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.models.java.type.JavaTypeFactory;
 
 /**
- * Naming class for union "is" methods: {@code is${ComponentName}}.
+ * Generates union "is" methods: {@code is${ComponentName}}.
+ * <p>
+ * When constructed with just a component name or variant type, this is a
+ * naming-only helper (calling {@link #writeTo} will throw). Supply the
+ * {@code active} flag via the full constructor to enable code generation.
  */
 public class UnionIsMethod implements Method {
 
     private final String componentName;
+    private final Boolean active;
 
     public UnionIsMethod(Type variantType) {
         this.componentName = JavaTypeFactory.getUnionComponentName(variantType);
+        this.active = null;
     }
 
     public UnionIsMethod(String componentName) {
         this.componentName = componentName;
+        this.active = null;
+    }
+
+    public UnionIsMethod(String componentName, boolean active) {
+        this.componentName = componentName;
+        this.active = active;
     }
 
     /**
@@ -41,8 +55,15 @@ public class UnionIsMethod implements Method {
 
     @Override
     public void writeTo(JavaSource<?> target) {
-        throw new UnsupportedOperationException(
-                "UnionIsMethod is a naming-only helper and does not support writeTo(JavaSource)");
+        if (active == null) {
+            throw new UnsupportedOperationException(
+                    "UnionIsMethod requires the active flag to support writeTo(JavaSource)");
+        }
+
+        MethodSource<?> method = ((MethodHolderSource<?>) target).addMethod()
+                .setName(getName()).setReturnType(boolean.class).setPublic();
+        method.addAnnotation(Override.class);
+        method.setBody(active ? "return true;" : "return false;");
     }
 
     @Override


### PR DESCRIPTION
## Summary

New method classes for remaining generated methods:

| Method Class | Generates | From Stage |
|-------------|-----------|------------|
| `EmptyCloneMethod` | `emptyClone()` | CreateEmptyCloneMethodStage |
| `AcceptMethod` | `accept(Visitor)` | CreateAcceptMethodStage |
| `UnionIsMethod` (writeTo) | `isXxx()` true/false | CreateUnionMethodImplementationsStage |
| `UnionAsMethod` (writeTo) | `asXxx()` return/throw | CreateUnionMethodImplementationsStage |
| `MappedNodeMethods` | 7 MappedNode methods | CreateImplMethodsStage |

Stages now delegate to method classes. Net -133 lines.

## Context

C32d Step 2c in #1042. All generated methods now have corresponding method classes with `writeTo(JavaSource<?>)`. Steps 2d (factory methods), 3 (orchestration base), 4 (AbstractJavaStage thinning), 5 (merge trivial stages) remain.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged