### PR TITLE
refactor(generator): util tidying, dispatch unification, predicate cleanup (C34)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/ListType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/ListType.java
@@ -43,4 +43,7 @@ public class ListType extends CollectionType {
 
     @Override
     public boolean isEntityListType() { return valueType.isEntityType(); }
+
+    @Override
+    public boolean isUnionListType() { return valueType.isUnionType(); }
 }

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/MapType.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/MapType.java
@@ -44,4 +44,7 @@ public class MapType extends CollectionType {
 
     @Override
     public boolean isEntityMapType() { return valueType.isEntityType(); }
+
+    @Override
+    public boolean isUnionMapType() { return valueType.isUnionType(); }
 }

--- a/generator/src/main/java/io/apitomy/umg/models/concept/type/Type.java
+++ b/generator/src/main/java/io/apitomy/umg/models/concept/type/Type.java
@@ -68,4 +68,8 @@ public interface Type {
     default boolean isEntityListType() { return false; }
 
     default boolean isEntityMapType() { return false; }
+
+    default boolean isUnionListType() { return false; }
+
+    default boolean isUnionMapType() { return false; }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/AbstractStage.java
@@ -1,7 +1,5 @@
 package io.apitomy.umg.pipe;
 
-import org.modeshape.common.text.Inflector;
-
 import io.apitomy.umg.logging.Logger;
 import io.apitomy.umg.models.concept.PropertyModel;
 import lombok.Getter;
@@ -10,8 +8,6 @@ import lombok.Getter;
  * Base class for all pipeline stages.
  */
 public abstract class AbstractStage implements Stage {
-
-    private static final Inflector inflector = new Inflector();
 
     @Getter
     private GeneratorState state;
@@ -37,13 +33,11 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isEntityList(PropertyModel property) {
-        return property.getResolvedType().isListType()
-                && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isEntityType();
+        return property.getResolvedType().isEntityListType();
     }
 
     protected boolean isEntityMap(PropertyModel property) {
-        return property.getResolvedType().isMapType()
-                && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isEntityType();
+        return property.getResolvedType().isEntityMapType();
     }
 
     protected boolean isEntity(PropertyModel property) {
@@ -59,28 +53,21 @@ public abstract class AbstractStage implements Stage {
     }
 
     protected boolean isPrimitiveList(PropertyModel property) {
-        return property.getResolvedType().isListType()
-                && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isPrimitiveType();
+        return property.getResolvedType().isPrimitiveListType();
     }
 
     protected boolean isPrimitiveMap(PropertyModel property) {
-        return property.getResolvedType().isMapType()
-                && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isPrimitiveType();
+        return property.getResolvedType().isPrimitiveMapType();
     }
 
     protected boolean isUnionList(PropertyModel property) {
-        return property.getResolvedType().isListType()
-                && ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType().isUnionType();
+        return property.getResolvedType().isUnionListType();
     }
 
     protected boolean isUnionMap(PropertyModel property) {
-        return property.getResolvedType().isMapType()
-                && ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType().isUnionType();
+        return property.getResolvedType().isUnionMapType();
     }
 
-    public String singularize(String name) {
-        return inflector.singularize(name);
-    }
 
     protected String extractRegex(String propertyName) {
         return propertyName.substring(1, propertyName.length() - 1);

--- a/generator/src/main/java/io/apitomy/umg/pipe/GeneratorState.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/GeneratorState.java
@@ -32,8 +32,6 @@ public class GeneratorState {
     /**
      * Returns all traits with the same name as the given parent trait.  Does a search of
      * the namespace tree to find such traits.
-     *
-     * @param parentTrait
      */
     public Collection<TraitModel> findChildTraitsFor(TraitModel parentTrait) {
         String traitName = parentTrait.getName();
@@ -51,8 +49,6 @@ public class GeneratorState {
     /**
      * Returns all entities with the same name as the given parent entity.  Does a search of
      * the namespace tree to find such entities.
-     *
-     * @param parentEntity
      */
     public Collection<EntityModel> findChildEntitiesFor(EntityModel parentEntity) {
         String entityName = parentEntity.getName();
@@ -69,9 +65,6 @@ public class GeneratorState {
 
     /**
      * Finds a child trait in the given namespace with the given name.
-     *
-     * @param namespaceModel
-     * @param traitName
      */
     public TraitModel findChildTraitIn(NamespaceModel namespaceModel, String traitName) {
         if (namespaceModel.containsTrait(traitName)) {
@@ -88,9 +81,6 @@ public class GeneratorState {
 
     /**
      * Finds a child entity in the given namespace with the given name.
-     *
-     * @param namespaceModel
-     * @param entityName
      */
     public EntityModel findChildEntityIn(NamespaceModel namespaceModel, String entityName) {
         if (namespaceModel.containsEntity(entityName)) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/CreateImplicitUnionRulesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/CreateImplicitUnionRulesStage.java
@@ -74,8 +74,6 @@ public class CreateImplicitUnionRulesStage extends AbstractStage {
     /**
      * Create implicit union rules for the union type.  This is only called if we actually need it.
      *
-     * @param entity
-     * @param property
      */
     private void createImplicitUnionRules(EntityModel entity, PropertyModel property) {
         var unionType = (UnionType) property.getResolvedType();
@@ -108,8 +106,6 @@ public class CreateImplicitUnionRulesStage extends AbstractStage {
      * 2) The entity definition has only one property.  The existence of that property is used for
      *    discrimination.
      *
-     * @param nsContext
-     * @param simpleType
      */
     private UnionRule createImplicitRuleForEntity(NamespaceModel nsContext, String entityName) {
         EntityModel entity = getState().getConceptIndex().lookupEntity(nsContext, entityName);

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeEntitiesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeEntitiesStage.java
@@ -64,8 +64,6 @@ public class NormalizeEntitiesStage extends AbstractStage {
      * interfaces are always generated (e.g. OpenRpcDocument) even when a spec has only
      * one major version.
      *
-     * @param namespaceModel
-     * @param entityName
      */
     private boolean needsParentEntity(NamespaceModel namespaceModel, String entityName) {
         int count = 0;

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizePropertiesStage.java
@@ -94,8 +94,6 @@ public class NormalizePropertiesStage extends AbstractStage {
     /**
      * Checks if the given collection of properties contains the given property.  It must have a property with
      * the same name and the property must have the same type.
-     * @param properties
-     * @param property
      */
     private boolean hasProperty(Map<String, PropertyModel> properties, PropertyModel property) {
         PropertyModel otherProperty = properties.get(property.getName());

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeTraitsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeTraitsStage.java
@@ -69,8 +69,6 @@ public class NormalizeTraitsStage extends AbstractStage {
      * even if only one child subtree contains the trait.  This ensures that spec-level
      * interfaces are always generated even when a spec has only one major version.
      *
-     * @param namespaceModel
-     * @param traitName
      */
     private boolean needsParentTrait(NamespaceModel namespaceModel, String traitName) {
         int count = 0;

--- a/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/concept/NormalizeVisitorsStage.java
@@ -65,7 +65,6 @@ public class NormalizeVisitorsStage extends AbstractStage {
     /**
      * Creates a visitor in the root namespace.  Ensures that all other unparented visitors
      * are parented by this new root visitor.
-     * @param rootNamespace
      */
     private void createRootVisitor(String rootNamespace) {
         NamespaceModel rootNS = getState().getConceptIndex().lookupNamespace(rootNamespace);
@@ -82,8 +81,6 @@ public class NormalizeVisitorsStage extends AbstractStage {
 
     /**
      * Returns true if the given entity exists in *all* of the given visitors.
-     * @param entity
-     * @param childVisitors
      */
     private boolean existsInAllChildren(EntityModel entity, Collection<VisitorModel> childVisitors) {
         return childVisitors.stream().map(visitor -> visitor.containsEntity(entity.getName())).reduce(true, (sub, element) -> sub && element);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
@@ -8,7 +8,9 @@ import java.util.function.Predicate;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.ClearMethod;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
@@ -58,7 +60,7 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
                 error("Regex property defined without a collection name: " + javaEntity.getCanonicalName() + "::" + property);
                 return;
             }
-            Type collectionResolvedType = io.apitomy.umg.models.concept.type.MapType.builder()
+            Type collectionResolvedType = MapType.builder()
                     .namespace(property.getResolvedType().getNamespace())
                     .name("{" + property.getResolvedType().getName() + "}")
                     .valueType(property.getResolvedType())
@@ -80,31 +82,29 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, t -> t.isEntityType())) {
+        } else if (resolvedTypeIs(property, Type::isEntityType)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             createFactoryMethodForType(javaEntity, property.getResolvedType());
-        } else if (resolvedTypeIs(property, t -> t.isCollectionType()
-                && ((io.apitomy.umg.models.concept.type.CollectionType) t).getValueType().isEntityType())) {
+        } else if (resolvedTypeIs(property, t -> t.isEntityListType() || t.isEntityMapType())) {
             createFactoryMethodForType(javaEntity, property.getResolvedType());
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
             new RemoveMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new InsertMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, t -> t.isUnionType())) {
+        } else if (resolvedTypeIs(property, Type::isUnionType)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             createUnionFactoryMethods(javaEntity, propertyWithOrigin);
-        } else if (resolvedTypeIs(property, t -> t.isCollectionType()
-                && ((io.apitomy.umg.models.concept.type.CollectionType) t).getValueType().isUnionType())) {
+        } else if (resolvedTypeIs(property, t -> t.isUnionListType() || t.isUnionMapType())) {
             createUnionFactoryMethods(javaEntity, propertyWithOrigin);
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
             new RemoveMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new InsertMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, t -> t.isCollectionType())) {
+        } else if (resolvedTypeIs(property, Type::isCollectionType)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
@@ -124,21 +124,17 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
      * When an entity has a "*" property, that means the entity is a wrapper around a map
      * of values of a particular type.  In this case, the entity needs to extend/implement
      * the "MappedNode" interface.
-     * @param javaEntity
-     * @param propertyWithOrigin
      */
     protected abstract void createMappedNodeMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin);
 
     /**
      * Creates a factory method for the entity type associated with the given type.
      * Unwraps collection types to get the effective entity type.
-     * @param javaEntity
-     * @param type
      */
     private void createFactoryMethodForType(JavaSource<?> javaEntity, Type type) {
         Type effectiveType = type;
         if (effectiveType.isMapType() || effectiveType.isListType()) {
-            effectiveType = ((io.apitomy.umg.models.concept.type.CollectionType) effectiveType).getValueType();
+            effectiveType = ((CollectionType) effectiveType).getValueType();
         }
         String entityName = effectiveType.getName();
         new FactoryMethod(javaEntity, entityName, ctx).writeTo(javaEntity);
@@ -153,20 +149,17 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
      * get individual factory methods for their entity variants — the old PropertyType-based code
      * never saw them as unions (only as simple type references), so we preserve that behavior.
      *
-     * @param javaEntity
-     * @param propertyWithOrigin
      */
     private void createUnionFactoryMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {
         PropertyModel property = propertyWithOrigin.getProperty();
         Type resolvedType = property.getResolvedType();
-        io.apitomy.umg.models.concept.type.UnionType unionType;
+        UnionType unionType;
 
         // Extract the union type - it might be directly a union, or wrapped in a list/map
         if (resolvedType.isUnionType()) {
-            unionType = (io.apitomy.umg.models.concept.type.UnionType) resolvedType;
-        } else if (resolvedType.isCollectionType()
-                && ((io.apitomy.umg.models.concept.type.CollectionType) resolvedType).getValueType().isUnionType()) {
-            unionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.CollectionType) resolvedType).getValueType();
+            unionType = (UnionType) resolvedType;
+        } else if (resolvedType.isUnionListType() || resolvedType.isUnionMapType()) {
+            unionType = (UnionType) ((CollectionType) resolvedType).getValueType();
         } else {
             return;
         }
@@ -179,9 +172,8 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         for (Type variantType : unionType.getTypes()) {
             if (variantType.isEntityType()) {
                 createFactoryMethodForType(javaEntity, variantType);
-            } else if (variantType.isCollectionType()
-                    && ((io.apitomy.umg.models.concept.type.CollectionType) variantType).getValueType().isEntityType()) {
-                createFactoryMethodForType(javaEntity, ((io.apitomy.umg.models.concept.type.CollectionType) variantType).getValueType());
+            } else if (variantType.isEntityListType() || variantType.isEntityMapType()) {
+                createFactoryMethodForType(javaEntity, ((CollectionType) variantType).getValueType());
             }
         }
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractCreateMethodsStage.java
@@ -3,8 +3,6 @@ package io.apitomy.umg.pipe.java;
 
 import org.jboss.forge.roaster.model.source.JavaSource;
 
-import java.util.function.Predicate;
-
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 import io.apitomy.umg.models.concept.type.CollectionType;
@@ -82,29 +80,29 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, Type::isEntityType)) {
+        } else if (isEntity(property)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             createFactoryMethodForType(javaEntity, property.getResolvedType());
-        } else if (resolvedTypeIs(property, t -> t.isEntityListType() || t.isEntityMapType())) {
+        } else if (isEntityList(property) || isEntityMap(property)) {
             createFactoryMethodForType(javaEntity, property.getResolvedType());
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
             new RemoveMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new InsertMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, Type::isUnionType)) {
+        } else if (isUnion(property)) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new SetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             createUnionFactoryMethods(javaEntity, propertyWithOrigin);
-        } else if (resolvedTypeIs(property, t -> t.isUnionListType() || t.isUnionMapType())) {
+        } else if (isUnionList(property) || isUnionMap(property)) {
             createUnionFactoryMethods(javaEntity, propertyWithOrigin);
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
             new RemoveMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new InsertMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
-        } else if (resolvedTypeIs(property, Type::isCollectionType)) {
+        } else if (property.getResolvedType().isCollectionType()) {
             new GetterMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new AddMethod(property, propertyWithOrigin, ctx).writeTo(javaEntity);
             new ClearMethod(property, ctx).writeTo(javaEntity);
@@ -113,11 +111,6 @@ public abstract class AbstractCreateMethodsStage extends AbstractJavaStage {
         } else {
             warn("Failed to create methods (not yet implemented) for property '" + property.getName() + "' of entity: " + javaEntity.getQualifiedName());
         }
-    }
-
-    private boolean resolvedTypeIs(PropertyModel property, Predicate<Type> predicate) {
-        var resolved = property.getResolvedType();
-        return resolved != null && predicate.test(resolved);
     }
 
     /**

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractIOStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractIOStage.java
@@ -9,9 +9,7 @@ import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
-import io.apitomy.umg.models.concept.type.ListType;
-import io.apitomy.umg.models.concept.type.MapType;
-import io.apitomy.umg.models.concept.type.UnionType;
+import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
@@ -84,38 +82,10 @@ public abstract class AbstractIOStage extends AbstractJavaStage {
 
     private boolean dispatchByResolvedType(BodyBuilder body, PropertyModel property,
             PropertyCodeGen prop, JavaClassSource classSource) {
-        var resolved = property.getResolvedType();
-        if (resolved == null) return false;
-
-        if (resolved instanceof UnionType) {
-            createPropertyBlock(PropertyBlockKind.UNION, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved instanceof ListType lt && lt.getValueType() instanceof UnionType) {
-            createPropertyBlock(PropertyBlockKind.UNION_LIST, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved instanceof MapType mt && mt.getValueType() instanceof UnionType) {
-            createPropertyBlock(PropertyBlockKind.UNION_MAP, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved.isEntityType()) {
-            createPropertyBlock(PropertyBlockKind.ENTITY, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved.isPrimitiveType()) {
-            createPropertyBlock(PropertyBlockKind.PRIMITIVE, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved.isListType()) {
-            createPropertyBlock(PropertyBlockKind.LIST, prop, classSource).appendTo(body);
-            return true;
-        }
-        if (resolved.isMapType()) {
-            createPropertyBlock(PropertyBlockKind.MAP, prop, classSource).appendTo(body);
-            return true;
-        }
-        return false;
+        PropertyBlockKind kind = PropertyBlockKind.fromResolvedType(property.getResolvedType());
+        if (kind == null) return false;
+        createPropertyBlock(kind, prop, classSource).appendTo(body);
+        return true;
     }
 
     // ---- Abstract methods (must override) ----
@@ -141,6 +111,22 @@ public abstract class AbstractIOStage extends AbstractJavaStage {
     // ---- Property block kinds ----
 
     protected enum PropertyBlockKind {
-        STAR, REGEX, UNION, UNION_LIST, UNION_MAP, ENTITY, PRIMITIVE, LIST, MAP
+        STAR, REGEX, UNION, UNION_LIST, UNION_MAP, ENTITY, PRIMITIVE, LIST, MAP;
+
+        /**
+         * Maps a resolved type to its PropertyBlockKind.
+         * Returns null if the type is null or not recognized.
+         */
+        public static PropertyBlockKind fromResolvedType(Type resolvedType) {
+            if (resolvedType == null) return null;
+            if (resolvedType.isUnionType())     return UNION;
+            if (resolvedType.isUnionListType())  return UNION_LIST;
+            if (resolvedType.isUnionMapType())   return UNION_MAP;
+            if (resolvedType.isEntityType())     return ENTITY;
+            if (resolvedType.isPrimitiveType())  return PRIMITIVE;
+            if (resolvedType.isListType())       return LIST;
+            if (resolvedType.isMapType())        return MAP;
+            return null;
+        }
     }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractJavaStage.java
@@ -1,24 +1,20 @@
 package io.apitomy.umg.pipe.java;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
-import org.jboss.forge.roaster.model.source.MethodHolderSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
 
 import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
-import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
 
 import io.apitomy.umg.models.concept.TraitModel;
 import io.apitomy.umg.models.concept.VisitorModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.models.java.type.JavaTypeFactory;
 import io.apitomy.umg.pipe.AbstractStage;
 import io.apitomy.umg.pipe.java.method.CodeGenContext;
@@ -72,7 +68,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
 
     /**
      * Determines the package to use for the interface generated for the given visitor.
-     * @param visitor
      */
     protected String getVisitorInterfacePackageName(VisitorModel visitor) {
         String packageName = visitor.getNamespace().fullName();
@@ -82,7 +77,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
 
     /**
      * Determines the prefix to use for the interface name for the given visitor.
-     * @param visitor
      */
     protected String getVisitorInterfacePrefix(VisitorModel visitor) {
         return (visitor.getParent() == null) ? "" : getState().getSpecIndex().prefixForNS(visitor.getNamespace().fullName());
@@ -90,7 +84,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
 
     /**
      * Determines the interface name for the given visitor.
-     * @param visitor
      */
     protected String getVisitorInterfaceName(VisitorModel visitor) {
         String visitorPrefix = getVisitorInterfacePrefix(visitor);
@@ -100,7 +93,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
 
     /**
      * Determines the fully qualified name of the Java interface for a given visitor.
-     * @param visitor
      */
     protected String getVisitorInterfaceFullName(VisitorModel visitor) {
         String packageName = visitor.getNamespace().fullName();
@@ -187,9 +179,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getState().getConfig().getRootNamespace() + ".RootCapable";
     }
 
-    protected String getMappedNodeInterfaceFQN() {
-        return getState().getConfig().getRootNamespace() + ".MappedNode";
-    }
 
     public String getNodeEntityClassFQN() {
         return getState().getConfig().getRootNamespace() + ".NodeImpl";
@@ -235,21 +224,15 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return getUnionTypesPackageName() + ".Union";
     }
 
-    protected String getUnionValueInterfaceFQN() {
-        return getUnionTypesPackageName() + ".UnionValue";
-    }
 
-    public Class<?> primitiveTypeToClass(Type type) {
-        return io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper.primitiveTypeToClass(type);
-    }
 
     public JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, PropertyModel property) {
-        var entityType = (io.apitomy.umg.models.concept.type.EntityType) property.getResolvedType();
+        var entityType = (EntityType) property.getResolvedType();
         return resolveJavaEntity(namespace.fullName(), entityType.getName());
     }
 
     public JavaInterfaceSource resolveJavaEntityType(String namespace, PropertyModel property) {
-        var entityType = (io.apitomy.umg.models.concept.type.EntityType) property.getResolvedType();
+        var entityType = (EntityType) property.getResolvedType();
         return resolveJavaEntity(namespace, entityType.getName());
     }
 
@@ -297,14 +280,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return lookupJavaEntity(commonEntity);
     }
 
-    protected boolean hasNamedMethod(MethodHolderSource<?> entityInterface, String methodName) {
-        for (MethodSource<?> method : entityInterface.getMethods()) {
-            if (method.getName().equals(methodName)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     protected JavaInterfaceSource lookupJavaEntity(EntityModel entity) {
         return lookupJavaEntity(getJavaEntityInterfaceFQN(entity));
@@ -352,16 +327,16 @@ public abstract class AbstractJavaStage extends AbstractStage {
         return pkg + "." + name;
     }
 
-    protected String resolveUnionPackage(io.apitomy.umg.models.concept.type.UnionType unionType) {
+    protected String resolveUnionPackage(UnionType unionType) {
         for (var variant : unionType.getTypes()) {
-            io.apitomy.umg.models.concept.type.EntityType entityType = null;
-            if (variant instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            EntityType entityType = null;
+            if (variant instanceof EntityType et) {
                 entityType = et;
-            } else if (variant instanceof io.apitomy.umg.models.concept.type.ListType lt
-                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            } else if (variant instanceof ListType lt
+                    && lt.getValueType() instanceof EntityType et) {
                 entityType = et;
-            } else if (variant instanceof io.apitomy.umg.models.concept.type.MapType mt
-                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            } else if (variant instanceof MapType mt
+                    && mt.getValueType() instanceof EntityType et) {
                 entityType = et;
             }
             if (entityType != null) {
@@ -374,32 +349,6 @@ public abstract class AbstractJavaStage extends AbstractStage {
         }
         return getUnionTypesPackageName();
     }
-
-
-
-    public static String getTypeName(Type type) {
-        if (type.isEntityType()) {
-            return type.getName();
-        } else if (type.isPrimitiveType()) {
-            return StringUtils.capitalize(type.getName());
-        } else if (type.isPrimitiveUnionVariantType()) {
-            return StringUtils.capitalize(type.getName());
-        } else if (type.isUnionType()) {
-            List<Type> nestedTypes = new ArrayList<>(((io.apitomy.umg.models.concept.type.UnionType) type).getTypes());
-            return getUnionTypeName(nestedTypes);
-        } else if (type.isListType()) {
-            return getTypeName(((io.apitomy.umg.models.concept.type.ListType) type).getValueType()) + "List";
-        } else if (type.isMapType()) {
-            return getTypeName(((io.apitomy.umg.models.concept.type.MapType) type).getValueType()) + "Map";
-        } else {
-            throw new RuntimeException("Unsupported type in union: " + type);
-        }
-    }
-
-    private static String getUnionTypeName(List<Type> unionNestedTypes) {
-        return unionNestedTypes.stream().map(pt -> getTypeName(pt)).reduce((t, u) -> t + u).orElseThrow() + "Union";
-    }
-
 
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
@@ -16,7 +16,6 @@ public abstract class AbstractVisitorStage extends AbstractJavaStage {
     /**
      * Finds all of the descendant visitors for the given visitor.  This walks down the
      * visitor hierarchy and finds all of the "leaf" visitor nodes in that tree.
-     * @param visitor
      */
     protected Set<VisitorModel> findDescendantVisitors(VisitorModel visitor) {
         return getState().getConceptIndex().findVisitors(visitor.getNamespace().fullName()).stream().filter(v -> isVisitorForSpecVersion(v)).collect(Collectors.toSet());
@@ -24,7 +23,6 @@ public abstract class AbstractVisitorStage extends AbstractJavaStage {
 
     /**
      * Returns ture if the given visitor is associated with a specification version.
-     * @param visitor
      */
     private boolean isVisitorForSpecVersion(VisitorModel visitor) {
         SpecificationVersionId id = SpecificationVersionId.create(visitor.getNamespace().fullName());
@@ -36,7 +34,6 @@ public abstract class AbstractVisitorStage extends AbstractJavaStage {
      * given visitor model.  This walks up the visitor hierarchy, collecting all methods
      * defined on visitor interfaces.  It returns the full collection of methods (for
      * this visitor and all super-interfaces).
-     * @param visitor
      */
     protected List<MethodSource<?>> getAllMethodsForVisitorInterface(VisitorModel visitor) {
         List<MethodSource<?>> methods = new LinkedList<>();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplFieldsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplFieldsStage.java
@@ -9,6 +9,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.MapType;
 
 /**
  * Creates the fields for each entity implementation.  This is done by iterating over all leaf entities
@@ -39,7 +40,7 @@ public class CreateImplFieldsStage extends AbstractJavaStage {
 
         boolean isStarProperty = false;
         if (isStarProperty(property)) {
-            var collectionResolvedType = io.apitomy.umg.models.concept.type.MapType.builder()
+            var collectionResolvedType = MapType.builder()
                     .namespace(property.getResolvedType().getNamespace())
                     .name("{" + property.getResolvedType().getName() + "}")
                     .valueType(property.getResolvedType())
@@ -51,7 +52,7 @@ public class CreateImplFieldsStage extends AbstractJavaStage {
                 error("Regex property defined without a collection name: " + javaEntityImpl.getCanonicalName() + "::" + property);
                 return;
             }
-            var collectionResolvedType = io.apitomy.umg.models.concept.type.MapType.builder()
+            var collectionResolvedType = MapType.builder()
                     .namespace(property.getResolvedType().getNamespace())
                     .name("{" + property.getResolvedType().getName() + "}")
                     .valueType(property.getResolvedType())

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateImplMethodsStage.java
@@ -29,7 +29,6 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
     /**
      * Creates implementations of all methods needed for an implementation of the given
      * entity model.
-     * @param entity
      */
     private void createEntityImplMethods(EntityModel entity) {
         JavaClassSource javaEntity = lookupJavaEntityImpl(entity);
@@ -44,8 +43,6 @@ public class CreateImplMethodsStage extends AbstractCreateMethodsStage {
      * When an entity has a "*" property, that means the entity is a wrapper around a map
      * of values of a particular type.  In this case, the entity interface needs to extend
      * the "MappedNode" interface.
-     * @param javaEntity
-     * @param propertyWithOrigin
      */
     @Override
     protected void createMappedNodeMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateInterfaceMethodsStage.java
@@ -66,8 +66,6 @@ public class CreateInterfaceMethodsStage extends AbstractCreateMethodsStage {
      * When an entity has a "*" property, that means the entity is a wrapper around a map of values of a
      * particular type. In this case, the entity interface needs to extend the "MappedNode" interface.
      *
-     * @param javaEntity
-     * @param propertyWithOrigin
      */
     @Override
     protected void createMappedNodeMethods(JavaSource<?> javaEntity, PropertyModelWithOrigin propertyWithOrigin) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreatePrimitiveUnionValuesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreatePrimitiveUnionValuesStage.java
@@ -1,7 +1,7 @@
 package io.apitomy.umg.pipe.java;
 
 import io.apitomy.umg.models.concept.type.PrimitiveUnionVariantType;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
@@ -27,7 +27,7 @@ public class CreatePrimitiveUnionValuesStage extends AbstractJavaStage {
 
     private void createPrimitiveUnionValue(PrimitiveUnionVariantType puv) {
         String typeName = StringUtils.capitalize(puv.getType().name().toLowerCase());
-        Class<?> javaClass = PrimitiveTypeHelper.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+        Class<?> javaClass = PrimitiveTypeUtil.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
         if (javaClass == null) return;
 
         String _package = getUnionTypesPackageName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
@@ -106,8 +107,8 @@ public class CreateReadersStage extends AbstractIOStage {
         var namespace = specVersion.getNamespace();
 
         getState().getConceptIndex().findTypes(namespace).stream()
-                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
-                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .filter(t -> t instanceof UnionType)
+                .map(t -> (UnionType) t)
                 .forEach(unionType -> {
                     new ReaderMethod(specVersion, unionType, ctx).writeTo(classSource);
                 });
@@ -120,7 +121,7 @@ public class CreateReadersStage extends AbstractIOStage {
         var namespace = specVersion.getNamespace();
 
         var rootType = getState().getConceptIndex().lookupType(namespace, rootTypeName);
-        if (rootType instanceof io.apitomy.umg.models.concept.type.UnionType unionType) {
+        if (rootType instanceof UnionType unionType) {
             createUnionReadRootMethod(specVersion, classSource, unionType);
             return;
         }
@@ -170,7 +171,7 @@ public class CreateReadersStage extends AbstractIOStage {
     }
 
     private void createUnionReadRootMethod(SpecificationVersion specVersion,
-            JavaClassSource classSource, io.apitomy.umg.models.concept.type.UnionType unionType) {
+            JavaClassSource classSource, UnionType unionType) {
         JavaInterfaceSource rootCapableSource =
                 getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
         classSource.addImport(rootCapableSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTestFixturesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTestFixturesStage.java
@@ -24,6 +24,8 @@ import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.pipe.AbstractStage;
 
 public class CreateTestFixturesStage extends AbstractStage {
@@ -90,7 +92,7 @@ public class CreateTestFixturesStage extends AbstractStage {
 
     private JsonNode generatePropertyValue(EntityModel entity, PropertyModel property, Stack<String> entityStack) {
         if (isStarProperty(property)) {
-            var collectionResolvedType = io.apitomy.umg.models.concept.type.MapType.builder()
+            var collectionResolvedType = MapType.builder()
                     .namespace(property.getResolvedType().getNamespace())
                     .name("{" + property.getResolvedType().getName() + "}")
                     .valueType(property.getResolvedType())
@@ -98,7 +100,7 @@ public class CreateTestFixturesStage extends AbstractStage {
             PropertyModel itemsProperty = PropertyModel.builder().name("_items").resolvedType(collectionResolvedType).build();
             return generatePropertyValue(entity, itemsProperty, entityStack);
         } else if (isRegexProperty(property)) {
-            var collectionResolvedType = io.apitomy.umg.models.concept.type.MapType.builder()
+            var collectionResolvedType = MapType.builder()
                     .namespace(property.getResolvedType().getNamespace())
                     .name("{" + property.getResolvedType().getName() + "}")
                     .valueType(property.getResolvedType())
@@ -117,7 +119,7 @@ public class CreateTestFixturesStage extends AbstractStage {
                 return generateEntityFixture(propertyEntity, entityStack);
             }
         } else if (isEntityList(property)) {
-            var listType = (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+            var listType = (ListType) property.getResolvedType();
             EntityModel propertyEntity = resolveEntity(entity.getNamespace(), listType.getValueType().getName());
             if (propertyEntity != null) {
                 return generateListValue(() -> {
@@ -126,7 +128,7 @@ public class CreateTestFixturesStage extends AbstractStage {
                 });
             }
         } else if (isEntityMap(property)) {
-            var mapType = (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+            var mapType = (MapType) property.getResolvedType();
             EntityModel propertyEntity = resolveEntity(entity.getNamespace(), mapType.getValueType().getName());
             if (propertyEntity != null) {
                 return generateEntityMapValue(property, propertyEntity, entityStack);
@@ -172,7 +174,7 @@ public class CreateTestFixturesStage extends AbstractStage {
     }
 
     private JsonNode generatePrimitiveListValue(PropertyModel property) {
-        var listType = (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+        var listType = (ListType) property.getResolvedType();
         PropertyModel primitiveProperty = PropertyModel.builder().name("_tmp").resolvedType(
                 listType.getValueType()).build();
         return generateListValue(() -> {
@@ -181,7 +183,7 @@ public class CreateTestFixturesStage extends AbstractStage {
     }
 
     private JsonNode generatePrimitiveMapValue(PropertyModel property) {
-        var mapType = (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+        var mapType = (MapType) property.getResolvedType();
         PropertyModel primitiveProperty = PropertyModel.builder().name("_tmp").resolvedType(
                 mapType.getValueType()).build();
         if (property.getCollection() != null) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
@@ -28,8 +28,6 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
      * Creates visitor interfaces for all visitors in a hierarchy, starting with the
      * given root visitor model.
      *
-     * @param visitor
-     * @param parentVisitorInterface
      */
     private void createVisitorInterfaces(VisitorModel visitor, JavaInterfaceSource parentVisitorInterface) {
         debug("Creating interface for: " + visitor.toString());
@@ -62,8 +60,6 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
     /**
      * Creates the readXyz() method for the given entity.
      *
-     * @param visitorInterfaceSource
-     * @param entity
      */
     private void createVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
         String visitMethodName = "visit" + entity.getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.umg.beans.SpecificationVersion;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
@@ -105,8 +106,8 @@ public class CreateWritersStage extends AbstractIOStage {
         var namespace = specVersion.getNamespace();
 
         getState().getConceptIndex().findTypes(namespace).stream()
-                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
-                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .filter(t -> t instanceof UnionType)
+                .map(t -> (UnionType) t)
                 .forEach(unionType -> {
                     new WriterMethod(specVersion, unionType, ctx).writeTo(classSource);
                 });
@@ -119,7 +120,7 @@ public class CreateWritersStage extends AbstractIOStage {
         var namespace = specVersion.getNamespace();
 
         var rootType = getState().getConceptIndex().lookupType(namespace, rootTypeName);
-        if (rootType instanceof io.apitomy.umg.models.concept.type.UnionType unionType) {
+        if (rootType instanceof UnionType unionType) {
             createUnionWriteRootMethod(specVersion, classSource, unionType);
             return;
         }
@@ -131,7 +132,7 @@ public class CreateWritersStage extends AbstractIOStage {
     }
 
     private void createUnionWriteRootMethod(SpecificationVersion specVersion,
-            JavaClassSource classSource, io.apitomy.umg.models.concept.type.UnionType unionType) {
+            JavaClassSource classSource, UnionType unionType) {
         JavaInterfaceSource rootCapableSource =
                 getState().getJavaIndex().lookupInterface(getRootNodeInterfaceFQN());
         classSource.addImport(rootCapableSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/JavaWriteStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/JavaWriteStage.java
@@ -26,8 +26,6 @@ public class JavaWriteStage extends AbstractStage {
     /**
      * Writes the given class out to a file.
      *
-     * @param javaSource
-     * @param outputDirectory
      */
     private void writeToFile(JavaSource<?> javaSource, File outputDirectory) {
         String pkg = javaSource.getPackage();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -13,7 +13,11 @@ import io.apitomy.umg.logging.Logger;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.EntityType;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.models.java.type.JavaTypeFactory;
 import java.util.Map;
 
@@ -129,16 +133,16 @@ public class CodeGenContext {
      * Resolves the package for union value impl classes, preferring the common-entity
      * namespace when a variant references a common entity.
      */
-    public String resolveUnionPackage(io.apitomy.umg.models.concept.type.UnionType unionType) {
+    public String resolveUnionPackage(UnionType unionType) {
         for (var variant : unionType.getTypes()) {
-            io.apitomy.umg.models.concept.type.EntityType entityType = null;
-            if (variant instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            EntityType entityType = null;
+            if (variant instanceof EntityType et) {
                 entityType = et;
-            } else if (variant instanceof io.apitomy.umg.models.concept.type.ListType lt
-                    && lt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            } else if (variant instanceof ListType lt
+                    && lt.getValueType() instanceof EntityType et) {
                 entityType = et;
-            } else if (variant instanceof io.apitomy.umg.models.concept.type.MapType mt
-                    && mt.getValueType() instanceof io.apitomy.umg.models.concept.type.EntityType et) {
+            } else if (variant instanceof MapType mt
+                    && mt.getValueType() instanceof EntityType et) {
                 entityType = et;
             }
             if (entityType != null) {
@@ -192,7 +196,7 @@ public class CodeGenContext {
     // --- Entity resolution ---
 
     public JavaInterfaceSource resolveJavaEntityType(NamespaceModel namespace, PropertyModel property) {
-        var entityType = (io.apitomy.umg.models.concept.type.EntityType) property.getResolvedType();
+        var entityType = (EntityType) property.getResolvedType();
         return resolveJavaEntity(namespace.fullName(), entityType.getName());
     }
 
@@ -247,7 +251,7 @@ public class CodeGenContext {
     // --- Primitive type mapping ---
 
     public Class<?> primitiveTypeToClass(Type type) {
-        return PrimitiveTypeHelper.primitiveTypeToClass(type);
+        return PrimitiveTypeUtil.primitiveTypeToClass(type);
     }
 
     public String singularize(String name) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeUtil.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeUtil.java
@@ -9,6 +9,8 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 
 /**
@@ -16,7 +18,7 @@ import io.apitomy.umg.models.concept.type.Type;
  * and to the corresponding {@code JsonUtil} consume/set method variants.
  * Extracted from duplicated code across reader, writer, and cloner blocks.
  */
-public final class PrimitiveTypeHelper {
+public final class PrimitiveTypeUtil {
 
     public static final Map<String, Class<?>> PRIMITIVE_TYPE_MAP = Map.ofEntries(
             entry("string", String.class),
@@ -26,7 +28,7 @@ public final class PrimitiveTypeHelper {
             entry("object", ObjectNode.class),
             entry("any", JsonNode.class));
 
-    private PrimitiveTypeHelper() {
+    private PrimitiveTypeUtil() {
     }
 
     /**
@@ -63,7 +65,7 @@ public final class PrimitiveTypeHelper {
         }
 
         if (type.isListType()) {
-            Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) type).getValueType();
+            Type listValueType = ((ListType) type).getValueType();
             if (listValueType.isPrimitiveType()) {
                 Class<?> _class = primitiveTypeToClass(listValueType);
                 if (_class != null) {
@@ -74,7 +76,7 @@ public final class PrimitiveTypeHelper {
         }
 
         if (type.isMapType()) {
-            Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) type).getValueType();
+            Type mapValueType = ((MapType) type).getValueType();
             if (mapValueType.isPrimitiveType()) {
                 Class<?> _class = primitiveTypeToClass(mapValueType);
                 if (_class != null) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -143,7 +143,7 @@ public class ReaderMethod implements Method {
                 body.append("    return node;");
                 body.append("}");
             } else if (variantType instanceof PrimitiveUnionVariantType puv) {
-                Class<?> javaClass = PrimitiveTypeHelper.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                Class<?> javaClass = PrimitiveTypeUtil.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
                 if (javaClass == null) continue;
 
                 String typeName = JavaTypeFactory.getUnionComponentName(variantType);
@@ -215,7 +215,7 @@ public class ReaderMethod implements Method {
                 JavaClassSource unionValueClass = ctx.getJavaIndex().lookupClass(unionValueClassFQN);
                 if (unionValueClass == null) continue;
 
-                Class<?> javaClass = PrimitiveTypeHelper.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                Class<?> javaClass = PrimitiveTypeUtil.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
                 if (javaClass == null) continue;
 
                 readerClassSource.addImport(unionValueClass);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/TypeNameUtil.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/TypeNameUtil.java
@@ -1,0 +1,40 @@
+package io.apitomy.umg.pipe.java.method;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
+
+public final class TypeNameUtil {
+
+    private TypeNameUtil() {
+    }
+
+    public static String getTypeName(Type type) {
+        if (type.isEntityType()) {
+            return type.getName();
+        } else if (type.isPrimitiveType()) {
+            return StringUtils.capitalize(type.getName());
+        } else if (type.isPrimitiveUnionVariantType()) {
+            return StringUtils.capitalize(type.getName());
+        } else if (type.isUnionType()) {
+            List<Type> nestedTypes = new ArrayList<>(((UnionType) type).getTypes());
+            return getUnionTypeName(nestedTypes);
+        } else if (type.isListType()) {
+            return getTypeName(((ListType) type).getValueType()) + "List";
+        } else if (type.isMapType()) {
+            return getTypeName(((MapType) type).getValueType()) + "Map";
+        } else {
+            throw new RuntimeException("Unsupported type in union: " + type);
+        }
+    }
+
+    private static String getUnionTypeName(List<Type> unionNestedTypes) {
+        return unionNestedTypes.stream().map(pt -> getTypeName(pt)).reduce((t, u) -> t + u).orElseThrow() + "Union";
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
@@ -121,7 +121,7 @@ public class WriterMethod implements Method {
                 body.append("}");
             } else if (variantType instanceof PrimitiveUnionVariantType puv) {
                 String typeName = JavaTypeFactory.getUnionComponentName(variantType);
-                Class<?> javaClass = PrimitiveTypeHelper.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
+                Class<?> javaClass = PrimitiveTypeUtil.PRIMITIVE_TYPE_MAP.get(puv.getType().name().toLowerCase());
                 if (javaClass == null) continue;
 
                 body.addContext("isMethod", new UnionIsMethod(typeName).getName());
@@ -164,7 +164,7 @@ public class WriterMethod implements Method {
                     body.append("    return array;");
                     body.append("}");
                 } else if (listType.getValueType() instanceof PrimitiveType primType) {
-                    Class<?> javaClass = PrimitiveTypeHelper.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
+                    Class<?> javaClass = PrimitiveTypeUtil.PRIMITIVE_TYPE_MAP.get(primType.name().toLowerCase());
                     if (javaClass == null) continue;
 
                     writerClassSource.addImport(javaClass);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -9,6 +9,7 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
@@ -16,7 +17,7 @@ import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -35,7 +36,7 @@ public class CloneListPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        Type listValueType = ((ListType) property.getResolvedType()).getValueType();
 
         if (listValueType.isPrimitiveType()) {
             clonerClassSource.addImport(List.class);
@@ -43,7 +44,7 @@ public class CloneListPropertyBlock extends CodeBlock {
             body.addContext(Map.of(
                     "getterMethodName", prop.getGetterName(),
                     "setterMethodName", prop.getSetterName(),
-                    "valueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), clonerClassSource)
+                    "valueType", PrimitiveTypeUtil.determineValueType(listValueType, prop.getCtx(), clonerClassSource)
             ));
 
             body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -8,6 +8,7 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
@@ -15,7 +16,7 @@ import io.apitomy.umg.pipe.java.method.ClonerMethod;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -34,7 +35,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        Type mapValueType = ((MapType) property.getResolvedType()).getValueType();
 
         if (mapValueType.isPrimitiveType()) {
             clonerClassSource.addImport(Map.class);
@@ -42,7 +43,7 @@ public class CloneMapPropertyBlock extends CodeBlock {
             body.addContext(Map.of(
                     "getterMethodName", prop.getGetterName(),
                     "setterMethodName", prop.getSetterName(),
-                    "valueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), clonerClassSource)
+                    "valueType", PrimitiveTypeUtil.determineValueType(mapValueType, prop.getCtx(), clonerClassSource)
             ));
 
             body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
@@ -16,7 +16,7 @@ import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -91,7 +91,7 @@ public class CloneRegexPropertyBlock extends CodeBlock {
         body.addContext(Map.of(
                 "getterMethodName", new GetterMethod(property).getName(),
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getCollection())).getName(),
-                "valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), clonerClassSource)
+                "valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), clonerClassSource)
         ));
 
         body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -1,6 +1,6 @@
 package io.apitomy.umg.pipe.java.method.cloner;
 
-import io.apitomy.umg.pipe.java.AbstractJavaStage;
+import io.apitomy.umg.pipe.java.method.TypeNameUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -12,6 +12,8 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
@@ -37,7 +39,7 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
-        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        UnionType effectiveUnionType = (UnionType) ((ListType) property.getResolvedType()).getValueType();
 
         clonerClassSource.addImport(List.class);
 
@@ -59,7 +61,7 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
         effectiveUnionType.getTypes().stream()
                 .sorted(UnionVariantComparator.INSTANCE)
                 .forEach(nestedType -> {
-            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String typeName = TypeNameUtil.getTypeName(nestedType);
             String isMethodName = new UnionIsMethod(typeName).getName();
             String asMethodName = new UnionAsMethod(typeName).getName();
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -1,6 +1,6 @@
 package io.apitomy.umg.pipe.java.method.cloner;
 
-import io.apitomy.umg.pipe.java.AbstractJavaStage;
+import io.apitomy.umg.pipe.java.method.TypeNameUtil;
 
 import java.util.Map;
 
@@ -11,7 +11,9 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
@@ -37,7 +39,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
-        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = (io.apitomy.umg.models.concept.type.UnionType) ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        UnionType effectiveUnionType = (UnionType) ((MapType) property.getResolvedType()).getValueType();
 
         clonerClassSource.addImport(Map.class);
 
@@ -60,7 +62,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
         effectiveUnionType.getTypes().stream()
                 .sorted(UnionVariantComparator.INSTANCE)
                 .forEach(nestedType -> {
-            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String typeName = TypeNameUtil.getTypeName(nestedType);
             String isMethodName = new UnionIsMethod(typeName).getName();
             String asMethodName = new UnionAsMethod(typeName).getName();
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -1,6 +1,6 @@
 package io.apitomy.umg.pipe.java.method.cloner;
 
-import io.apitomy.umg.pipe.java.AbstractJavaStage;
+import io.apitomy.umg.pipe.java.method.TypeNameUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,10 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.EntityModel;
 import io.apitomy.umg.models.concept.NamespaceModel;
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.CollectionType;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.models.concept.type.Type;
+import io.apitomy.umg.models.concept.type.UnionType;
 import io.apitomy.umg.models.concept.type.UnionVariantComparator;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
@@ -40,7 +43,7 @@ public class CloneUnionPropertyBlock extends CodeBlock {
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
         NamespaceModel nsContext = prop.getPropertyWithOrigin().getOrigin().getNamespace();
-        io.apitomy.umg.models.concept.type.UnionType effectiveUnionType = getEffectiveUnionType(property);
+        UnionType effectiveUnionType = getEffectiveUnionType(property);
 
         body.addContext(Map.of(
                 "unionJavaType", getUnionJavaTypeName(property, effectiveUnionType),
@@ -59,7 +62,7 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                 .sorted(UnionVariantComparator.INSTANCE)
                 .collect(Collectors.toList());
         body.forEach(sortedTypes, (loopCtx, nestedType, isFirst) -> {
-            String typeName = AbstractJavaStage.getTypeName(nestedType);
+            String typeName = TypeNameUtil.getTypeName(nestedType);
             String isMethodName = new UnionIsMethod(typeName).getName();
             String asMethodName = new UnionAsMethod(typeName).getName();
 
@@ -82,8 +85,8 @@ public class CloneUnionPropertyBlock extends CodeBlock {
         }
 """;
                 }
-            } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isPrimitiveType()) {
-                String unionValueName = AbstractJavaStage.getTypeName(nestedType);
+            } else if (nestedType.isListType() && ((ListType) nestedType).getValueType().isPrimitiveType()) {
+                String unionValueName = TypeNameUtil.getTypeName(nestedType);
                 String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(unionValueName + "UnionValue");
                 String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
                 JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
@@ -122,14 +125,14 @@ public class CloneUnionPropertyBlock extends CodeBlock {
 """;
                     }
                 }
-            } else if (nestedType.isListType() && ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType().isEntityType()) {
-                Type listItemType = ((io.apitomy.umg.models.concept.type.ListType) nestedType).getValueType();
+            } else if (nestedType.isListType() && ((ListType) nestedType).getValueType().isEntityType()) {
+                Type listItemType = ((ListType) nestedType).getValueType();
                 String listItemEntityName = prop.getOwningEntity().getNamespace().fullName() + "." + listItemType.getName();
                 EntityModel listItemEntity = prop.getCtx().getConceptIndex().lookupEntity(listItemEntityName);
                 if (listItemEntity != null) {
                     JavaInterfaceSource listItemEntitySource = prop.getCtx().getJavaIndex().lookupInterface(prop.getCtx().getJavaEntityInterfaceFQN(listItemEntity));
                     if (listItemEntitySource != null) {
-                        String unionValueName = AbstractJavaStage.getTypeName(nestedType);
+                        String unionValueName = TypeNameUtil.getTypeName(nestedType);
                         String unionValueInterfaceFQN = prop.getCtx().getUnionTypeFQN(unionValueName + "UnionValue");
                         String unionValueClassFQN = unionValueInterfaceFQN + "Impl";
                         JavaInterfaceSource unionValueInterface = prop.getCtx().getJavaIndex().lookupInterface(unionValueInterfaceFQN);
@@ -182,21 +185,21 @@ public class CloneUnionPropertyBlock extends CodeBlock {
         unionJavaType.addImportsTo(clonerClassSource);
     }
 
-    private io.apitomy.umg.models.concept.type.UnionType getEffectiveUnionType(PropertyModel property) {
+    private UnionType getEffectiveUnionType(PropertyModel property) {
         Type resolved = property.getResolvedType();
         if (resolved.isUnionType()) {
-            return (io.apitomy.umg.models.concept.type.UnionType) resolved;
+            return (UnionType) resolved;
         }
         if (resolved.isCollectionType()) {
-            Type valueType = ((io.apitomy.umg.models.concept.type.CollectionType) resolved).getValueType();
+            Type valueType = ((CollectionType) resolved).getValueType();
             if (valueType.isUnionType()) {
-                return (io.apitomy.umg.models.concept.type.UnionType) valueType;
+                return (UnionType) valueType;
             }
         }
         throw new IllegalStateException("Could not extract union type from: " + resolved);
     }
 
-    private String getUnionJavaTypeName(PropertyModel property, io.apitomy.umg.models.concept.type.UnionType unionType) {
+    private String getUnionJavaTypeName(PropertyModel property, UnionType unionType) {
         var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         var jt = prop.getCtx().getJavaTypeFactory().createJavaType(unionType, nsModel);
         jt.addImportsTo(clonerClassSource);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -10,13 +10,14 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
@@ -36,15 +37,15 @@ public class ReadListPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        Type listValueType = ((ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(List.class);
             readerClassSource.addImport(ArrayList.class);
 
-            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx());
-            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource);
-            String elementValueType = PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource);
+            String expectedType = PrimitiveTypeUtil.determineExpectedTypeString(listValueType, prop.getCtx());
+            String toConversionMethod = PrimitiveTypeUtil.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource);
+            String elementValueType = PrimitiveTypeUtil.determineValueType(listValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
                     "setterMethodName", prop.getSetterName(),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -11,13 +11,14 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
@@ -37,7 +38,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        Type mapValueType = ((MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
             readerClassSource.addImport(JsonNode.class);
             readerClassSource.addImport(ObjectNode.class);
@@ -45,9 +46,9 @@ public class ReadMapPropertyBlock extends CodeBlock {
             readerClassSource.addImport(LinkedHashMap.class);
             readerClassSource.addImport(List.class);
 
-            String expectedType = PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx());
-            String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource);
-            String elementValueType = PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource);
+            String expectedType = PrimitiveTypeUtil.determineExpectedTypeString(mapValueType, prop.getCtx());
+            String toConversionMethod = PrimitiveTypeUtil.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource);
+            String elementValueType = PrimitiveTypeUtil.determineValueType(mapValueType, prop.getCtx(), readerClassSource);
             body.addContext(Map.of(
                     "propertyName", property.getName(),
                     "setterMethodName", prop.getSetterName(),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadPrimitivePropertyBlock.java
@@ -10,7 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -31,8 +31,8 @@ public class ReadPrimitivePropertyBlock extends CodeBlock {
         PropertyModel property = prop.getProperty();
         readerClassSource.addImport(JsonNode.class);
 
-        String isCheckMethod = PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
-        String toConversionMethod = PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
+        String isCheckMethod = PrimitiveTypeUtil.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
+        String toConversionMethod = PrimitiveTypeUtil.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource);
         body.addContext(Map.of(
                 "propertyName", property.getName(),
                 "setterMethodName", prop.getSetterName(),

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
@@ -11,13 +11,15 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
@@ -96,8 +98,8 @@ public class ReadRegexPropertyBlock extends CodeBlock {
 
         body.addContext(Map.of(
                 "propertyRegex", encodeRegex(extractRegex(property.getName())),
-                "isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource),
-                "toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource),
+                "isCheckMethod", PrimitiveTypeUtil.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource),
+                "toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource),
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getCollection())).getName()
         ));
 
@@ -121,11 +123,11 @@ public class ReadRegexPropertyBlock extends CodeBlock {
         readerClassSource.addImport(ArrayList.class);
         readerClassSource.addImport(JsonNode.class);
 
-        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        Type listValueType = ((ListType) property.getResolvedType()).getValueType();
         body.addContext(Map.of(
-                "expectedType", PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx()),
-                "toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource),
-                "elementValueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource),
+                "expectedType", PrimitiveTypeUtil.determineExpectedTypeString(listValueType, prop.getCtx()),
+                "toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource),
+                "elementValueType", PrimitiveTypeUtil.determineValueType(listValueType, prop.getCtx(), readerClassSource),
                 "propertyRegex", encodeRegex(extractRegex(property.getName())),
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getCollection())).getName()
         ));
@@ -156,11 +158,11 @@ public class ReadRegexPropertyBlock extends CodeBlock {
         readerClassSource.addImport(Map.class);
         readerClassSource.addImport(LinkedHashMap.class);
 
-        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        Type mapValueType = ((MapType) property.getResolvedType()).getValueType();
         body.addContext(Map.of(
-                "expectedType", PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx()),
-                "toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource),
-                "elementValueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource),
+                "expectedType", PrimitiveTypeUtil.determineExpectedTypeString(mapValueType, prop.getCtx()),
+                "toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource),
+                "elementValueType", PrimitiveTypeUtil.determineValueType(mapValueType, prop.getCtx(), readerClassSource),
                 "propertyRegex", encodeRegex(extractRegex(property.getName())),
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getCollection())).getName()
         ));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
@@ -11,12 +11,14 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.FactoryMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.ReaderMethod;
 
@@ -92,8 +94,8 @@ public class ReadStarPropertyBlock extends CodeBlock {
         readerClassSource.addImport(List.class);
         readerClassSource.addImport(JsonNode.class);
 
-        body.addContext("isCheckMethod", PrimitiveTypeHelper.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
-        body.addContext("toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+        body.addContext("isCheckMethod", PrimitiveTypeUtil.determineIsCheckMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
+        body.addContext("toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(property.getResolvedType(), prop.getCtx(), readerClassSource));
 
         body.appendBlock("""
 {
@@ -115,11 +117,11 @@ public class ReadStarPropertyBlock extends CodeBlock {
         readerClassSource.addImport(ArrayList.class);
         readerClassSource.addImport(JsonNode.class);
 
-        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        Type listValueType = ((ListType) property.getResolvedType()).getValueType();
         body.addContext(Map.of(
-                "expectedType", PrimitiveTypeHelper.determineExpectedTypeString(listValueType, prop.getCtx()),
-                "toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource),
-                "elementValueType", PrimitiveTypeHelper.determineValueType(listValueType, prop.getCtx(), readerClassSource)
+                "expectedType", PrimitiveTypeUtil.determineExpectedTypeString(listValueType, prop.getCtx()),
+                "toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(listValueType, prop.getCtx(), readerClassSource),
+                "elementValueType", PrimitiveTypeUtil.determineValueType(listValueType, prop.getCtx(), readerClassSource)
         ));
 
         body.appendBlock("""
@@ -148,11 +150,11 @@ public class ReadStarPropertyBlock extends CodeBlock {
         readerClassSource.addImport(Map.class);
         readerClassSource.addImport(LinkedHashMap.class);
 
-        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        Type mapValueType = ((MapType) property.getResolvedType()).getValueType();
         body.addContext(Map.of(
-                "expectedType", PrimitiveTypeHelper.determineExpectedTypeString(mapValueType, prop.getCtx()),
-                "toConversionMethod", PrimitiveTypeHelper.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource),
-                "elementValueType", PrimitiveTypeHelper.determineValueType(mapValueType, prop.getCtx(), readerClassSource)
+                "expectedType", PrimitiveTypeUtil.determineExpectedTypeString(mapValueType, prop.getCtx()),
+                "toConversionMethod", PrimitiveTypeUtil.determineToConversionMethod(mapValueType, prop.getCtx(), readerClassSource),
+                "elementValueType", PrimitiveTypeUtil.determineValueType(mapValueType, prop.getCtx(), readerClassSource)
         ));
 
         body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -10,6 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
@@ -32,8 +33,8 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        io.apitomy.umg.models.concept.type.ListType listType =
-                (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+        ListType listType =
+                (ListType) property.getResolvedType();
         var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
         String readMethodName = new ReaderMethod(valueJt.getSimpleName()).getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -10,6 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.pipe.java.method.AddMethod;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
@@ -32,8 +33,8 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        io.apitomy.umg.models.concept.type.MapType mapType =
-                (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+        MapType mapType =
+                (MapType) property.getResolvedType();
         var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
         String readMethodName = new ReaderMethod(valueJt.getSimpleName()).getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -10,6 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
@@ -35,7 +36,7 @@ public class WriteListPropertyBlock extends CodeBlock {
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", prop.getGetterName());
 
-        Type listValueType = ((io.apitomy.umg.models.concept.type.ListType) property.getResolvedType()).getValueType();
+        Type listValueType = ((ListType) property.getResolvedType()).getValueType();
         if (listValueType.isPrimitiveType()) {
             body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toArrayNode(node.${getterMethodName}()));");
         } else if (listValueType.isEntityType()) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -7,11 +7,12 @@ import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -34,7 +35,7 @@ public class WriteMapPropertyBlock extends CodeBlock {
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", prop.getGetterName());
 
-        Type mapValueType = ((io.apitomy.umg.models.concept.type.MapType) property.getResolvedType()).getValueType();
+        Type mapValueType = ((MapType) property.getResolvedType()).getValueType();
         if (mapValueType.isPrimitiveType()) {
             body.append("JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toObjectNode(node.${getterMethodName}()));");
         } else if (mapValueType.isEntityType()) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WritePrimitivePropertyBlock.java
@@ -6,7 +6,7 @@ import org.jboss.forge.roaster.model.source.JavaSource;
 import io.apitomy.umg.models.concept.PropertyModel;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 
 /**
@@ -28,7 +28,7 @@ public class WritePrimitivePropertyBlock extends CodeBlock {
         body.addContext("propertyName", property.getName());
         body.addContext("getterMethodName", prop.getGetterName());
 
-        body.ifElse(PrimitiveTypeHelper.isJsonNodeType(property.getResolvedType(), prop.getCtx()),
+        body.ifElse(PrimitiveTypeUtil.isJsonNodeType(property.getResolvedType(), prop.getCtx()),
                 // ObjectNode and JsonNode are already JsonNode subtypes, use setProperty directly
                 () -> "JsonUtil.setProperty(json, \"${propertyName}\", node.${getterMethodName}());",
                 () -> "JsonUtil.setProperty(json, \"${propertyName}\", JsonUtil.toJsonNode(node.${getterMethodName}()));");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteRegexPropertyBlock.java
@@ -13,7 +13,7 @@ import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
 import io.apitomy.umg.pipe.java.method.GetterMethod;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -91,7 +91,7 @@ public class WriteRegexPropertyBlock extends CodeBlock {
         writerClassSource.addImport(List.class);
         writerClassSource.addImport(Map.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
         body.addContext("getterMethodName", new GetterMethod(property).getName());
 
         body.appendBlock("""
@@ -113,7 +113,7 @@ public class WriteRegexPropertyBlock extends CodeBlock {
         writerClassSource.addImport(List.class);
         writerClassSource.addImport(Map.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
         body.addContext("getterMethodName", new GetterMethod(property).getName());
 
         body.appendBlock("""
@@ -135,7 +135,7 @@ public class WriteRegexPropertyBlock extends CodeBlock {
         writerClassSource.addImport(List.class);
         writerClassSource.addImport(Map.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
         body.addContext("getterMethodName", new GetterMethod(property).getName());
 
         body.appendBlock("""

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteStarPropertyBlock.java
@@ -11,7 +11,7 @@ import io.apitomy.umg.models.concept.type.Type;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.EntityResolver;
-import io.apitomy.umg.pipe.java.method.PrimitiveTypeHelper;
+import io.apitomy.umg.pipe.java.method.PrimitiveTypeUtil;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
 import io.apitomy.umg.pipe.java.method.WriterMethod;
 
@@ -78,7 +78,7 @@ public class WriteStarPropertyBlock extends CodeBlock {
     private void appendPrimitive(BodyBuilder body, PropertyModel property) {
         writerClassSource.addImport(List.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
 
         body.appendBlock("""
 {
@@ -95,7 +95,7 @@ public class WriteStarPropertyBlock extends CodeBlock {
     private void appendPrimitiveList(BodyBuilder body, PropertyModel property) {
         writerClassSource.addImport(List.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
 
         body.appendBlock("""
 {
@@ -113,7 +113,7 @@ public class WriteStarPropertyBlock extends CodeBlock {
         writerClassSource.addImport(List.class);
         writerClassSource.addImport(Map.class);
 
-        body.addContext("valueType", PrimitiveTypeHelper.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
+        body.addContext("valueType", PrimitiveTypeUtil.determineValueType(property.getResolvedType(), prop.getCtx(), writerClassSource));
 
         body.appendBlock("""
 {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -10,6 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.ListType;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
@@ -31,8 +32,8 @@ public class WriteUnionListPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        io.apitomy.umg.models.concept.type.ListType listType =
-                (io.apitomy.umg.models.concept.type.ListType) property.getResolvedType();
+        ListType listType =
+                (ListType) property.getResolvedType();
         var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(listType.getValueType(), nsModel);
         String writeMethodName = new WriterMethod(valueJt.getSimpleName()).getName();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -10,6 +10,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.type.MapType;
 import io.apitomy.umg.pipe.java.method.BodyBuilder;
 import io.apitomy.umg.pipe.java.method.CodeBlock;
 import io.apitomy.umg.pipe.java.method.PropertyCodeGen;
@@ -31,8 +32,8 @@ public class WriteUnionMapPropertyBlock extends CodeBlock {
     @Override
     public void appendTo(BodyBuilder body) {
         PropertyModel property = prop.getProperty();
-        io.apitomy.umg.models.concept.type.MapType mapType =
-                (io.apitomy.umg.models.concept.type.MapType) property.getResolvedType();
+        MapType mapType =
+                (MapType) property.getResolvedType();
         var nsModel = prop.getPropertyWithOrigin().getOrigin().getNamespace();
         var valueJt = prop.getCtx().getJavaTypeFactory().createJavaType(mapType.getValueType(), nsModel);
         String writeMethodName = new WriterMethod(valueJt.getSimpleName()).getName();


### PR DESCRIPTION
## Summary

### Util consolidation
- Renamed `PrimitiveTypeHelper` → `PrimitiveTypeUtil`
- Moved `getTypeName`/`getUnionTypeName` from `AbstractJavaStage` → new `TypeNameUtil`
- Removed unused methods from `AbstractJavaStage`: `getUnionValueInterfaceFQN`, `getMappedNodeInterfaceFQN`, `hasNamedMethod`, `primitiveTypeToClass`
- Removed unused `singularize()` from `AbstractStage`
- Replaced all FQN type casts with proper imports (20+ files)
- Cleaned up empty `@param` javadoc tags (14 files)

### Dispatch unification
- Added `isUnionListType()`/`isUnionMapType()` to `Type` interface
- Simplified `AbstractStage` predicates to delegate to Type methods
- Centralized `AbstractIOStage` dispatch via `PropertyBlockKind.fromResolvedType()`
- Replaced `resolvedTypeIs` in `AbstractCreateMethodsStage` with inherited predicates

## Context

C34 polish in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output unchanged