### PR TITLE
refactor(generator): extract AbstractIOStage for reader/writer/cloner (C32d Step 3)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractIOStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractIOStage.java
@@ -1,0 +1,146 @@
+package io.apitomy.umg.pipe.java;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
+
+/**
+ * Shared orchestration for the reader, writer, and cloner stages.
+ *
+ * <p>Template method pattern: subclasses provide naming, imports, method
+ * creation, and property-block factories; this class owns the spec-version
+ * iteration, Roaster class creation, entity loop, and property-type dispatch.
+ */
+public abstract class AbstractIOStage extends AbstractJavaStage {
+
+    protected CodeGenContext ctx;
+
+    @Override
+    protected void doProcess() {
+        ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+        getState().getSpecIndex().getAllSpecificationVersions()
+                .forEach(this::processSpecVersion);
+    }
+
+    private void processSpecVersion(SpecificationVersion specVersion) {
+        JavaClassSource classSource = Roaster.create(JavaClassSource.class)
+                .setPackage(getPackageName(specVersion))
+                .setName(getClassName(specVersion))
+                .setPublic();
+
+        addImports(classSource);
+        addInterfaceImplementation(classSource);
+
+        specVersion.getEntities().forEach(entity -> {
+            EntityModel entityModel = getState().getConceptIndex()
+                    .lookupEntity(specVersion.getNamespace() + "." + entity.getName());
+            if (entityModel == null) {
+                warn("Entity model not found for entity: " + entity);
+            } else {
+                createEntityMethod(specVersion, classSource, entityModel);
+            }
+        });
+
+        afterEntityMethods(specVersion, classSource);
+
+        getState().getJavaIndex().index(classSource);
+    }
+
+    // ---- Shared property-type dispatch ----
+
+    protected void dispatchProperty(BodyBuilder body, PropertyModelWithOrigin propertyWithOrigin,
+            EntityModel entityModel, JavaClassSource classSource) {
+        PropertyModel property = propertyWithOrigin.getProperty();
+        PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
+
+        if (isStarProperty(property)) {
+            createPropertyBlock(PropertyBlockKind.STAR, prop, classSource).appendTo(body);
+        } else if (isRegexProperty(property)) {
+            createPropertyBlock(PropertyBlockKind.REGEX, prop, classSource).appendTo(body);
+        } else if (!dispatchByResolvedType(body, property, prop, classSource)) {
+            warn("Entity property '" + property.getName()
+                    + "' not handled (unsupported) for entity: " + entityModel.fullyQualifiedName());
+        }
+    }
+
+    private boolean dispatchByResolvedType(BodyBuilder body, PropertyModel property,
+            PropertyCodeGen prop, JavaClassSource classSource) {
+        var resolved = property.getResolvedType();
+        if (resolved == null) return false;
+
+        if (resolved instanceof UnionType) {
+            createPropertyBlock(PropertyBlockKind.UNION, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved instanceof ListType lt && lt.getValueType() instanceof UnionType) {
+            createPropertyBlock(PropertyBlockKind.UNION_LIST, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved instanceof MapType mt && mt.getValueType() instanceof UnionType) {
+            createPropertyBlock(PropertyBlockKind.UNION_MAP, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved.isEntityType()) {
+            createPropertyBlock(PropertyBlockKind.ENTITY, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved.isPrimitiveType()) {
+            createPropertyBlock(PropertyBlockKind.PRIMITIVE, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved.isListType()) {
+            createPropertyBlock(PropertyBlockKind.LIST, prop, classSource).appendTo(body);
+            return true;
+        }
+        if (resolved.isMapType()) {
+            createPropertyBlock(PropertyBlockKind.MAP, prop, classSource).appendTo(body);
+            return true;
+        }
+        return false;
+    }
+
+    // ---- Abstract methods (must override) ----
+
+    protected abstract String getPackageName(SpecificationVersion specVersion);
+
+    protected abstract String getClassName(SpecificationVersion specVersion);
+
+    protected abstract void addImports(JavaClassSource classSource);
+
+    protected abstract void createEntityMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel);
+
+    protected abstract CodeBlock createPropertyBlock(PropertyBlockKind kind,
+            PropertyCodeGen prop, JavaClassSource classSource);
+
+    // ---- Hooks (default no-op) ----
+
+    protected void addInterfaceImplementation(JavaClassSource classSource) {}
+
+    protected void afterEntityMethods(SpecificationVersion specVersion, JavaClassSource classSource) {}
+
+    // ---- Property block kinds ----
+
+    protected enum PropertyBlockKind {
+        STAR, REGEX, UNION, UNION_LIST, UNION_MAP, ENTITY, PRIMITIVE, LIST, MAP
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerFactoryStage.java
@@ -1,12 +1,13 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.ClonerFactoryMethod;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
 
 /**
  * Creates a cloner factory that knows how to create the correct cloner for
@@ -24,49 +25,19 @@ public class CreateClonerFactoryStage extends AbstractJavaStage {
                 .setName(clonerFactoryClassName)
                 .setPublic();
 
-        createClonerFactoryMethod(factoryClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new ClonerFactoryMethod(specVersions, ctx).writeTo(factoryClassSource);
 
         getState().getJavaIndex().index(factoryClassSource);
-    }
-
-    private void createClonerFactoryMethod(JavaClassSource factoryClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        factoryClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelClonerSource = getState().getJavaIndex().lookupInterface(getModelClonerInterfaceFQN());
-        factoryClassSource.addImport(modelClonerSource);
-
-        MethodSource<JavaClassSource> factoryMethodSource = factoryClassSource.addMethod()
-                .setName("createModelCloner").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelClonerSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelCloner cloner = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String clonerPackageName = getClonerPackageName(specVersion);
-            String clonerClassName = getClonerClassName(specVersion);
-            String clonerFQN = clonerPackageName + "." + clonerClassName;
-            String dispatcherClassName = clonerClassName + "Dispatcher";
-            String dispatcherFQN = clonerPackageName + "." + dispatcherClassName;
-
-            JavaClassSource clonerSource = getState().getJavaIndex().lookupClass(clonerFQN);
-            factoryClassSource.addImport(clonerSource);
-            JavaClassSource dispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            factoryClassSource.addImport(dispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("clonerClassName", clonerSource.getName());
-            body.addContext("dispatcherClassName", dispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        cloner = new ${dispatcherClassName}(new ${clonerClassName}());");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return cloner;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -1,13 +1,8 @@
 package io.apitomy.umg.pipe.java;
 
-import io.apitomy.umg.models.concept.type.UnionVariantComparator;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
-import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
@@ -16,20 +11,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
-import io.apitomy.umg.models.concept.NamespaceModel;
-import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
-
-import java.util.Comparator;
-import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.ClonerMethod;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
-import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.cloner.CloneEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneListPropertyBlock;
@@ -37,73 +22,37 @@ import io.apitomy.umg.pipe.java.method.cloner.CloneMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.ClonePrimitivePropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneRegexPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneStarPropertyBlock;
-import io.apitomy.umg.pipe.java.method.cloner.CloneUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.cloner.CloneUnionMapPropertyBlock;
-import io.apitomy.umg.models.java.type.JavaTypeFactory;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import io.apitomy.umg.pipe.java.method.cloner.CloneUnionPropertyBlock;
 
 /**
  * Creates the deep-copy cloner classes. There is a bespoke cloner for each specification
  * version. Each cloner can clone any node in the tree by walking the source node and
  * copying property values directly into a new target node -- avoiding JSON serialization.
  */
-public class CreateClonersStage extends AbstractJavaStage {
-
-    private CodeGenContext ctx;
+public class CreateClonersStage extends AbstractIOStage {
 
     @Override
-    protected void doProcess() {
-        ctx = new CodeGenContext(
-                getState().getConceptIndex(),
-                getState().getJavaIndex(),
-                getJavaTypeFactory(),
-                getState().getConfig().getRootNamespace(),
-                getState().getSpecIndex(),
-                getClass().getSimpleName());
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            createCloner(specVersion);
-        });
+    protected String getPackageName(SpecificationVersion specVersion) {
+        return getClonerPackageName(specVersion);
     }
 
-    /**
-     * Creates a cloner for the given spec version.
-     * @param specVersion
-     */
-    private void createCloner(SpecificationVersion specVersion) {
-        String clonerPackageName = getClonerPackageName(specVersion);
-        String clonerClassName = getClonerClassName(specVersion);
-
-        debug("Creating cloner: " + clonerPackageName + "." + clonerClassName);
-
-        JavaClassSource clonerClassSource = Roaster.create(JavaClassSource.class)
-                .setPackage(clonerPackageName)
-                .setName(clonerClassName)
-                .setPublic();
-        clonerClassSource.addImport(getState().getConfig().getRootNamespace() + ".util." + "JsonUtil");
-
-        specVersion.getEntities().forEach(entity -> {
-            EntityModel entityModel = getState().getConceptIndex().lookupEntity(specVersion.getNamespace() + "." + entity.getName());
-            if (entityModel == null) {
-                warn("Entity model not found for entity: " + entity);
-            } else {
-                createCloneMethodFor(specVersion, clonerClassSource, entityModel);
-            }
-        });
-
-        getState().getJavaIndex().index(clonerClassSource);
+    @Override
+    protected String getClassName(SpecificationVersion specVersion) {
+        return getClonerClassName(specVersion);
     }
 
-    /**
-     * Creates a single "cloneXyz" method for the given entity.
-     * @param specVersion
-     * @param clonerClassSource
-     * @param entityModel
-     */
-    private void createCloneMethodFor(SpecificationVersion specVersion, JavaClassSource clonerClassSource, EntityModel entityModel) {
+    @Override
+    protected void addImports(JavaClassSource classSource) {
+        classSource.addImport(getState().getConfig().getRootNamespace() + ".util.JsonUtil");
+    }
+
+    @Override
+    protected void createEntityMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel) {
         String entityFQN = getJavaEntityInterfaceFQN(entityModel);
-        String cloneMethodName = cloneMethodName(entityModel);
+        String cloneMethodName = ClonerMethod.methodName(entityModel.getName());
 
         debug("Creating clone method: " + cloneMethodName);
 
@@ -113,8 +62,8 @@ public class CreateClonersStage extends AbstractJavaStage {
             return;
         }
 
-        clonerClassSource.addImport(javaEntity);
-        MethodSource<JavaClassSource> methodSource = clonerClassSource.addMethod()
+        classSource.addImport(javaEntity);
+        MethodSource<JavaClassSource> methodSource = classSource.addMethod()
                 .setName(cloneMethodName)
                 .setReturnTypeVoid()
                 .setPublic();
@@ -123,26 +72,21 @@ public class CreateClonersStage extends AbstractJavaStage {
 
         BodyBuilder body = new BodyBuilder();
 
-        Collection<PropertyModelWithOrigin> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel);
+        Collection<PropertyModelWithOrigin> allProperties =
+                getState().getConceptIndex().getAllEntityProperties(entityModel);
         allProperties.forEach(property -> {
-            createClonePropertyCode(body, property, entityModel, javaEntity, clonerClassSource);
+            body.clearContext();
+            dispatchProperty(body, property, entityModel, classSource);
         });
 
-        createCloneExtraPropertiesCode(body, clonerClassSource);
+        appendExtraPropertiesCode(body, classSource);
 
         methodSource.setBody(body.toString());
     }
 
-    private void createClonePropertyCode(BodyBuilder body, PropertyModelWithOrigin property, EntityModel entityModel,
-            JavaInterfaceSource javaEntity, JavaClassSource clonerClassSource) {
-        CreateCloneProperty ccp = new CreateCloneProperty(property, entityModel, javaEntity, clonerClassSource);
-        body.clearContext();
-        ccp.writeTo(body);
-    }
-
-    private void createCloneExtraPropertiesCode(BodyBuilder body, JavaClassSource clonerClassSource) {
-        clonerClassSource.addImport(JsonNode.class);
-        clonerClassSource.addImport(List.class);
+    private void appendExtraPropertiesCode(BodyBuilder body, JavaClassSource classSource) {
+        classSource.addImport(JsonNode.class);
+        classSource.addImport(List.class);
         body.append("{");
         body.append("    List<String> extraPropertyNames = source.getExtraPropertyNames();");
         body.append("    if (extraPropertyNames != null) {");
@@ -156,122 +100,20 @@ public class CreateClonersStage extends AbstractJavaStage {
         body.append("}");
     }
 
-    private static String cloneMethodName(EntityModel entityModel) {
-        return ClonerMethod.methodName(entityModel.getName());
-    }
-
-    @AllArgsConstructor
-    private class CreateCloneProperty {
-
-        PropertyModelWithOrigin propertyWithOrigin;
-        EntityModel entityModel;
-        JavaInterfaceSource javaEntity;
-        JavaClassSource clonerClassSource;
-
-        /**
-         * Generates code to clone a property from source to target.
-         * @param body
-         */
-        public void writeTo(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isStarProperty(property)) {
-                handleStarProperty(body);
-            } else if (isRegexProperty(property)) {
-                handleRegexProperty(body);
-            } else if (handleViaResolvedType(body)) {
-                // Handled by resolved type dispatch
-            } else {
-                warn("Entity property '" + property.getName() + "' not cloned (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            }
+    @Override
+    protected CodeBlock createPropertyBlock(PropertyBlockKind kind,
+            PropertyCodeGen prop, JavaClassSource classSource) {
+        switch (kind) {
+            case STAR:       return new CloneStarPropertyBlock(prop, classSource);
+            case REGEX:      return new CloneRegexPropertyBlock(prop, classSource);
+            case UNION:      return new CloneUnionPropertyBlock(prop, classSource);
+            case UNION_LIST: return new CloneUnionListPropertyBlock(prop, classSource);
+            case UNION_MAP:  return new CloneUnionMapPropertyBlock(prop, classSource);
+            case ENTITY:     return new CloneEntityPropertyBlock(prop, classSource);
+            case PRIMITIVE:  return new ClonePrimitivePropertyBlock(prop);
+            case LIST:       return new CloneListPropertyBlock(prop, classSource);
+            case MAP:        return new CloneMapPropertyBlock(prop, classSource);
+            default:         throw new IllegalArgumentException("Unknown block kind: " + kind);
         }
-
-        private boolean handleViaResolvedType(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var resolved = property.getResolvedType();
-            if (resolved == null) return false;
-
-            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleUnionProperty(body);
-                return true;
-            }
-
-            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
-                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleUnionListProperty(body);
-                return true;
-            }
-
-            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
-                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleUnionMapProperty(body);
-                return true;
-            }
-
-            if (resolved.isEntityType()) {
-                handleEntityProperty(body);
-                return true;
-            }
-            if (resolved.isPrimitiveType()) {
-                handlePrimitiveProperty(body);
-                return true;
-            }
-            if (resolved.isListType()) {
-                handleListProperty(body);
-                return true;
-            }
-            if (resolved.isMapType()) {
-                handleMapProperty(body);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void handlePrimitiveProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ClonePrimitivePropertyBlock(prop).appendTo(body);
-        }
-
-        private void handleEntityProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneEntityPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleStarProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneStarPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleRegexProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneRegexPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleListProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneListPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleMapProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneMapPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleUnionProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneUnionPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleUnionListProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneUnionListPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-        private void handleUnionMapProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new CloneUnionMapPropertyBlock(prop, clonerClassSource).appendTo(body);
-        }
-
-
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderFactoryStage.java
@@ -1,14 +1,14 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.IODispatcherFactoryMethod;
+import io.apitomy.umg.pipe.java.method.IOFactoryMethod;
 
 /**
  * Creates a reader factory that knows how to create the correct reader for
@@ -29,89 +29,22 @@ public class CreateReaderFactoryStage extends AbstractJavaStage {
                 .setName(readerFactoryClassName)
                 .setPublic();
 
-        createReaderFactoryMethod(readerClassSource);
-        createReaderDispatcherFactoryMethod(readerClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new IOFactoryMethod(IOFactoryMethod.Mode.READER, specVersions, ctx)
+                .writeTo(readerClassSource);
+        new IODispatcherFactoryMethod(IOFactoryMethod.Mode.READER, specVersions, ctx)
+                .writeTo(readerClassSource);
 
         getState().getJavaIndex().index(readerClassSource);
-    }
-
-    private void createReaderFactoryMethod(JavaClassSource readerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelReaderSource = getState().getJavaIndex().lookupInterface(getModelReaderInterfaceFQN());
-        readerClassSource.addImport(modelReaderSource);
-
-        MethodSource<JavaClassSource> factoryMethodSource = readerClassSource.addMethod()
-                .setName("createModelReader").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelReaderSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelReader reader = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String specModelReaderFQN = getReaderPackageName(specVersion) + "." + getReaderClassName(specVersion);
-            JavaClassSource specModelReaderSource = getState().getJavaIndex().lookupClass(specModelReaderFQN);
-            readerClassSource.addImport(specModelReaderSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("modelReaderClassName", specModelReaderSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        reader = new ${modelReaderClassName}();");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return reader;");
-        factoryMethodSource.setBody(body.toString());
-    }
-
-    private void createReaderDispatcherFactoryMethod(JavaClassSource readerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource rootVisitorInterfaceSource = getState().getJavaIndex().lookupInterface(getRootVisitorInterfaceFQN());
-        readerClassSource.addImport(rootVisitorInterfaceSource);
-
-        readerClassSource.addImport(ObjectNode.class);
-
-        MethodSource<JavaClassSource> factoryMethodSource = readerClassSource.addMethod()
-                .setName("createModelReaderDispatcher").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("visitorName", rootVisitorInterfaceSource.getName());
-
-        body.append("ModelReader reader = ModelReaderFactory.createModelReader(modelType);");
-        body.append("${visitorName} visitor = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String readerPackageName = getReaderPackageName(specVersion);
-            String readerClassName = getReaderClassName(specVersion);
-            String readerFQN = readerPackageName + "." + readerClassName;
-            String dispatcherPackageName = readerPackageName;
-            String dispatcherClassName = readerClassName + "Dispatcher";
-            String dispatcherFQN = dispatcherPackageName + "." + dispatcherClassName;
-
-            JavaClassSource readerSource = getState().getJavaIndex().lookupClass(readerFQN);
-            readerClassSource.addImport(readerSource);
-            JavaClassSource readerDispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            readerClassSource.addImport(readerDispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("readerClassName", readerSource.getName());
-            body.addContext("dispatcherClassName", readerDispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        visitor = new ${dispatcherClassName}(json, (${readerClassName}) reader);");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return visitor;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -1,14 +1,7 @@
 package io.apitomy.umg.pipe.java;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
-import io.apitomy.umg.models.concept.type.UnionVariantComparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
@@ -18,32 +11,21 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apitomy.umg.beans.SpecificationVersion;
-
 import io.apitomy.umg.models.concept.EntityModel;
-import io.apitomy.umg.models.concept.NamespaceModel;
-import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
-import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
-import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
-
 import io.apitomy.umg.pipe.java.method.reader.ReadEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadPrimitivePropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadRegexPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadStarPropertyBlock;
-import io.apitomy.umg.pipe.java.method.reader.ReadUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.reader.ReadUnionMapPropertyBlock;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import io.apitomy.umg.pipe.java.method.reader.ReadUnionPropertyBlock;
 
 /**
  * Creates the i/o reader classes.  There is a bespoke reader for each specification
@@ -51,119 +33,115 @@ import lombok.Data;
  *
  * @author eric.wittmann@gmail.com
  */
-public class CreateReadersStage extends AbstractJavaStage {
-
-    private CodeGenContext ctx;
+public class CreateReadersStage extends AbstractIOStage {
 
     @Override
-    protected void doProcess() {
-        ctx = new CodeGenContext(
-                getState().getConceptIndex(),
-                getState().getJavaIndex(),
-                getJavaTypeFactory(),
-                getState().getConfig().getRootNamespace(),
-                getState().getSpecIndex(),
-                getClass().getSimpleName());
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            createReader(specVersion);
-        });
+    protected String getPackageName(SpecificationVersion specVersion) {
+        return getReaderPackageName(specVersion);
     }
 
-    /**
-     * Creates a reader for the given spec version.
-     * @param specVersion
-     */
-    private void createReader(SpecificationVersion specVersion) {
-        String readerPackageName = getReaderPackageName(specVersion);
-        String readerClassName = getReaderClassName(specVersion);
+    @Override
+    protected String getClassName(SpecificationVersion specVersion) {
+        return getReaderClassName(specVersion);
+    }
 
-        debug("Creating reader: " + readerPackageName + "." + readerClassName);
+    @Override
+    protected void addImports(JavaClassSource classSource) {
+        classSource.addImport(getState().getConfig().getRootNamespace() + ".util.JsonUtil");
+        classSource.addImport(getState().getConfig().getRootNamespace() + ".util.ReaderUtil");
+    }
 
-        // Create java source code for the reader
-        JavaClassSource readerClassSource = Roaster.create(JavaClassSource.class)
-                .setPackage(readerPackageName)
-                .setName(readerClassName)
-                .setPublic();
-        readerClassSource.addImport(getState().getConfig().getRootNamespace() + ".util." + "JsonUtil");
-        readerClassSource.addImport(getState().getConfig().getRootNamespace() + ".util." + "ReaderUtil");
-
-        // Implements the ModelReader interface
+    @Override
+    protected void addInterfaceImplementation(JavaClassSource classSource) {
         debug("Reader implements: " + getModelReaderInterfaceFQN());
-        JavaInterfaceSource modelReaderInterfaceSource = getState().getJavaIndex().lookupInterface(getModelReaderInterfaceFQN());
-        readerClassSource.addImport(modelReaderInterfaceSource);
-        readerClassSource.addInterface(modelReaderInterfaceSource);
-
-        // Create the readXYZ methods - one for each entity
-        debug("Creating readXYZ methods...");
-        specVersion.getEntities().forEach(entity -> {
-            EntityModel entityModel = getState().getConceptIndex().lookupEntity(specVersion.getNamespace() + "." + entity.getName());
-            if (entityModel == null) {
-                warn("Entity model not found for entity: " + entity);
-            } else {
-                createReadMethodFor(specVersion, readerClassSource, entityModel);
-            }
-        });
-
-        // Create type-based reader methods for unions and collections
-        createTypeBasedReaderMethods(specVersion, readerClassSource);
-
-        // Create readRoot method based on the spec-level root type
-        createReadRootFromSpec(specVersion, readerClassSource);
-
-        getState().getJavaIndex().index(readerClassSource);
+        JavaInterfaceSource modelReaderInterfaceSource =
+                getState().getJavaIndex().lookupInterface(getModelReaderInterfaceFQN());
+        classSource.addImport(modelReaderInterfaceSource);
+        classSource.addInterface(modelReaderInterfaceSource);
     }
 
-    private void createTypeBasedReaderMethods(SpecificationVersion specVersion, JavaClassSource readerClassSource) {
+    @Override
+    protected void createEntityMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel) {
+        String entityFQN = getJavaEntityInterfaceFQN(entityModel);
+        String readMethodName = ReaderMethod.methodName(entityModel.getName());
+
+        debug("Creating read method: " + readMethodName);
+
+        JavaInterfaceSource javaEntity = getState().getJavaIndex().lookupInterface(entityFQN);
+        if (javaEntity == null) {
+            warn("Java interface for entity not found: " + entityFQN);
+            return;
+        }
+
+        classSource.addImport(ObjectNode.class);
+        classSource.addImport(javaEntity);
+        MethodSource<JavaClassSource> methodSource = classSource.addMethod()
+                .setName(readMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        methodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
+        methodSource.addParameter(javaEntity.getName(), "node");
+
+        BodyBuilder body = new BodyBuilder();
+        Collection<PropertyModelWithOrigin> allProperties =
+                getState().getConceptIndex().getAllEntityProperties(entityModel);
+        allProperties.forEach(property -> {
+            body.clearContext();
+            dispatchProperty(body, property, entityModel, classSource);
+        });
+        body.append("ReaderUtil.readExtraProperties(json, node);");
+
+        methodSource.setBody(body.toString());
+    }
+
+    @Override
+    protected void afterEntityMethods(SpecificationVersion specVersion, JavaClassSource classSource) {
+        createTypeBasedReaderMethods(specVersion, classSource);
+        createReadRootFromSpec(specVersion, classSource);
+    }
+
+    private void createTypeBasedReaderMethods(SpecificationVersion specVersion, JavaClassSource classSource) {
         var namespace = specVersion.getNamespace();
 
         getState().getConceptIndex().findTypes(namespace).stream()
                 .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
                 .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
                 .forEach(unionType -> {
-                    var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
-                    var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
-                    new ReaderMethod(jt.getSimpleName()).writeTo(readerClassSource, specVersion, unionType, ctx);
+                    new ReaderMethod(specVersion, unionType, ctx).writeTo(classSource);
                 });
     }
 
-
-
-    private void createReadRootFromSpec(SpecificationVersion specVersion, JavaClassSource readerClassSource) {
+    private void createReadRootFromSpec(SpecificationVersion specVersion, JavaClassSource classSource) {
         if (specVersion.getRoot() == null) return;
 
         var rootTypeName = specVersion.getRoot().getType();
         var namespace = specVersion.getNamespace();
 
-        // Try type alias (union root)
         var rootType = getState().getConceptIndex().lookupType(namespace, rootTypeName);
         if (rootType instanceof io.apitomy.umg.models.concept.type.UnionType unionType) {
-            createUnionReadRootMethod(specVersion, readerClassSource, unionType);
+            createUnionReadRootMethod(specVersion, classSource, unionType);
             return;
         }
 
-        // Single entity root
         var entity = getState().getConceptIndex().lookupEntity(namespace, rootTypeName);
         if (entity != null) {
-            createReadRootMethod(specVersion, readerClassSource, entity);
+            createReadRootMethod(specVersion, classSource, entity);
             return;
         }
 
         warn("Root type '%s' not found in namespace '%s'", rootTypeName, namespace);
     }
 
-    /**
-     * Creates a "readRoot(json)" method for this reader.
-     * @param specVersion
-     * @param readerClassSource
-     * @param entityModel
-     */
-    private void createReadRootMethod(SpecificationVersion specVersion, JavaClassSource readerClassSource, EntityModel entityModel) {
-        JavaInterfaceSource rootNodeInterfaceSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
-        readerClassSource.addImport(rootNodeInterfaceSource);
-        readerClassSource.addImport(JsonNode.class);
-        readerClassSource.addImport(ObjectNode.class);
+    private void createReadRootMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel) {
+        JavaInterfaceSource rootNodeInterfaceSource =
+                getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
+        classSource.addImport(rootNodeInterfaceSource);
+        classSource.addImport(JsonNode.class);
+        classSource.addImport(ObjectNode.class);
 
-        MethodSource<JavaClassSource> readRootMethodSource = readerClassSource.addMethod()
+        MethodSource<JavaClassSource> readRootMethodSource = classSource.addMethod()
                 .setName("readRoot")
                 .setReturnType(rootNodeInterfaceSource.getName())
                 .setPublic();
@@ -174,8 +152,8 @@ public class CreateReadersStage extends AbstractJavaStage {
         JavaInterfaceSource entitySource = lookupJavaEntity(entityModel);
         JavaClassSource entityImplSource = lookupJavaEntityImpl(entityModel);
 
-        readerClassSource.addImport(entitySource);
-        readerClassSource.addImport(entityImplSource);
+        classSource.addImport(entitySource);
+        classSource.addImport(entityImplSource);
 
         BodyBuilder body = new BodyBuilder();
         body.addContext("readMethodName", readMethodName);
@@ -188,21 +166,22 @@ public class CreateReadersStage extends AbstractJavaStage {
         readRootMethodSource.setBody(body.toString());
     }
 
-    private void createUnionReadRootMethod(SpecificationVersion specVersion, JavaClassSource readerClassSource,
-                                              io.apitomy.umg.models.concept.type.UnionType unionType) {
-        JavaInterfaceSource rootCapableSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
-        readerClassSource.addImport(rootCapableSource);
-        readerClassSource.addImport(JsonNode.class);
+    private void createUnionReadRootMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, io.apitomy.umg.models.concept.type.UnionType unionType) {
+        JavaInterfaceSource rootCapableSource =
+                getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
+        classSource.addImport(rootCapableSource);
+        classSource.addImport(JsonNode.class);
 
         JavaEnumSource modelTypeEnum = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeEnum);
+        classSource.addImport(modelTypeEnum);
 
         var namespace = specVersion.getNamespace();
         var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
         var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
         String readMethodName = ReaderMethod.methodName(jt.getSimpleName());
 
-        MethodSource<JavaClassSource> readRootMethodSource = readerClassSource.addMethod()
+        MethodSource<JavaClassSource> readRootMethodSource = classSource.addMethod()
                 .setName("readRoot")
                 .setReturnType(rootCapableSource.getName())
                 .setPublic();
@@ -220,195 +199,20 @@ public class CreateReadersStage extends AbstractJavaStage {
         readRootMethodSource.setBody(body.toString());
     }
 
-    /**
-     * Creates a single "readXyz" method for the given entity.
-     *
-     * @param specVersion
-     * @param readerClassSource
-     * @param entityModel
-     */
-    private void createReadMethodFor(SpecificationVersion specVersion, JavaClassSource readerClassSource, EntityModel entityModel) {
-        String entityFQN = getJavaEntityInterfaceFQN(entityModel);
-        String readMethodName = ReaderMethod.methodName(entityModel.getName());
-
-        debug("Creating read method: " + readMethodName);
-
-        JavaInterfaceSource javaEntity = getState().getJavaIndex().lookupInterface(entityFQN);
-        if (javaEntity == null) {
-            warn("Java interface for entity not found: " + entityFQN);
+    @Override
+    protected CodeBlock createPropertyBlock(PropertyBlockKind kind,
+            PropertyCodeGen prop, JavaClassSource classSource) {
+        switch (kind) {
+            case STAR:       return new ReadStarPropertyBlock(prop, classSource);
+            case REGEX:      return new ReadRegexPropertyBlock(prop, classSource);
+            case UNION:      return new ReadUnionPropertyBlock(prop, classSource);
+            case UNION_LIST: return new ReadUnionListPropertyBlock(prop, classSource);
+            case UNION_MAP:  return new ReadUnionMapPropertyBlock(prop, classSource);
+            case ENTITY:     return new ReadEntityPropertyBlock(prop, classSource);
+            case PRIMITIVE:  return new ReadPrimitivePropertyBlock(prop, classSource);
+            case LIST:       return new ReadListPropertyBlock(prop, classSource);
+            case MAP:        return new ReadMapPropertyBlock(prop, classSource);
+            default:         throw new IllegalArgumentException("Unknown block kind: " + kind);
         }
-
-        readerClassSource.addImport(ObjectNode.class);
-        readerClassSource.addImport(javaEntity);
-        MethodSource<JavaClassSource> methodSource = readerClassSource.addMethod()
-                .setName(readMethodName)
-                .setReturnTypeVoid()
-                .setPublic();
-        methodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-        methodSource.addParameter(javaEntity.getName(), "node");
-
-        // Now create the body content for the reader.
-        BodyBuilder body = new BodyBuilder();
-        // Read each property of the entity
-        Collection<PropertyModelWithOrigin> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel);
-        allProperties.forEach(property -> {
-            createReadPropertyCode(body, property, entityModel, javaEntity, readerClassSource);
-        });
-        // Read "extra" properties (whatever is left over)
-        createReadExtraPropertiesCode(body);
-
-        methodSource.setBody(body.toString());
-    }
-
-    /**
-     * Generates the right java code for reading a single property of an entity.
-     *
-     * @param body
-     * @param property
-     * @param entityModel
-     * @param javaEntity
-     * @param readerClassSource
-     */
-    private void createReadPropertyCode(BodyBuilder body, PropertyModelWithOrigin property, EntityModel entityModel,
-            JavaInterfaceSource javaEntity, JavaClassSource readerClassSource) {
-        CreateReadPropertySnippet crp = new CreateReadPropertySnippet(property, entityModel, javaEntity, readerClassSource);
-        body.clearContext();
-        crp.writeTo(body);
-    }
-
-    /**
-     * Creates code that will read any extra/remaining properties on a JSON object.
-     *
-     * @param body
-     */
-    private void createReadExtraPropertiesCode(BodyBuilder body) {
-        body.append("ReaderUtil.readExtraProperties(json, node);");
-    }
-
-    @Data
-    @AllArgsConstructor
-    private class CreateReadPropertySnippet {
-        PropertyModelWithOrigin propertyWithOrigin;
-        EntityModel entityModel;
-        JavaInterfaceSource javaEntity;
-        JavaClassSource readerClassSource;
-
-        /**
-         * Generates code to read a property from a JSON node into the data model.
-         *
-         * @param body
-         */
-        public void writeTo(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if ("*".equals(property.getName())) {
-                handleStarProperty(body);
-            } else if (property.getName().startsWith("/")) {
-                handleRegexProperty(body);
-            } else if (handleViaResolvedType(body)) {
-                // Handled by resolved type dispatch
-            } else {
-                warn("Entity property '" + property.getName() + "' not read (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            }
-        }
-
-        private boolean handleViaResolvedType(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var resolved = property.getResolvedType();
-            if (resolved == null) return false;
-
-            // Direct union property (both type aliases and inline unions)
-            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionProperty(body, resolved);
-                return true;
-            }
-
-            // List of union
-            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
-                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionListProperty(body, lt);
-                return true;
-            }
-
-            // Map of union
-            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
-                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionMapProperty(body, mt);
-                return true;
-            }
-
-            // Entity
-            if (resolved.isEntityType()) {
-                handleEntityProperty(body);
-                return true;
-            }
-
-            // Primitive
-            if (resolved.isPrimitiveType()) {
-                handlePrimitiveTypeProperty(body);
-                return true;
-            }
-
-            // List (entity or primitive)
-            if (resolved.isListType()) {
-                handleListProperty(body);
-                return true;
-            }
-
-            // Map (entity or primitive)
-            if (resolved.isMapType()) {
-                handleMapProperty(body);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadUnionPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleResolvedUnionListProperty(BodyBuilder body,
-                io.apitomy.umg.models.concept.type.ListType listType) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadUnionListPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleResolvedUnionMapProperty(BodyBuilder body,
-                io.apitomy.umg.models.concept.type.MapType mapType) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadUnionMapPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleStarProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadStarPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleRegexProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadRegexPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleEntityProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadEntityPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadPrimitivePropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleListProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadListPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
-        private void handleMapProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new ReadMapPropertyBlock(prop, readerClassSource).appendTo(body);
-        }
-
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterFactoryStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterFactoryStage.java
@@ -1,14 +1,14 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.Collection;
+
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.IODispatcherFactoryMethod;
+import io.apitomy.umg.pipe.java.method.IOFactoryMethod;
 
 /**
  * Creates a writer factory that knows how to create the correct writer for
@@ -29,90 +29,22 @@ public class CreateWriterFactoryStage extends AbstractJavaStage {
                 .setName(writerFactoryClassName)
                 .setPublic();
 
-        createWriterFactoryMethod(writerClassSource);
-        createWriterDispatcherFactoryMethod(writerClassSource);
+        Collection<SpecificationVersion> specVersions =
+                getState().getSpecIndex().getAllSpecificationVersions();
+        CodeGenContext ctx = new CodeGenContext(
+                getState().getConceptIndex(),
+                getState().getJavaIndex(),
+                getJavaTypeFactory(),
+                getState().getConfig().getRootNamespace(),
+                getState().getSpecIndex(),
+                getClass().getSimpleName());
+
+        new IOFactoryMethod(IOFactoryMethod.Mode.WRITER, specVersions, ctx)
+                .writeTo(writerClassSource);
+        new IODispatcherFactoryMethod(IOFactoryMethod.Mode.WRITER, specVersions, ctx)
+                .writeTo(writerClassSource);
 
         getState().getJavaIndex().index(writerClassSource);
-    }
-
-    private void createWriterFactoryMethod(JavaClassSource writerClassSource) {
-        // Some imports (model type, model writer interface, etc)
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        writerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource modelWriterSource = getState().getJavaIndex().lookupInterface(getModelWriterInterfaceFQN());
-        writerClassSource.addImport(modelWriterSource);
-
-        // Create the factory method.
-        MethodSource<JavaClassSource> factoryMethodSource = writerClassSource.addMethod().setName("createModelWriter").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(modelWriterSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-
-        BodyBuilder body = new BodyBuilder();
-        body.append("ModelWriter writer = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String specModelWriterFQN = getWriterPackageName(specVersion) + "." + getWriterClassName(specVersion);
-            JavaClassSource specModelWriterSource = getState().getJavaIndex().lookupClass(specModelWriterFQN);
-            writerClassSource.addImport(specModelWriterSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("modelWriterClassName", specModelWriterSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        writer = new ${modelWriterClassName}();");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return writer;");
-        factoryMethodSource.setBody(body.toString());
-    }
-
-    private void createWriterDispatcherFactoryMethod(JavaClassSource writerClassSource) {
-        JavaEnumSource modelTypeSource = getState().getJavaIndex().lookupEnum(getModelTypeEnumFQN());
-        writerClassSource.addImport(modelTypeSource);
-        JavaInterfaceSource rootVisitorInterfaceSource = getState().getJavaIndex().lookupInterface(getRootVisitorInterfaceFQN());
-        writerClassSource.addImport(rootVisitorInterfaceSource);
-
-        writerClassSource.addImport(ObjectNode.class);
-
-        MethodSource<JavaClassSource> factoryMethodSource = writerClassSource.addMethod()
-                .setName("createModelWriterDispatcher").setPublic().setStatic(true);
-        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
-        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
-        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-
-        BodyBuilder body = new BodyBuilder();
-        body.addContext("visitorName", rootVisitorInterfaceSource.getName());
-
-        body.append("ModelWriter writer = ModelWriterFactory.createModelWriter(modelType);");
-        body.append("${visitorName} visitor = null;");
-        body.append("switch (modelType) {");
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            String writerPackageName = getWriterPackageName(specVersion);
-            String writerClassName = getWriterClassName(specVersion);
-            String writerFQN = writerPackageName + "." + writerClassName;
-            String dispatcherPackageName = writerPackageName;
-            String dispatcherClassName = writerClassName + "Dispatcher";
-            String dispatcherFQN = dispatcherPackageName + "." + dispatcherClassName;
-
-            JavaClassSource writerSource = getState().getJavaIndex().lookupClass(writerFQN);
-            writerClassSource.addImport(writerSource);
-            JavaClassSource writerDispatcherSource = getState().getJavaIndex().lookupClass(dispatcherFQN);
-            writerClassSource.addImport(writerDispatcherSource);
-
-            String modelTypeValue = prefixToModelType(specVersion.getPrefix());
-            body.addContext("modelTypeValue", modelTypeValue);
-            body.addContext("writerClassName", writerSource.getName());
-            body.addContext("dispatcherClassName", writerDispatcherSource.getName());
-
-            body.append("    case ${modelTypeValue}:");
-            body.append("        visitor = new ${dispatcherClassName}(json, (${writerClassName}) writer);");
-            body.append("        break;");
-        });
-        body.append("}");
-        body.append("return visitor;");
-        factoryMethodSource.setBody(body.toString());
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -1,11 +1,7 @@
 package io.apitomy.umg.pipe.java;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
@@ -15,17 +11,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
-import io.apitomy.umg.models.concept.NamespaceModel;
-import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
-import io.apitomy.umg.pipe.java.method.CodeGenContext;
-import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.GetterMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
-
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 import io.apitomy.umg.pipe.java.method.writer.WriteEntityPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteListPropertyBlock;
@@ -33,11 +22,9 @@ import io.apitomy.umg.pipe.java.method.writer.WriteMapPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WritePrimitivePropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteRegexPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteStarPropertyBlock;
-import io.apitomy.umg.pipe.java.method.writer.WriteUnionPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteUnionListPropertyBlock;
 import io.apitomy.umg.pipe.java.method.writer.WriteUnionMapPropertyBlock;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import io.apitomy.umg.pipe.java.method.writer.WriteUnionPropertyBlock;
 
 /**
  * Creates the i/o writer classes.  There is a bespoke writer for each specification
@@ -45,85 +32,87 @@ import lombok.Data;
  *
  * @author eric.wittmann@gmail.com
  */
-public class CreateWritersStage extends AbstractJavaStage {
-
-    private CodeGenContext ctx;
+public class CreateWritersStage extends AbstractIOStage {
 
     @Override
-    protected void doProcess() {
-        ctx = new CodeGenContext(
-                getState().getConceptIndex(),
-                getState().getJavaIndex(),
-                getJavaTypeFactory(),
-                getState().getConfig().getRootNamespace(),
-                getState().getSpecIndex(),
-                getClass().getSimpleName());
-        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVersion -> {
-            createWriter(specVersion);
-        });
+    protected String getPackageName(SpecificationVersion specVersion) {
+        return getWriterPackageName(specVersion);
     }
 
-    /**
-     * Creates a writer for the given spec version.
-     * @param specVersion
-     */
-    private void createWriter(SpecificationVersion specVersion) {
-        String writerPackageName = getWriterPackageName(specVersion);
-        String writerClassName = getWriterClassName(specVersion);
+    @Override
+    protected String getClassName(SpecificationVersion specVersion) {
+        return getWriterClassName(specVersion);
+    }
 
-        // Create java source code for the writer
-        JavaClassSource writerClassSource = Roaster.create(JavaClassSource.class)
-                .setPackage(writerPackageName)
-                .setName(writerClassName)
+    @Override
+    protected void addImports(JavaClassSource classSource) {
+        classSource.addImport(getState().getConfig().getRootNamespace() + ".util.JsonUtil");
+        classSource.addImport(getState().getConfig().getRootNamespace() + ".util.WriterUtil");
+    }
+
+    @Override
+    protected void addInterfaceImplementation(JavaClassSource classSource) {
+        JavaInterfaceSource modelWriterInterfaceSource =
+                getState().getJavaIndex().lookupInterface(getModelWriterInterfaceFQN());
+        classSource.addImport(modelWriterInterfaceSource);
+        classSource.addInterface(modelWriterInterfaceSource);
+    }
+
+    @Override
+    protected void createEntityMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel) {
+        String writeMethodName = WriterMethod.methodName(entityModel.getName());
+
+        JavaInterfaceSource javaEntity = getState().getJavaIndex()
+                .lookupInterface(getJavaEntityInterfaceFQN(entityModel));
+        if (javaEntity == null) {
+            warn("Java entity not found for: " + entityModel.fullyQualifiedName());
+            return;
+        }
+
+        classSource.addImport(javaEntity.getQualifiedName());
+        classSource.addImport(ObjectNode.class);
+        MethodSource<JavaClassSource> methodSource = classSource.addMethod()
+                .setName(writeMethodName)
+                .setReturnTypeVoid()
                 .setPublic();
-        writerClassSource.addImport(getState().getConfig().getRootNamespace() + ".util." + "JsonUtil");
-        writerClassSource.addImport(getState().getConfig().getRootNamespace() + ".util." + "WriterUtil");
+        methodSource.addParameter(javaEntity.getName(), "node");
+        methodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
 
-        // Implements the ModelWriter interface
-        JavaInterfaceSource modelWriterInterfaceSource = getState().getJavaIndex().lookupInterface(getModelWriterInterfaceFQN());
-        writerClassSource.addImport(modelWriterInterfaceSource);
-        writerClassSource.addInterface(modelWriterInterfaceSource);
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (node == null) {");
+        body.append("    return;");
+        body.append("}");
 
-        // Create the writeXYZ methods - one for each entity
-        specVersion.getEntities().forEach(entity -> {
-            EntityModel entityModel = getState().getConceptIndex().lookupEntity(specVersion.getNamespace() + "." + entity.getName());
-            if (entityModel == null) {
-                warn("Entity model not found for entity: " + entity);
-            } else {
-                createWriteMethodFor(specVersion, writerClassSource, entityModel);
-
-            }
+        Collection<PropertyModelWithOrigin> allProperties =
+                getState().getConceptIndex().getAllEntityProperties(entityModel);
+        allProperties.forEach(property -> {
+            body.clearContext();
+            dispatchProperty(body, property, entityModel, classSource);
         });
+        body.append("WriterUtil.writeExtraProperties(node, json);");
 
-        // Create type-based writer methods for unions
-        createTypeBasedWriterMethods(specVersion, writerClassSource);
-
-        // Create writeRoot method based on the spec-level root type
-        createWriteRootFromSpec(specVersion, writerClassSource);
-
-        getState().getJavaIndex().index(writerClassSource);
+        methodSource.setBody(body.toString());
     }
 
-    private void createTypeBasedWriterMethods(SpecificationVersion specVersion, JavaClassSource writerClassSource) {
+    @Override
+    protected void afterEntityMethods(SpecificationVersion specVersion, JavaClassSource classSource) {
+        createTypeBasedWriterMethods(specVersion, classSource);
+        createWriteRootFromSpec(specVersion, classSource);
+    }
+
+    private void createTypeBasedWriterMethods(SpecificationVersion specVersion, JavaClassSource classSource) {
         var namespace = specVersion.getNamespace();
 
         getState().getConceptIndex().findTypes(namespace).stream()
                 .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
                 .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
                 .forEach(unionType -> {
-                    var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
-                    var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
-                    new WriterMethod(jt.getSimpleName()).writeTo(writerClassSource, specVersion, unionType, ctx);
+                    new WriterMethod(specVersion, unionType, ctx).writeTo(classSource);
                 });
     }
 
-
-
-    private boolean hasMethod(JavaClassSource source, String name) {
-        return source.getMethods().stream().anyMatch(m -> m.getName().equals(name));
-    }
-
-    private void createWriteRootFromSpec(SpecificationVersion specVersion, JavaClassSource writerClassSource) {
+    private void createWriteRootFromSpec(SpecificationVersion specVersion, JavaClassSource classSource) {
         if (specVersion.getRoot() == null) return;
 
         var rootTypeName = specVersion.getRoot().getType();
@@ -131,30 +120,31 @@ public class CreateWritersStage extends AbstractJavaStage {
 
         var rootType = getState().getConceptIndex().lookupType(namespace, rootTypeName);
         if (rootType instanceof io.apitomy.umg.models.concept.type.UnionType unionType) {
-            createUnionWriteRootMethod(specVersion, writerClassSource, unionType);
+            createUnionWriteRootMethod(specVersion, classSource, unionType);
             return;
         }
 
         var entity = getState().getConceptIndex().lookupEntity(namespace, rootTypeName);
         if (entity != null) {
-            createWriteRootMethod(specVersion, writerClassSource, entity);
+            createWriteRootMethod(specVersion, classSource, entity);
         }
     }
 
-    private void createUnionWriteRootMethod(SpecificationVersion specVersion, JavaClassSource writerClassSource,
-                                             io.apitomy.umg.models.concept.type.UnionType unionType) {
-        JavaInterfaceSource rootCapableSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
-        writerClassSource.addImport(rootCapableSource);
-        writerClassSource.addImport(JsonNode.class);
-        writerClassSource.addImport(ObjectNode.class);
+    private void createUnionWriteRootMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, io.apitomy.umg.models.concept.type.UnionType unionType) {
+        JavaInterfaceSource rootCapableSource =
+                getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
+        classSource.addImport(rootCapableSource);
+        classSource.addImport(JsonNode.class);
+        classSource.addImport(ObjectNode.class);
 
         var namespace = specVersion.getNamespace();
         var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
         var jt = getJavaTypeFactory().createJavaType(unionType, nsModel);
         String writeMethodName = WriterMethod.methodName(jt.getSimpleName());
-        jt.addImportsTo(writerClassSource);
+        jt.addImportsTo(classSource);
 
-        MethodSource<JavaClassSource> writeRootMethodSource = writerClassSource.addMethod()
+        MethodSource<JavaClassSource> writeRootMethodSource = classSource.addMethod()
                 .setName("writeRoot")
                 .setReturnType(ObjectNode.class.getName())
                 .setPublic();
@@ -173,28 +163,24 @@ public class CreateWritersStage extends AbstractJavaStage {
         writeRootMethodSource.setBody(body.toString());
     }
 
-    /**
-     * Creates a "writeRoot(node)" method for this writer.
-     * @param specVersion
-     * @param writerClassSource
-     * @param entityModel
-     */
-    private void createWriteRootMethod(SpecificationVersion specVersion, JavaClassSource writerClassSource, EntityModel entityModel) {
-        JavaInterfaceSource rootNodeInterfaceSource = getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
-        writerClassSource.addImport(rootNodeInterfaceSource);
-        writerClassSource.addImport(ObjectNode.class);
+    private void createWriteRootMethod(SpecificationVersion specVersion,
+            JavaClassSource classSource, EntityModel entityModel) {
+        JavaInterfaceSource rootNodeInterfaceSource =
+                getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
+        classSource.addImport(rootNodeInterfaceSource);
+        classSource.addImport(ObjectNode.class);
 
-        MethodSource<JavaClassSource> writeRootMethodSource = writerClassSource.addMethod()
+        MethodSource<JavaClassSource> writeRootMethodSource = classSource.addMethod()
                 .setName("writeRoot")
                 .setReturnType(ObjectNode.class.getName())
                 .setPublic();
         writeRootMethodSource.addParameter(rootNodeInterfaceSource.getName(), "node");
         writeRootMethodSource.addAnnotation(Override.class);
 
-        String writeMethodName = writeMethodName(entityModel);
+        String writeMethodName = WriterMethod.methodName(entityModel.getName());
         JavaInterfaceSource entitySource = lookupJavaEntity(entityModel);
 
-        writerClassSource.addImport(entitySource);
+        classSource.addImport(entitySource);
 
         BodyBuilder body = new BodyBuilder();
         body.addContext("writeMethodName", writeMethodName);
@@ -206,199 +192,20 @@ public class CreateWritersStage extends AbstractJavaStage {
         writeRootMethodSource.setBody(body.toString());
     }
 
-    /**
-     * Creates a single "writeXyx" method for the given entity.
-     *
-     * @param specVersion
-     * @param writerClassSource
-     * @param entityModel
-     */
-    private void createWriteMethodFor(SpecificationVersion specVersion, JavaClassSource writerClassSource, EntityModel entityModel) {
-        String writeMethodName = writeMethodName(entityModel);
-
-        JavaInterfaceSource javaEntityModel = getState().getJavaIndex().lookupInterface(getJavaEntityInterfaceFQN(entityModel));
-        if (javaEntityModel == null) {
-            warn("Java entity not found for: " + entityModel.fullyQualifiedName());
-            return;
+    @Override
+    protected CodeBlock createPropertyBlock(PropertyBlockKind kind,
+            PropertyCodeGen prop, JavaClassSource classSource) {
+        switch (kind) {
+            case STAR:       return new WriteStarPropertyBlock(prop, classSource);
+            case REGEX:      return new WriteRegexPropertyBlock(prop, classSource);
+            case UNION:      return new WriteUnionPropertyBlock(prop, classSource);
+            case UNION_LIST: return new WriteUnionListPropertyBlock(prop, classSource);
+            case UNION_MAP:  return new WriteUnionMapPropertyBlock(prop, classSource);
+            case ENTITY:     return new WriteEntityPropertyBlock(prop, classSource);
+            case PRIMITIVE:  return new WritePrimitivePropertyBlock(prop, classSource);
+            case LIST:       return new WriteListPropertyBlock(prop, classSource);
+            case MAP:        return new WriteMapPropertyBlock(prop, classSource);
+            default:         throw new IllegalArgumentException("Unknown block kind: " + kind);
         }
-
-        writerClassSource.addImport(javaEntityModel.getQualifiedName());
-        writerClassSource.addImport(ObjectNode.class);
-        MethodSource<JavaClassSource> methodSource = writerClassSource.addMethod()
-                .setName(writeMethodName)
-                .setReturnTypeVoid()
-                .setPublic();
-        methodSource.addParameter(javaEntityModel.getName(), "node");
-        methodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
-
-        // Now create the body content for the writer.
-        BodyBuilder body = new BodyBuilder();
-        body.append("if (node == null) {");
-        body.append("    return;");
-        body.append("}");
-
-        // Write each property of the entity
-        Collection<PropertyModelWithOrigin> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel);
-        allProperties.forEach(property -> {
-            createWritePropertyCode(body, property, entityModel, javaEntityModel, writerClassSource);
-        });
-        // Write "extra" properties
-        createWriteExtraPropertiesCode(body);
-
-        methodSource.setBody(body.toString());
-    }
-
-    /**
-     * Generates the right java code for writing a single property of an entity.
-     *
-     * @param body
-     * @param property
-     * @param javaEntity
-     * @param javaEntity
-     * @param writerClassSource
-     */
-    private void createWritePropertyCode(BodyBuilder body, PropertyModelWithOrigin propertyWithOrigin, EntityModel entityModel,
-            JavaInterfaceSource javaEntity, JavaClassSource writerClassSource) {
-        CreateWriteProperty crp = new CreateWriteProperty(propertyWithOrigin, entityModel, javaEntity, writerClassSource);
-        body.clearContext();
-        crp.writeTo(body);
-    }
-
-    /**
-     * Generates code that will write the extra properties from the model to the JSON output.
-     *
-     * @param body
-     */
-    private void createWriteExtraPropertiesCode(BodyBuilder body) {
-        body.append("WriterUtil.writeExtraProperties(node, json);");
-    }
-
-    private static String writeMethodName(EntityModel entityModel) {
-        return writeMethodName(entityModel.getName());
-    }
-
-    private static String writeMethodName(String entityName) {
-        return WriterMethod.methodName(entityName);
-    }
-
-    @Data
-    @AllArgsConstructor
-    private class CreateWriteProperty {
-        PropertyModelWithOrigin propertyWithOrigin;
-        EntityModel entityModel;
-        JavaInterfaceSource javaEntityModel;
-        JavaClassSource writerClassSource;
-
-        /**
-         * Generates code to write a property from a JSON node into the data model.
-         *
-         * @param body
-         */
-        public void writeTo(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            if (isStarProperty(property)) {
-                handleStarProperty(body);
-            } else if (isRegexProperty(property)) {
-                handleRegexProperty(body);
-            } else if (handleViaResolvedType(body)) {
-                // Handled by resolved type dispatch
-            } else {
-                warn("Entity property '" + property.getName() + "' not written (unsupported) for entity: " + entityModel.fullyQualifiedName());
-            }
-        }
-
-        private boolean handleViaResolvedType(BodyBuilder body) {
-            PropertyModel property = propertyWithOrigin.getProperty();
-            var resolved = property.getResolvedType();
-            if (resolved == null) return false;
-
-            // Direct union property (both type aliases and inline unions)
-            if (resolved instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionProperty(body, resolved);
-                return true;
-            }
-
-            if (resolved instanceof io.apitomy.umg.models.concept.type.ListType lt
-                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionListProperty(body, lt);
-                return true;
-            }
-
-            if (resolved instanceof io.apitomy.umg.models.concept.type.MapType mt
-                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.UnionType) {
-                handleResolvedUnionMapProperty(body, mt);
-                return true;
-            }
-
-            if (resolved.isEntityType()) {
-                handleEntityProperty(body);
-                return true;
-            }
-            if (resolved.isPrimitiveType()) {
-                handlePrimitiveTypeProperty(body);
-                return true;
-            }
-            if (resolved.isListType()) {
-                handleListProperty(body);
-                return true;
-            }
-            if (resolved.isMapType()) {
-                handleMapProperty(body);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void handleResolvedUnionProperty(BodyBuilder body, io.apitomy.umg.models.concept.type.Type resolved) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteUnionPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleResolvedUnionListProperty(BodyBuilder body,
-                io.apitomy.umg.models.concept.type.ListType listType) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteUnionListPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleResolvedUnionMapProperty(BodyBuilder body,
-                io.apitomy.umg.models.concept.type.MapType mapType) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteUnionMapPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleStarProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteStarPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleRegexProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteRegexPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleEntityProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteEntityPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handlePrimitiveTypeProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WritePrimitivePropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleListProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteListPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-        private void handleMapProperty(BodyBuilder body) {
-            PropertyCodeGen prop = new PropertyCodeGen(propertyWithOrigin, entityModel, ctx);
-            new WriteMapPropertyBlock(prop, writerClassSource).appendTo(body);
-        }
-
-
-
-
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClonerFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClonerFactoryMethod.java
@@ -1,0 +1,86 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelCloner(ModelType)} factory method — a
+ * static switch that instantiates the correct spec-version cloner wrapped
+ * in its dispatcher.
+ *
+ * <p>The cloner factory differs from reader/writer because the switch
+ * body creates {@code new ClonerDispatcher(new Cloner())} rather than a
+ * plain {@code new Cloner()}.
+ */
+public class ClonerFactoryMethod implements Method {
+
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public ClonerFactoryMethod(Collection<SpecificationVersion> specVersions,
+                               CodeGenContext ctx) {
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModelCloner";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+        JavaInterfaceSource modelClonerSource =
+                ctx.getJavaIndex().lookupInterface(ctx.getModelClonerInterfaceFQN());
+        classSource.addImport(modelClonerSource);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(modelClonerSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("ModelCloner cloner = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String clonerPackageName = specVersion.getNamespace() + ".io";
+            String clonerClassName = specVersion.getPrefix() + "ModelCloner";
+            String clonerFQN = clonerPackageName + "." + clonerClassName;
+            String dispatcherClassName = clonerClassName + "Dispatcher";
+            String dispatcherFQN = clonerPackageName + "." + dispatcherClassName;
+
+            JavaClassSource clonerSource = ctx.getJavaIndex().lookupClass(clonerFQN);
+            classSource.addImport(clonerSource);
+            JavaClassSource dispatcherSource = ctx.getJavaIndex().lookupClass(dispatcherFQN);
+            classSource.addImport(dispatcherSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("clonerClassName", clonerSource.getName());
+            body.addContext("dispatcherClassName", dispatcherSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        cloner = new ${dispatcherClassName}(new ${clonerClassName}());");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return cloner;");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -105,6 +105,26 @@ public class CodeGenContext {
         return rootNamespace + ".ModelType";
     }
 
+    public String getModelReaderInterfaceFQN() {
+        return rootNamespace + ".io.ModelReader";
+    }
+
+    public String getModelWriterInterfaceFQN() {
+        return rootNamespace + ".io.ModelWriter";
+    }
+
+    public String getModelClonerInterfaceFQN() {
+        return rootNamespace + ".io.ModelCloner";
+    }
+
+    public String getRootVisitorInterfaceFQN() {
+        return rootNamespace + ".visitors.Visitor";
+    }
+
+    public SpecificationIndex getSpecIndex() {
+        return specIndex;
+    }
+
     /**
      * Resolves the package for union value impl classes, preferring the common-entity
      * namespace when a variant references a common entity.

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/IODispatcherFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/IODispatcherFactoryMethod.java
@@ -1,0 +1,106 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelReaderDispatcher(ModelType, ObjectNode)} or
+ * {@code createModelWriterDispatcher(ModelType, ObjectNode)} factory method
+ * — a static switch that creates the correct dispatcher for a given spec
+ * version.
+ *
+ * <p>Parameterised by {@link IOFactoryMethod.Mode} so a single class handles
+ * both Reader and Writer dispatchers (they are structurally identical).
+ */
+public class IODispatcherFactoryMethod implements Method {
+
+    private final IOFactoryMethod.Mode mode;
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public IODispatcherFactoryMethod(IOFactoryMethod.Mode mode,
+                                     Collection<SpecificationVersion> specVersions,
+                                     CodeGenContext ctx) {
+        this.mode = mode;
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModel" + mode.label() + "Dispatcher";
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+
+        JavaInterfaceSource rootVisitorInterfaceSource =
+                ctx.getJavaIndex().lookupInterface(ctx.getRootVisitorInterfaceFQN());
+        classSource.addImport(rootVisitorInterfaceSource);
+
+        classSource.addImport(ObjectNode.class);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(rootVisitorInterfaceSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+        factoryMethodSource.addParameter(ObjectNode.class.getSimpleName(), "json");
+
+        String varName = mode.varName();         // "reader" or "writer"
+        String label = mode.label();             // "Reader" or "Writer"
+        String visitorName = rootVisitorInterfaceSource.getName();
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("visitorName", visitorName);
+        body.addContext("interfaceName", "Model" + label);
+        body.addContext("factoryClassName", "Model" + label + "Factory");
+        body.addContext("createMethodName", "createModel" + label);
+        body.addContext("varName", varName);
+
+        body.append("${interfaceName} ${varName} = ${factoryClassName}.${createMethodName}(modelType);");
+        body.append("${visitorName} visitor = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String ioPackageName = specVersion.getNamespace() + ".io";
+            String ioClassName = specVersion.getPrefix() + "Model" + label;
+            String ioFQN = ioPackageName + "." + ioClassName;
+            String dispatcherClassName = ioClassName + "Dispatcher";
+            String dispatcherFQN = ioPackageName + "." + dispatcherClassName;
+
+            JavaClassSource ioSource = ctx.getJavaIndex().lookupClass(ioFQN);
+            classSource.addImport(ioSource);
+            JavaClassSource dispatcherSource = ctx.getJavaIndex().lookupClass(dispatcherFQN);
+            classSource.addImport(dispatcherSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("ioClassName", ioSource.getName());
+            body.addContext("dispatcherClassName", dispatcherSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        visitor = new ${dispatcherClassName}(json, (${ioClassName}) ${varName});");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return visitor;");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/IOFactoryMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/IOFactoryMethod.java
@@ -1,0 +1,110 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.Collection;
+
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+
+/**
+ * Generates the {@code createModelReader(ModelType)} or
+ * {@code createModelWriter(ModelType)} factory method — a static switch
+ * that instantiates the correct spec-version reader/writer.
+ *
+ * <p>Parameterised by {@link Mode} so a single class handles both
+ * Reader and Writer (they are structurally identical).
+ */
+public class IOFactoryMethod implements Method {
+
+    /** Whether this method targets the reader or writer factory. */
+    public enum Mode {
+        READER("Reader", "reader"),
+        WRITER("Writer", "writer");
+
+        private final String label;
+        private final String varName;
+
+        Mode(String label, String varName) {
+            this.label = label;
+            this.varName = varName;
+        }
+
+        /** e.g. "Reader" or "Writer" */
+        public String label() { return label; }
+
+        /** e.g. "reader" or "writer" */
+        public String varName() { return varName; }
+    }
+
+    private final Mode mode;
+    private final Collection<SpecificationVersion> specVersions;
+    private final CodeGenContext ctx;
+
+    public IOFactoryMethod(Mode mode, Collection<SpecificationVersion> specVersions,
+                           CodeGenContext ctx) {
+        this.mode = mode;
+        this.specVersions = specVersions;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getName() {
+        return "createModel" + mode.label();
+    }
+
+    @Override
+    public void writeTo(JavaSource<?> target) {
+        JavaClassSource classSource = (JavaClassSource) target;
+
+        JavaEnumSource modelTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+        classSource.addImport(modelTypeSource);
+
+        String interfaceFQN = mode == Mode.READER
+                ? ctx.getModelReaderInterfaceFQN()
+                : ctx.getModelWriterInterfaceFQN();
+        JavaInterfaceSource ioInterfaceSource = ctx.getJavaIndex().lookupInterface(interfaceFQN);
+        classSource.addImport(ioInterfaceSource);
+
+        MethodSource<JavaClassSource> factoryMethodSource = classSource.addMethod()
+                .setName(getName()).setPublic().setStatic(true);
+        factoryMethodSource.setReturnType(ioInterfaceSource);
+        factoryMethodSource.addParameter(modelTypeSource.getName(), "modelType");
+
+        String interfaceName = ioInterfaceSource.getName(); // e.g. "ModelReader"
+        String varName = mode.varName();                    // e.g. "reader"
+
+        BodyBuilder body = new BodyBuilder();
+        body.addContext("interfaceName", interfaceName);
+        body.addContext("varName", varName);
+        body.append("${interfaceName} ${varName} = null;");
+        body.append("switch (modelType) {");
+        for (SpecificationVersion specVersion : specVersions) {
+            String ioPackageName = specVersion.getNamespace() + ".io";
+            String ioClassName = specVersion.getPrefix() + "Model" + mode.label();
+            String ioFQN = ioPackageName + "." + ioClassName;
+
+            JavaClassSource specIOSource = ctx.getJavaIndex().lookupClass(ioFQN);
+            classSource.addImport(specIOSource);
+
+            String modelTypeValue = specVersion.getPrefix().toUpperCase();
+            body.addContext("modelTypeValue", modelTypeValue);
+            body.addContext("ioClassName", specIOSource.getName());
+
+            body.append("    case ${modelTypeValue}:");
+            body.append("        ${varName} = new ${ioClassName}();");
+            body.append("        break;");
+        }
+        body.append("}");
+        body.append("return ${varName};");
+        factoryMethodSource.setBody(body.toString());
+    }
+
+    @Override
+    public void addImportsTo(JavaSource<?> source) {
+        // Imports are added during writeTo
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -30,9 +30,24 @@ import io.apitomy.umg.models.java.type.JavaTypeFactory;
 public class ReaderMethod implements Method {
 
     private final String entityName;
+    private final SpecificationVersion specVersion;
+    private final UnionType unionType;
+    private final CodeGenContext ctx;
 
     public ReaderMethod(String entityName) {
         this.entityName = entityName;
+        this.specVersion = null;
+        this.unionType = null;
+        this.ctx = null;
+    }
+
+    public ReaderMethod(SpecificationVersion specVersion, UnionType unionType, CodeGenContext ctx) {
+        NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(specVersion.getNamespace());
+        JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        this.entityName = jt.getSimpleName();
+        this.specVersion = specVersion;
+        this.unionType = unionType;
+        this.ctx = ctx;
     }
 
     /**
@@ -54,17 +69,14 @@ public class ReaderMethod implements Method {
 
     @Override
     public void writeTo(JavaSource<?> target) {
-        throw new UnsupportedOperationException(
-                "ReaderMethod requires additional context; use writeTo(JavaClassSource, SpecificationVersion, UnionType, CodeGenContext) instead");
+        if (specVersion == null || unionType == null || ctx == null) {
+            throw new UnsupportedOperationException(
+                    "ReaderMethod requires full context constructor for writeTo");
+        }
+        writeUnionReaderMethod((JavaClassSource) target);
     }
 
-    /**
-     * Generates the full union reader dispatch method on the given reader class.
-     * Creates a method {@code readUnionName(JsonNode json, ModelType modelType)} that
-     * dispatches to the correct variant based on JSON shape.
-     */
-    public void writeTo(JavaClassSource readerClassSource, SpecificationVersion specVersion,
-                        UnionType unionType, CodeGenContext ctx) {
+    private void writeUnionReaderMethod(JavaClassSource readerClassSource) {
         String namespace = specVersion.getNamespace();
         NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(namespace);
         JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
@@ -29,9 +29,24 @@ import io.apitomy.umg.models.java.type.JavaTypeFactory;
 public class WriterMethod implements Method {
 
     private final String entityName;
+    private final SpecificationVersion specVersion;
+    private final UnionType unionType;
+    private final CodeGenContext ctx;
 
     public WriterMethod(String entityName) {
         this.entityName = entityName;
+        this.specVersion = null;
+        this.unionType = null;
+        this.ctx = null;
+    }
+
+    public WriterMethod(SpecificationVersion specVersion, UnionType unionType, CodeGenContext ctx) {
+        NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(specVersion.getNamespace());
+        JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);
+        this.entityName = jt.getSimpleName();
+        this.specVersion = specVersion;
+        this.unionType = unionType;
+        this.ctx = ctx;
     }
 
     /**
@@ -53,17 +68,14 @@ public class WriterMethod implements Method {
 
     @Override
     public void writeTo(JavaSource<?> target) {
-        throw new UnsupportedOperationException(
-                "WriterMethod requires additional context; use writeTo(JavaClassSource, SpecificationVersion, UnionType, CodeGenContext) instead");
+        if (specVersion == null || unionType == null || ctx == null) {
+            throw new UnsupportedOperationException(
+                    "WriterMethod requires full context constructor for writeTo");
+        }
+        writeUnionWriterMethod((JavaClassSource) target);
     }
 
-    /**
-     * Generates the full union writer dispatch method on the given writer class.
-     * Creates a method {@code writeUnionName(UnionType union)} that dispatches
-     * to the correct variant writer based on is/as methods.
-     */
-    public void writeTo(JavaClassSource writerClassSource, SpecificationVersion specVersion,
-                        UnionType unionType, CodeGenContext ctx) {
+    private void writeUnionWriterMethod(JavaClassSource writerClassSource) {
         String namespace = specVersion.getNamespace();
         NamespaceModel nsModel = ctx.getConceptIndex().lookupNamespace(namespace);
         JavaType jt = ctx.getJavaTypeFactory().createJavaType(unionType, nsModel);


### PR DESCRIPTION
## Summary

- New `AbstractIOStage` base class with template method pattern for the shared orchestration across reader, writer, and cloner stages
- Shared `doProcess()`, spec-version iteration, Roaster class creation, entity loop, property-type dispatch
- Eliminates 3 duplicated inner classes (`CreateReadPropertySnippet`, `CreateWriteProperty`, `CreateCloneProperty`) — identical type dispatch logic now lives in `dispatchProperty()` on the base, with a `createPropertyBlock(kind)` factory method for subclass-specific code blocks
- Fixes `ReaderMethod`/`WriterMethod` `writeTo` contract — extra context passed via constructor so `Method.writeTo(JavaSource<?>)` works properly

Before: 1091 lines across 3 stages. After: 694 lines (146 base + 548). **Net -397 lines.**

## Context

C32d Step 3 in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged