### PR TITLE
refactor(generator): factory method classes — IOFactory, IODispatcher, ClonerFactory (C32d Step 2d)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerFactoryStage.java
@@ -1,12 +1,13 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.ClonerFactoryMethod;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
 
 /**
  * Creates a cloner factory that knows how to create the correct cloner for
@@ -24,49 +25,19 @@ public class CreateClonerFactoryStage extends AbstractJavaStage {
                 .setName(clonerFactoryClassName)
                 .setPublic();
 
-        createClonerFactoryMethod(factoryClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new ClonerFactoryMethod(specVersions, ctx).writeTo(factoryClassSource);
 
         getState().getJavaIndex().index(factoryClassSource);
-    }
-
-    private void createClonerFactoryMethod(JavaClassSource factoryClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        factoryClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelClonerSource = getState().getJavaIndex().lookupInterface(getModelClonerInterfaceFQN());
-        factoryClassSource.addImport(modelClonerSource);
-
-        MethodSource<JavaClassSource> factoryMethodSource = factoryClassSource.addMethod()
-                .setName("createModelCloner").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelClonerSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelCloner cloner = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String clonerPackageName = getClonerPackageName(specVersion);
-            String clonerClassName = getClonerClassName(specVersion);
-            String clonerFQN = clonerPackageName + "." + clonerClassName;
-            String dispatcherClassName = clonerClassName + "Dispatcher";
-            String dispatcherFQN = clonerPackageName + "." + dispatcherClassName;
-
-            JavaClassSource clonerSource = getState().getJavaIndex().lookupClass(clonerFQN);
-            factoryClassSource.addImport(clonerSource);
-            JavaClassSource dispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            factoryClassSource.addImport(dispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("clonerClassName", clonerSource.getName());
-            body.addContext("dispatcherClassName", dispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        cloner = new ${dispatcherClassName}(new ${clonerClassName}());");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return cloner;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderFactoryStage.java
@@ -1,14 +1,14 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.IODispatcherFactoryMethod;
+import io.apitomy.umg.pipe.java.method.IOFactoryMethod;
 
 /**
  * Creates a reader factory that knows how to create the correct reader for
@@ -29,89 +29,22 @@ public class CreateReaderFactoryStage extends AbstractJavaStage {
                 .setName(readerFactoryClassName)
                 .setPublic();
 
-        createReaderFactoryMethod(readerClassSource);
-        createReaderDispatcherFactoryMethod(readerClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new IOFactoryMethod(IOFactoryMethod.Mode.READER, specVersions, ctx)
+                .writeTo(readerClassSource);
+        new IODispatcherFactoryMethod(IOFactoryMethod.Mode.READER, specVersions, ctx)
+                .writeTo(readerClassSource);
 
         getState().getJavaIndex().index(readerClassSource);
-    }
-
-    private void createReaderFactoryMethod(JavaClassSource readerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelReaderSource = getState().getJavaIndex().lookupInterface(getModelReaderInterfaceFQN());
-        readerClassSource.addImport(modelReaderSource);
-
-        MethodSource<JavaClassSource> factoryMethodSource = readerClassSource.addMethod()
-                .setName("createModelReader").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelReaderSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelReader reader = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String specModelReaderFQN = getReaderPackageName(specVersion) + "." + getReaderClassName(specVersion);
-            JavaClassSource specModelReaderSource = getState().getJavaIndex().lookupClass(specModelReaderFQN);
-            readerClassSource.addImport(specModelReaderSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("modelReaderClassName", specModelReaderSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        reader = new ${modelReaderClassName}();");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return reader;");
-        factoryMethodSource.setBody(body.toString());
-    }
-
-    private void createReaderDispatcherFactoryMethod(JavaClassSource readerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource rootVisitorInterfaceSource = getState().getJavaIndex().lookupInterface(getRootVisitorInterfaceFQN());
-        readerClassSource.addImport(rootVisitorInterfaceSource);
-
-        readerClassSource.addImport(ObjectNode.class);
-
-        MethodSource<JavaClassSource> factoryMethodSource = readerClassSource.addMethod()
-                .setName("createModelReaderDispatcher").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("visitorName", rootVisitorInterfaceSource.getName());
-
-        body.append("ModelReader reader = ModelReaderFactory.createModelReader(modelType);");
-        body.append("${visitorName} visitor = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String readerPackageName = getReaderPackageName(specVersion);
-            String readerClassName = getReaderClassName(specVersion);
-            String readerFQN = readerPackageName + "." + readerClassName;
-            String dispatcherPackageName = readerPackageName;
-            String dispatcherClassName = readerClassName + "Dispatcher";
-            String dispatcherFQN = dispatcherPackageName + "." + dispatcherClassName;
-
-            JavaClassSource readerSource = getState().getJavaIndex().lookupClass(readerFQN);
-            readerClassSource.addImport(readerSource);
-            JavaClassSource readerDispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            readerClassSource.addImport(readerDispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("readerClassName", readerSource.getName());
-            body.addContext("dispatcherClassName", readerDispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        visitor = new ${dispatcherClassName}(json, (${readerClassName}) reader);");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return visitor;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterFactoryStage.java
@@ -1,14 +1,14 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.IODispatcherFactoryMethod;
+import io.apitomy.umg.pipe.java.method.IOFactoryMethod;
 
 /**
  * Creates a writer factory that knows how to create the correct writer for
@@ -29,90 +29,22 @@ public class CreateWriterFactoryStage extends AbstractJavaStage {
                 .setName(writerFactoryClassName)
                 .setPublic();
 
-        createWriterFactoryMethod(writerClassSource);
-        createWriterDispatcherFactoryMethod(writerClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new IOFactoryMethod(IOFactoryMethod.Mode.WRITER, specVersions, ctx)
+                .writeTo(writerClassSource);
+        new IODispatcherFactoryMethod(IOFactoryMethod.Mode.WRITER, specVersions, ctx)
+                .writeTo(writerClassSource);
 
         getState().getJavaIndex().index(writerClassSource);
-    }
-
-    private void createWriterFactoryMethod(JavaClassSource writerClassSource) {
-        // Some imports (model type, model writer interface, etc)
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        writerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelWriterSource = getState().getJavaIndex().lookupInterface(getModelWriterInterfaceFQN());
-        writerClassSource.addImport(modelWriterSource);
-
-        // Create the factory method.
-        MethodSource<JavaClassSource> factoryMethodSource = writerClassSource.addMethod().setName("createModelWriter").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelWriterSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelWriter writer = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String specModelWriterFQN = getWriterPackageName(specVersion) + "." + getWriterClassName(specVersion);
-            JavaClassSource specModelWriterSource = getState().getJavaIndex().lookupClass(specModelWriterFQN);
-            writerClassSource.addImport(specModelWriterSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("modelWriterClassName", specModelWriterSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        writer = new ${modelWriterClassName}();");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return writer;");
-        factoryMethodSource.setBody(body.toString());
-    }
-
-    private void createWriterDispatcherFactoryMethod(JavaClassSource writerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        writerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource rootVisitorInterfaceSource = getState().getJavaIndex().lookupInterface(getRootVisitorInterfaceFQN());
-        writerClassSource.addImport(rootVisitorInterfaceSource);
-
-        writerClassSource.addImport(ObjectNode.class);
-
-        MethodSource<JavaClassSource> factoryMethodSource = writerClassSource.addMethod()
-                .setName("createModelWriterDispatcher").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("visitorName", rootVisitorInterfaceSource.getName());
-
-        body.append("ModelWriter writer = ModelWriterFactory.createModelWriter(modelType);");
-        body.append("${visitorName} visitor = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String writerPackageName = getWriterPackageName(specVersion);
-            String writerClassName = getWriterClassName(specVersion);
-            String writerFQN = writerPackageName + "." + writerClassName;
-            String dispatcherPackageName = writerPackageName;
-            String dispatcherClassName = writerClassName + "Dispatcher";
-            String dispatcherFQN = dispatcherPackageName + "." + dispatcherClassName;
-
-            JavaClassSource writerSource = getState().getJavaIndex().lookupClass(writerFQN);
-            writerClassSource.addImport(writerSource);
-            JavaClassSource writerDispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            writerClassSource.addImport(writerDispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("writerClassName", writerSource.getName());
-            body.addContext("dispatcherClassName", writerDispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        visitor = new ${dispatcherClassName}(json, (${writerClassName}) writer);");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return visitor;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClonerFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClonerFactoryMethod.java
@@ -1,0 +1,86 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelCloner(ModelType)} factory method — a
+ * static switch that instantiates the correct spec-version cloner wrapped
+ * in its dispatcher.
+ *
+ * <p>The cloner factory differs from reader/writer because the switch
+ * body creates {@code new ClonerDispatcher(new Cloner())} rather than a
+ * plain {@code new Cloner()}.
+ */
+public class ClonerFactoryMethod implements Method {
+
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public ClonerFactoryMethod(Collection<SpecificationVersion> specVersions,
+                               CodeGenContext ctx) {
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModelCloner";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+        JavaInterfaceSource modelClonerSource =
+                ctx.getJavaIndex().lookupInterface(ctx.getModelClonerInterfaceFQN());
+        classSource.addImport(modelClonerSource);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(modelClonerSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("ModelCloner cloner = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String clonerPackageName = specVersion.getNamespace() + ".io";
+            String clonerClassName = specVersion.getPrefix() + "ModelCloner";
+            String clonerFQN = clonerPackageName + "." + clonerClassName;
+            String dispatcherClassName = clonerClassName + "Dispatcher";
+            String dispatcherFQN = clonerPackageName + "." + dispatcherClassName;
+
+            JavaClassSource clonerSource = ctx.getJavaIndex().lookupClass(clonerFQN);
+            classSource.addImport(clonerSource);
+            JavaClassSource dispatcherSource = ctx.getJavaIndex().lookupClass(dispatcherFQN);
+            classSource.addImport(dispatcherSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("clonerClassName", clonerSource.getName());
+            body.addContext("dispatcherClassName", dispatcherSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        cloner = new ${dispatcherClassName}(new ${clonerClassName}());");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return cloner;");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -105,6 +105,26 @@ public class CodeGenContext {
         return rootNamespace + ".ModelType";
     }
 
+    public String getModelReaderInterfaceFQN() {
+        return rootNamespace + ".io.ModelReader";
+    }
+
+    public String getModelWriterInterfaceFQN() {
+        return rootNamespace + ".io.ModelWriter";
+    }
+
+    public String getModelClonerInterfaceFQN() {
+        return rootNamespace + ".io.ModelCloner";
+    }
+
+    public String getRootVisitorInterfaceFQN() {
+        return rootNamespace + ".visitors.Visitor";
+    }
+
+    public SpecificationIndex getSpecIndex() {
+        return specIndex;
+    }
+
     /**
      * Resolves the package for union value impl classes, preferring the common-entity
      * namespace when a variant references a common entity.

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/IODispatcherFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/IODispatcherFactoryMethod.java
@@ -1,0 +1,106 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelReaderDispatcher(ModelType, ObjectNode)} or
+ * {@code createModelWriterDispatcher(ModelType, ObjectNode)} factory method
+ * — a static switch that creates the correct dispatcher for a given spec
+ * version.
+ *
+ * <p>Parameterised by {@link IOFactoryMethod.Mode} so a single class handles
+ * both Reader and Writer dispatchers (they are structurally identical).
+ */
+public class IODispatcherFactoryMethod implements Method {
+
+    private final IOFactoryMethod.Mode mode;
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public IODispatcherFactoryMethod(IOFactoryMethod.Mode mode,
+                                     Collection<SpecificationVersion> specVersions,
+                                     CodeGenContext ctx) {
+        this.mode = mode;
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModel" + mode.label() + "Dispatcher";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+
+        JavaInterfaceSource rootVisitorInterfaceSource =
+                ctx.getJavaIndex().lookupInterface(ctx.getRootVisitorInterfaceFQN());
+        classSource.addImport(rootVisitorInterfaceSource);
+
+        classSource.addImport(ObjectNode.class);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
+
+        String varName = mode.varName();         // "reader" or "writer"
+        String label = mode.label();             // "Reader" or "Writer"
+        String visitorName = rootVisitorInterfaceSource.getName();
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("visitorName", visitorName);
+        body.addContext("interfaceName", "Model" + label);
+        body.addContext("factoryClassName", "Model" + label + "Factory");
+        body.addContext("createMethodName", "createModel" + label);
+        body.addContext("varName", varName);
+
+        body.append("${interfaceName} ${varName} = ${factoryClassName}.${createMethodName}(modelType);");
+        body.append("${visitorName} visitor = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String ioPackageName = specVersion.getNamespace() + ".io";
+            String ioClassName = specVersion.getPrefix() + "Model" + label;
+            String ioFQN = ioPackageName + "." + ioClassName;
+            String dispatcherClassName = ioClassName + "Dispatcher";
+            String dispatcherFQN = ioPackageName + "." + dispatcherClassName;
+
+            JavaClassSource ioSource = ctx.getJavaIndex().lookupClass(ioFQN);
+            classSource.addImport(ioSource);
+            JavaClassSource dispatcherSource = ctx.getJavaIndex().lookupClass(dispatcherFQN);
+            classSource.addImport(dispatcherSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("ioClassName", ioSource.getName());
+            body.addContext("dispatcherClassName", dispatcherSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        visitor = new ${dispatcherClassName}(json, (${ioClassName}) ${varName});");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return visitor;");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/IOFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/IOFactoryMethod.java
@@ -1,0 +1,110 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelReader(ModelType)} or
+ * {@code createModelWriter(ModelType)} factory method — a static switch
+ * that instantiates the correct spec-version reader/writer.
+ *
+ * <p>Parameterised by {@link Mode} so a single class handles both
+ * Reader and Writer (they are structurally identical).
+ */
+public class IOFactoryMethod implements Method {
+
+    /** Whether this method targets the reader or writer factory. */
+    public enum Mode {
+        READER("Reader", "reader"),
+        WRITER("Writer", "writer");
+
+        private final String label;
+        private final String varName;
+
+        Mode(String label, String varName) {
+            this.label = label;
+            this.varName = varName;
+        }
+
+        /** e.g. "Reader" or "Writer" */
+        public String label() { return label; }
+
+        /** e.g. "reader" or "writer" */
+        public String varName() { return varName; }
+    }
+
+    private final Mode mode;
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public IOFactoryMethod(Mode mode, Collection<SpecificationVersion> specVersions,
+                           CodeGenContext ctx) {
+        this.mode = mode;
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModel" + mode.label();
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+
+        String interfaceFQN = mode == Mode.READER
+                ? ctx.getModelReaderInterfaceFQN()
+                : ctx.getModelWriterInterfaceFQN();
+        JavaInterfaceSource ioInterfaceSource = ctx.getJavaIndex().lookupInterface(interfaceFQN);
+        classSource.addImport(ioInterfaceSource);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(ioInterfaceSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+
+        String interfaceName = ioInterfaceSource.getName(); // e.g. "ModelReader"
+        String varName = mode.varName();                    // e.g. "reader"
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("interfaceName", interfaceName);
+        body.addContext("varName", varName);
+        body.append("${interfaceName} ${varName} = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String ioPackageName = specVersion.getNamespace() + ".io";
+            String ioClassName = specVersion.getPrefix() + "Model" + mode.label();
+            String ioFQN = ioPackageName + "." + ioClassName;
+
+            JavaClassSource specIOSource = ctx.getJavaIndex().lookupClass(ioFQN);
+            classSource.addImport(specIOSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("ioClassName", specIOSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        ${varName} = new ${ioClassName}();");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return ${varName};");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}


### PR DESCRIPTION
## Summary

3 new method classes for factory stage logic (parameterized to avoid 6 separate classes):

| Method Class | Mode | Generates |
|-------------|------|-----------|
| `IOFactoryMethod` | READER/WRITER | `createModelReader/Writer(ModelType)` switch |
| `IODispatcherFactoryMethod` | READER/WRITER | `createModelReader/WriterDispatcher(ModelType, ObjectNode)` switch |
| `ClonerFactoryMethod` | — | `createModelCloner(ModelType)` with unique dispatcher construction |

Factory stages are now thin wrappers. Net -144 lines.

Smart observation by the agent: reader/writer factories are structurally identical (just class name substitution), so a single parameterized `IOFactoryMethod` with `Mode.READER`/`Mode.WRITER` handles both. Cloner has a unique pattern (nested dispatcher construction), so it gets its own class.

## Context

C32d Step 2d in #1042. Completes the method class extraction — every generated method now has a corresponding method class.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged