### PR TITLE
feat(generator): CLAUDE.md style guide + forEach→for in generated code (C35)

### DIFF
--- a/generator/CLAUDE.md
+++ b/generator/CLAUDE.md
@@ -1,0 +1,109 @@
+# Generator (UMG) Style Guide
+
+## Architecture
+
+The Unified Model Generator (UMG) reads YAML spec files and generates Java model classes,
+which are then transpiled to TypeScript via JSweet.
+
+### Pipeline structure
+
+- **Stages** (`pipe/java/`) — thin orchestrators that iterate spec versions, entities,
+  and properties. Delegate code generation to method classes and code blocks.
+- **Method classes** (`pipe/java/method/`) — implement `Method` interface. Each generated
+  method (getter, setter, reader, writer, cloner, etc.) is its own class with `getName()`
+  and `writeTo(JavaSource<?>)`.
+- **Code blocks** (`pipe/java/method/reader/`, `writer/`, `cloner/`) — extend `CodeBlock`.
+  Handle property-level code generation for a specific property type (entity, primitive,
+  list, map, union, star, regex).
+- **`CodeGenContext`** — concrete class owning entity resolution, FQN construction, naming,
+  and field logic. Constructed from indexes/config, passed to method classes and code blocks.
+- **`PropertyCodeGen`** — wrapper bundling `PropertyModelWithOrigin` + `EntityModel` +
+  `CodeGenContext`. Code blocks take `(PropertyCodeGen, JavaClassSource)` instead of
+  3-4 separate params.
+
+### Key base classes
+
+- `AbstractStage` — type predicates (`isEntity`, `isPrimitive`, etc.), logging
+- `AbstractJavaStage` — FQN construction, entity lookup, naming conventions
+- `AbstractIOStage` — shared orchestration for reader/writer/cloner (template method pattern)
+- `AbstractCreateMethodsStage` — shared property method dispatch for interface/impl stages
+
+## BodyBuilder conventions
+
+`BodyBuilder` generates method bodies with `${var}` template substitution.
+
+- Use `appendBlock("""...""")` for 4+ line templates. Individual `append()` for short snippets.
+- Use `Map.of()` with `addContext(Map)` for 3+ context variables.
+  Individual `addContext(name, value)` for 1-2 variables.
+- Use `ifElse`/`ifTrue` for conditional code generation.
+- Use `forEach` with `LoopContext` + `isFirst` for if/else-if chains.
+- Text block content is flush-left (not indented to match surrounding Java source).
+- Use `${var}` inline in templates. Don't create intermediate variables like `quotedName`
+  just to add quotes — put them directly in the template: `"${name}"`.
+
+## Method classes
+
+- Every generated method gets a class implementing `Method`.
+- `getName()` returns the method name, `writeTo(JavaSource<?>)` generates signature + body + imports.
+- Use naming-only constructors for name lookups, full constructors for generation.
+- No static `methodName()` helpers — use `new MethodClass(args).getName()`.
+
+## Type system
+
+- `resolvedType` is always non-null. No defensive null guards needed.
+- Use inherited `AbstractStage` predicates (`isEntity(property)`, `isUnionList(property)`)
+  or `Type` interface methods (`type.isEntityType()`, `type.isUnionListType()`) directly.
+- Use `PropertyBlockKind.fromResolvedType()` for dispatch in IO stages.
+
+## JSweet / TypeScript compatibility
+
+Generated base classes (`generator/src/main/resources/base/`) are transpiled by JSweet.
+These restrictions apply to base classes AND generated code:
+
+- **No `var`** — use explicit types.
+- **No `instanceof` pattern matching** — use separate cast after check.
+- **No text blocks** — use string concatenation.
+- **No `json.remove()`** — use `JsonUtil.removeProperty(json, name)`.
+- **No `(ObjectNode) value` casts** — use `JsonUtil.toObject(value)`.
+- **Use external iteration** (`for` loops) instead of internal iteration (`.forEach()`,
+  `.stream()`) in generated code. JSweet transpilation handles `for` loops reliably.
+- JSweet mangles overloaded method names: `toJsonNode(Object)` becomes
+  `toJsonNode$java_lang_Object` in TypeScript.
+
+### JsonUtil synchronization
+
+**Java and TypeScript JsonUtil must stay in sync.** When modifying
+`generator/src/main/resources/base/.../JsonUtil.java`, always update
+`data-models/src/main/ts/src/.../JsonUtil.ts` to match, including
+JSweet mangled name aliases.
+
+Patterns:
+- Reader: `getProperty` + type check + `removeProperty`
+- Writer: `setProperty` + `toJsonNode`/`toArrayNode`/`toObjectNode`
+- Defensive validation: `allMatch`/`allValuesMatch`
+
+## Generated code style
+
+- Fields are prefixed with underscore: `_name`, `_items`.
+- No unnecessary casts (e.g., don't cast when the return type already matches).
+- Use `traverseUnion` (not `traverseNode`) for union properties in traversers.
+- Union variant ordering via `UnionVariantComparator` (entities first, then collections,
+  then primitives).
+
+## Java source style
+
+- Use imports, not fully-qualified class names in casts.
+  `(EntityType) type` not `(io.apitomy.umg.models.concept.type.EntityType) type`.
+- Utility classes end in `*Util` (e.g., `PrimitiveTypeUtil`, `TypeNameUtil`),
+  unless there's a standard naming expectation (e.g., `Logger` not `LoggerUtil`).
+- No empty `@param` tags in javadoc — remove them or add a description.
+
+## Testing
+
+All 1129+ data-models tests must pass after any generator change:
+```
+JAVA_HOME=/usr/lib/jvm/temurin-21-jdk mvn test -pl data-models -am
+```
+
+Synthetic snapshot tests compare generated output byte-for-byte. If generated output
+changes intentionally, delete `expected/` and regenerate.

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonersStage.java
@@ -91,12 +91,13 @@ public class CreateClonersStage extends AbstractIOStage {
 {
     List<String> extraPropertyNames = source.getExtraPropertyNames();
     if (extraPropertyNames != null) {
-        extraPropertyNames.forEach(name -> {
+        for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+            String name = extraPropertyNames.get(_idx);
             JsonNode value = source.getExtraProperty(name);
             if (value != null) {
                 target.addExtraProperty(name, JsonUtil.clone(value));
             }
-        });
+        }
     }
 }
 """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
@@ -52,15 +52,19 @@ public class ClearMethod implements Method {
             BodyBuilder body = new BodyBuilder();
             body.addContext("fieldName", fieldName);
 
+            if (needsDetach) {
+                ((JavaClassSource) target).addImport(ctx.getNodeInterfaceFQN());
+            }
+
             body.ifElse(needsDetach, () -> {
                 String valuesExpr = resolvedType.isMapType()
                         ? "this." + fieldName + ".values()" : "this." + fieldName;
                 body.addContext("valuesExpr", valuesExpr);
                 return """
 if (this.${fieldName} != null) {
-    ${valuesExpr}.forEach(item -> {
-        if (item != null) item.detach();
-    });
+    for (Object item : ${valuesExpr}) {
+        if (item != null) ((Node) item).detach();
+    }
     this.${fieldName}.clear();
 }
 """;

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -85,6 +85,10 @@ public class CodeGenContext {
         return rootNamespace + ".NodeImpl";
     }
 
+    public String getNodeInterfaceFQN() {
+        return rootNamespace + ".Node";
+    }
+
     public String getDataModelUtilFQCN() {
         return rootNamespace + ".util.DataModelUtil";
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
@@ -178,9 +178,9 @@ if (item != null) {
         method.setReturnTypeVoid();
         BodyBuilder body = new BodyBuilder();
         if (entityProperty) {
-            body.append("this._items.values().forEach(item -> {");
-            body.append("    if (item != null) item.detach();");
-            body.append("});");
+            body.append("for (Object item : this._items.values()) {");
+            body.append("    if (item != null) ((Node) item).detach();");
+            body.append("}");
         }
         body.append("this._items.clear();");
         method.setBody(body.toString());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -198,12 +198,12 @@ public class ReaderMethod implements Method {
                 body.append("if (JsonUtil.isArray(json)) {");
                 body.append("    List<JsonNode> array = JsonUtil.toList(json);");
                 body.append("    List<${listValueType}> models = new ArrayList<>();");
-                body.append("    array.forEach(item -> {");
-                body.append("        ObjectNode object = JsonUtil.toObject(item);");
+                body.append("    for (int _idx = 0; _idx < array.size(); _idx++) {");
+                body.append("        ObjectNode object = JsonUtil.toObject(array.get(_idx));");
                 body.append("        ${listValueType} model = new ${listValueType}Impl();");
                 body.append("        this.${readMethodName}(object, model);");
                 body.append("        models.add(model);");
-                body.append("    });");
+                body.append("    }");
                 body.append("    @SuppressWarnings({ \"unchecked\", \"rawtypes\" })");
                 body.append("    ${unionValueClass} unionValue = new ${unionValueClass}((List) models);");
                 body.append("    return unionValue;");
@@ -235,9 +235,9 @@ public class ReaderMethod implements Method {
                 body.append("if (JsonUtil.isArray(json)) {");
                 body.append("    List<JsonNode> array = JsonUtil.toList(json);");
                 body.append("    List<${primType}> items = new ArrayList<>();");
-                body.append("    array.forEach(item -> {");
-                body.append("        items.add(JsonUtil.${toMethod}(item));");
-                body.append("    });");
+                body.append("    for (int _idx = 0; _idx < array.size(); _idx++) {");
+                body.append("        items.add(JsonUtil.${toMethod}(array.get(_idx)));");
+                body.append("    }");
                 body.append("    return new ${unionValueClass}(items);");
                 body.append("}");
             }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneListPropertyBlock.java
@@ -78,11 +78,12 @@ public class CloneListPropertyBlock extends CodeBlock {
                     {
                         List<? extends ${commonEntityType}> srcList = source.${getterMethodName}();
                         if (srcList != null && !srcList.isEmpty()) {
-                            srcList.forEach(srcItem -> {
+                            for (int _idx = 0; _idx < srcList.size(); _idx++) {
+                                ${entityJavaType} srcItem = (${entityJavaType}) srcList.get(_idx);
                                 ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
-                                this.${cloneMethodName}((${entityJavaType}) srcItem, tgtItem);
+                                this.${cloneMethodName}(srcItem, tgtItem);
                                 target.${addMethodName}(tgtItem);
-                            });
+                            }
                         }
                     }
                     """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneMapPropertyBlock.java
@@ -79,11 +79,11 @@ public class CloneMapPropertyBlock extends CodeBlock {
                     {
                         Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();
                         if (srcMap != null && !srcMap.isEmpty()) {
-                            srcMap.keySet().forEach(name -> {
+                            for (String name : srcMap.keySet()) {
                                 ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
                                 this.${cloneMethodName}((${entityJavaType}) srcMap.get(name), tgtItem);
                                 target.${addMethodName}(name, tgtItem);
-                            });
+                            }
                         }
                     }
                     """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneRegexPropertyBlock.java
@@ -73,12 +73,12 @@ public class CloneRegexPropertyBlock extends CodeBlock {
 {
     Map<String, ? extends ${commonEntityType}> srcMap = source.${getterMethodName}();
     if (srcMap != null && !srcMap.isEmpty()) {
-        srcMap.keySet().forEach(name -> {
+        for (String name : srcMap.keySet()) {
             ${entityJavaType} srcItem = (${entityJavaType}) srcMap.get(name);
             ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
             this.${cloneMethodName}(srcItem, tgtItem);
             target.${addMethodName}(name, tgtItem);
-        });
+        }
     }
 }
 """);
@@ -99,9 +99,10 @@ public class CloneRegexPropertyBlock extends CodeBlock {
     Map<String, ${valueType}> srcMap = source.${getterMethodName}();
     if (srcMap != null && !srcMap.isEmpty()) {
         List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-        keys.forEach(name -> {
+        for (int _idx = 0; _idx < keys.size(); _idx++) {
+            String name = keys.get(_idx);
             target.${addMethodName}(name, srcMap.get(name));
-        });
+        }
     }
 }
 """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneStarPropertyBlock.java
@@ -63,14 +63,15 @@ public class CloneStarPropertyBlock extends CodeBlock {
 {
     List<String> itemNames = source.getItemNames();
     if (itemNames != null) {
-        itemNames.forEach(name -> {
+        for (int _idx = 0; _idx < itemNames.size(); _idx++) {
+            String name = itemNames.get(_idx);
             ${entityJavaType} srcItem = (${entityJavaType}) source.getItem(name);
             if (srcItem != null) {
                 ${entityJavaType} tgtItem = (${entityJavaType}) target.${createMethodName}();
                 this.${cloneMethodName}(srcItem, tgtItem);
                 target.addItem(name, tgtItem);
             }
-        });
+        }
     }
 }
 """);
@@ -83,9 +84,10 @@ public class CloneStarPropertyBlock extends CodeBlock {
 {
     List<String> itemNames = source.getItemNames();
     if (itemNames != null) {
-        itemNames.forEach(name -> {
+        for (int _idx = 0; _idx < itemNames.size(); _idx++) {
+            String name = itemNames.get(_idx);
             target.addItem(name, source.getItem(name));
-        });
+        }
     }
 }
 """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionListPropertyBlock.java
@@ -55,7 +55,8 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
 {
     List<${unionJavaType}> srcList = source.${getterMethodName}();
     if (srcList != null && !srcList.isEmpty()) {
-        srcList.forEach(srcUnion -> {
+        for (int _idx = 0; _idx < srcList.size(); _idx++) {
+            ${unionJavaType} srcUnion = srcList.get(_idx);
 """);
 
         effectiveUnionType.getTypes().stream()
@@ -106,7 +107,7 @@ public class CloneUnionListPropertyBlock extends CodeBlock {
             body.append("            }");
         });
 
-        body.append("        });");
+        body.append("        }");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionMapPropertyBlock.java
@@ -55,7 +55,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
 {
     Map<String, ${unionJavaType}> srcMap = source.${getterMethodName}();
     if (srcMap != null && !srcMap.isEmpty()) {
-        srcMap.keySet().forEach(key -> {
+        for (String key : srcMap.keySet()) {
             ${unionJavaType} srcUnion = srcMap.get(key);
 """);
 
@@ -116,7 +116,7 @@ public class CloneUnionMapPropertyBlock extends CodeBlock {
             body.append("            }");
         });
 
-        body.append("        });");
+        body.append("        }");
         body.append("    }");
         body.append("}");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/cloner/CloneUnionPropertyBlock.java
@@ -156,11 +156,12 @@ public class CloneUnionPropertyBlock extends CodeBlock {
                             return """
         if (srcUnion.${isMethodName}()) {
             List<${listItemType}> clonedList = new ArrayList<>();
-            srcUnion.${asMethodName}().forEach(srcItem -> {
+            for (int _idx = 0; _idx < srcUnion.${asMethodName}().size(); _idx++) {
+                ${listItemType} srcItem = (${listItemType}) srcUnion.${asMethodName}().get(_idx);
                 ${listItemType} tgtItem = (${listItemType}) target.${createMethodName}();
-                this.${cloneMethodName}((${listItemType}) srcItem, tgtItem);
+                this.${cloneMethodName}(srcItem, tgtItem);
                 clonedList.add(tgtItem);
-            });
+            }
             @SuppressWarnings({ "unchecked", "rawtypes" })
             ${unionValueClassName} unionValue = new ${unionValueClassName}((List) clonedList);
             target.${setterMethodName}(unionValue);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteListPropertyBlock.java
@@ -64,11 +64,12 @@ public class WriteListPropertyBlock extends CodeBlock {
                         List<? extends ${listValueCommonJavaType}> models = node.${getterMethodName}();
                         if (models != null && !models.isEmpty()) {
                             ArrayNode array = JsonUtil.arrayNode();
-                            models.forEach(model -> {
+                            for (int _idx = 0; _idx < models.size(); _idx++) {
+                                ${listValueCommonJavaType} model = models.get(_idx);
                                 ObjectNode object = JsonUtil.objectNode();
                                 this.${writeMethodName}((${listValueJavaType}) model, object);
                                 JsonUtil.addToArray(array, object);
-                            });
+                            }
                             JsonUtil.setProperty(json, "${propertyName}", array);
                         }
                     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteMapPropertyBlock.java
@@ -63,11 +63,11 @@ public class WriteMapPropertyBlock extends CodeBlock {
                         Map<String, ? extends ${mapValueCommonJavaType}> models = node.${getterMethodName}();
                         if (models != null && !models.isEmpty()) {
                             ObjectNode object = JsonUtil.objectNode();
-                            models.keySet().forEach(jsonName -> {
+                            for (String jsonName : models.keySet()) {
                                 ObjectNode jsonValue = JsonUtil.objectNode();
                                 this.${writeMethodName}((${mapValueJavaType}) models.get(jsonName), jsonValue);
                                 JsonUtil.setProperty(object, jsonName, jsonValue);
-                            });
+                            }
                             JsonUtil.setProperty(json, "${propertyName}", object);
                         }
                     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionListPropertyBlock.java
@@ -55,10 +55,11 @@ public class WriteUnionListPropertyBlock extends CodeBlock {
                     List<${unionJavaType}> items = node.${getterMethodName}();
                     if (items != null && !items.isEmpty()) {
                         ArrayNode array = JsonUtil.arrayNode();
-                        items.forEach(item -> {
+                        for (int _idx = 0; _idx < items.size(); _idx++) {
+                            ${unionJavaType} item = items.get(_idx);
                             JsonNode value = this.${writeMethodName}(item);
                             if (value != null) array.add(value);
-                        });
+                        }
                         JsonUtil.setProperty(json, "${propertyName}", array);
                     }
                 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/writer/WriteUnionMapPropertyBlock.java
@@ -58,10 +58,10 @@ public class WriteUnionMapPropertyBlock extends CodeBlock {
                     if (items != null && !items.isEmpty()) {
                         ObjectNode mapJson = JsonUtil.objectNode();
                         Collection<String> keys = items.keySet();
-                        keys.forEach(key -> {
+                        for (String key : keys) {
                             JsonNode value = this.${writeMethodName}(items.get(key));
                             if (value != null) JsonUtil.setProperty(mapJson, key, value);
-                        });
+                        }
                         JsonUtil.setProperty(json, "${propertyName}", mapJson);
                     }
                 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/WriterUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/WriterUtil.java
@@ -9,10 +9,12 @@ public class WriterUtil {
 
     public static final void writeExtraProperties(Node node, ObjectNode json) {
         if (node.hasExtraProperties()) {
-            node.getExtraPropertyNames().forEach(name -> {
+            java.util.List<String> extraPropertyNames = node.getExtraPropertyNames();
+            for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+                String name = extraPropertyNames.get(_idx);
                 JsonNode value = node.getExtraProperty(name);
                 JsonUtil.setProperty(json, name, value);
-            });
+            }
         }
     }
     

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/AbstractTraverser.java
@@ -90,14 +90,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
         if (items != null) {
             traversalContext.pushProperty(propertyName);
             List<String> keys = JsonUtil.collectionToList(items.keySet());
-            keys.forEach(key -> {
+            for (int _idx = 0; _idx < keys.size(); _idx++) {
+                String key = keys.get(_idx);
                 Any value = items.get(key);
                 if (value != null && value.isNode()) {
                     this.traversalContext.pushMapIndex(key);
                     this.doTraverseNode((Node) value);
                     this.traversalContext.pop();
                 }
-            });
+            }
             this.traversalContext.pop();
         }
     }
@@ -110,14 +111,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
     protected void traverseMappedNode(MappedNode<? extends Node> mappedNode) {
         if (mappedNode != null) {
             List<String> names = JsonUtil.collectionToList(mappedNode.getItemNames());
-            names.forEach(name -> {
+            for (int _idx = 0; _idx < names.size(); _idx++) {
+                String name = names.get(_idx);
                 Node value = mappedNode.getItem(name);
                 if (value != null) {
                     this.traversalContext.pushMapIndex(name);
                     this.doTraverseNode(value);
                     this.traversalContext.pop();
                 }
-            });
+            }
         }
     }
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/WriterUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/WriterUtil.java
@@ -8,10 +8,12 @@ public class WriterUtil {
 
 	public static final void writeExtraProperties(Node node, ObjectNode json) {
 		if (node.hasExtraProperties()) {
-			node.getExtraPropertyNames().forEach(name -> {
+			java.util.List<String> extraPropertyNames = node.getExtraPropertyNames();
+			for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+				String name = extraPropertyNames.get(_idx);
 				JsonNode value = node.getExtraProperty(name);
 				JsonUtil.setProperty(json, name, value);
-			});
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -88,10 +88,10 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
-			this.items.forEach(item -> {
+			for (Object item : this.items) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.items.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -79,10 +79,10 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
-			this.parameters.forEach(item -> {
+			for (Object item : this.parameters) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.parameters.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -69,10 +69,10 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 
 	@Override
 	public void clearItems() {
-		this._items.values().forEach(item -> {
+		for (Object item : this._items.values()) {
 			if (item != null)
-				item.detach();
-		});
+				((Node) item).detach();
+		}
 		this._items.clear();
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -144,10 +144,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
-			this.properties.values().forEach(item -> {
+			for (Object item : this.properties.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.properties.clear();
 		}
 	}
@@ -209,10 +209,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
-			this.allOf.forEach(item -> {
+			for (Object item : this.allOf) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.allOf.clear();
 		}
 	}
@@ -276,10 +276,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
-			this.definitions.values().forEach(item -> {
+			for (Object item : this.definitions.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.definitions.clear();
 		}
 	}
@@ -343,10 +343,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
-			this.nestedSchemas.values().forEach(item -> {
+			for (Object item : this.nestedSchemas.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.nestedSchemas.clear();
 		}
 	}
@@ -408,10 +408,10 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
-			this.composedSchemas.forEach(item -> {
+			for (Object item : this.composedSchemas) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.composedSchemas.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelCloner.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelCloner.java
@@ -37,11 +37,12 @@ public class Syn1ModelCloner {
 		{
 			List<? extends SynItem> srcList = source.getItems();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcItem -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					Syn1Item srcItem = (Syn1Item) srcList.get(_idx);
 					Syn1Item tgtItem = (Syn1Item) target.createItem();
-					this.cloneItem((Syn1Item) srcItem, tgtItem);
+					this.cloneItem(srcItem, tgtItem);
 					target.addItem(tgtItem);
-				});
+				}
 			}
 		}
 		{
@@ -73,20 +74,22 @@ public class Syn1ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -104,20 +107,22 @@ public class Syn1ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -129,12 +134,13 @@ public class Syn1ModelCloner {
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -177,20 +183,22 @@ public class Syn1ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -208,11 +216,12 @@ public class Syn1ModelCloner {
 				}
 				if (srcUnion.isSchemaList()) {
 					List<Syn1Schema> clonedList = new ArrayList<>();
-					srcUnion.asSchemaList().forEach(srcItem -> {
+					for (int _idx = 0; _idx < srcUnion.asSchemaList().size(); _idx++) {
+						Syn1Schema srcItem = (Syn1Schema) srcUnion.asSchemaList().get(_idx);
 						Syn1Schema tgtItem = (Syn1Schema) target.createSchema();
-						this.cloneSchema((Syn1Schema) srcItem, tgtItem);
+						this.cloneSchema(srcItem, tgtItem);
 						clonedList.add(tgtItem);
-					});
+					}
 					@SuppressWarnings({"unchecked", "rawtypes"})
 					SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) clonedList);
 					target.setItems(unionValue);
@@ -225,7 +234,7 @@ public class Syn1ModelCloner {
 		{
 			Map<String, BooleanSchemaUnion> srcMap = source.getProperties();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					BooleanSchemaUnion srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn1Schema tgtItem = new Syn1SchemaImpl();
@@ -235,13 +244,14 @@ public class Syn1ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addProperty(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			List<BooleanSchemaUnion> srcList = source.getAllOf();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcUnion -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					BooleanSchemaUnion srcUnion = srcList.get(_idx);
 					if (srcUnion.isSchema()) {
 						Syn1Schema tgtItem = new Syn1SchemaImpl();
 						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
@@ -250,13 +260,13 @@ public class Syn1ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addAllOf(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, BooleanSchemaUnion> srcMap = source.getDefinitions();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					BooleanSchemaUnion srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn1Schema tgtItem = new Syn1SchemaImpl();
@@ -266,13 +276,13 @@ public class Syn1ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addDefinition(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, SchemaOrBoolean> srcMap = source.getNestedSchemas();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					SchemaOrBoolean srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn1Schema tgtItem = new Syn1SchemaImpl();
@@ -282,13 +292,14 @@ public class Syn1ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addNestedSchema(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			List<SchemaOrBoolean> srcList = source.getComposedSchemas();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcUnion -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					SchemaOrBoolean srcUnion = srcList.get(_idx);
 					if (srcUnion.isSchema()) {
 						Syn1Schema tgtItem = new Syn1SchemaImpl();
 						this.cloneSchema((Syn1Schema) srcUnion.asSchema(), tgtItem);
@@ -297,7 +308,7 @@ public class Syn1ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addComposedSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		target.setMinLength(source.getMinLength());
@@ -312,20 +323,22 @@ public class Syn1ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -334,34 +347,37 @@ public class Syn1ModelCloner {
 		{
 			List<String> itemNames = source.getItemNames();
 			if (itemNames != null) {
-				itemNames.forEach(name -> {
+				for (int _idx = 0; _idx < itemNames.size(); _idx++) {
+					String name = itemNames.get(_idx);
 					Syn1PathItem srcItem = (Syn1PathItem) source.getItem(name);
 					if (srcItem != null) {
 						Syn1PathItem tgtItem = (Syn1PathItem) target.createPathItem();
 						this.clonePathItem(srcItem, tgtItem);
 						target.addItem(name, tgtItem);
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -391,20 +407,22 @@ public class Syn1ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -421,31 +439,34 @@ public class Syn1ModelCloner {
 		{
 			List<? extends SynItem> srcList = source.getParameters();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcItem -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					Syn1Item srcItem = (Syn1Item) srcList.get(_idx);
 					Syn1Item tgtItem = (Syn1Item) target.createItem();
-					this.cloneItem((Syn1Item) srcItem, tgtItem);
+					this.cloneItem(srcItem, tgtItem);
 					target.addParameter(tgtItem);
-				});
+				}
 			}
 		}
 		{
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -578,12 +578,12 @@ public class Syn1ModelReader implements ModelReader {
 		} else if (JsonUtil.isArray(json)) {
 			List<JsonNode> array = JsonUtil.toList(json);
 			List<Syn1Schema> models = new ArrayList<>();
-			array.forEach(item -> {
-				ObjectNode object = JsonUtil.toObject(item);
+			for (int _idx = 0; _idx < array.size(); _idx++) {
+				ObjectNode object = JsonUtil.toObject(array.get(_idx));
 				Syn1Schema model = new Syn1SchemaImpl();
 				this.readSchema(object, model);
 				models.add(model);
-			});
+			}
 			@SuppressWarnings({"unchecked", "rawtypes"})
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -41,11 +41,12 @@ public class Syn1ModelWriter implements ModelWriter {
 			List<? extends SynItem> models = node.getItems();
 			if (models != null && !models.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				models.forEach(model -> {
+				for (int _idx = 0; _idx < models.size(); _idx++) {
+					SynItem model = models.get(_idx);
 					ObjectNode object = JsonUtil.objectNode();
 					this.writeItem((Syn1Item) model, object);
 					JsonUtil.addToArray(array, object);
-				});
+				}
 				JsonUtil.setProperty(json, "items", array);
 			}
 		}
@@ -162,11 +163,11 @@ public class Syn1ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "properties", mapJson);
 			}
 		}
@@ -174,11 +175,12 @@ public class Syn1ModelWriter implements ModelWriter {
 			List<BooleanSchemaUnion> items = node.getAllOf();
 			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				items.forEach(item -> {
+				for (int _idx = 0; _idx < items.size(); _idx++) {
+					BooleanSchemaUnion item = items.get(_idx);
 					JsonNode value = this.writeBooleanSchemaUnion(item);
 					if (value != null)
 						array.add(value);
-				});
+				}
 				JsonUtil.setProperty(json, "allOf", array);
 			}
 		}
@@ -187,11 +189,11 @@ public class Syn1ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "definitions", mapJson);
 			}
 		}
@@ -200,11 +202,11 @@ public class Syn1ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "nestedSchemas", mapJson);
 			}
 		}
@@ -212,11 +214,12 @@ public class Syn1ModelWriter implements ModelWriter {
 			List<SchemaOrBoolean> items = node.getComposedSchemas();
 			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				items.forEach(item -> {
+				for (int _idx = 0; _idx < items.size(); _idx++) {
+					SchemaOrBoolean item = items.get(_idx);
 					JsonNode value = this.writeSchemaOrBoolean(item);
 					if (value != null)
 						array.add(value);
-				});
+				}
 				JsonUtil.setProperty(json, "composedSchemas", array);
 			}
 		}
@@ -316,11 +319,12 @@ public class Syn1ModelWriter implements ModelWriter {
 			List<? extends SynItem> models = node.getParameters();
 			if (models != null && !models.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				models.forEach(model -> {
+				for (int _idx = 0; _idx < models.size(); _idx++) {
+					SynItem model = models.get(_idx);
 					ObjectNode object = JsonUtil.objectNode();
 					this.writeItem((Syn1Item) model, object);
 					JsonUtil.addToArray(array, object);
-				});
+				}
 				JsonUtil.setProperty(json, "parameters", array);
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -89,10 +89,10 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
-			this.items.forEach(item -> {
+			for (Object item : this.items) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.items.clear();
 		}
 	}
@@ -170,10 +170,10 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void clearWebhooks() {
 		if (this.webhooks != null) {
-			this.webhooks.values().forEach(item -> {
+			for (Object item : this.webhooks.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.webhooks.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -79,10 +79,10 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
-			this.parameters.forEach(item -> {
+			for (Object item : this.parameters) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.parameters.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -69,10 +69,10 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 
 	@Override
 	public void clearItems() {
-		this._items.values().forEach(item -> {
+		for (Object item : this._items.values()) {
 			if (item != null)
-				item.detach();
-		});
+				((Node) item).detach();
+		}
 		this._items.clear();
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -144,10 +144,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
-			this.properties.values().forEach(item -> {
+			for (Object item : this.properties.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.properties.clear();
 		}
 	}
@@ -209,10 +209,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
-			this.allOf.forEach(item -> {
+			for (Object item : this.allOf) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.allOf.clear();
 		}
 	}
@@ -276,10 +276,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
-			this.definitions.values().forEach(item -> {
+			for (Object item : this.definitions.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.definitions.clear();
 		}
 	}
@@ -343,10 +343,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
-			this.nestedSchemas.values().forEach(item -> {
+			for (Object item : this.nestedSchemas.values()) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.nestedSchemas.clear();
 		}
 	}
@@ -408,10 +408,10 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
-			this.composedSchemas.forEach(item -> {
+			for (Object item : this.composedSchemas) {
 				if (item != null)
-					item.detach();
-			});
+					((Node) item).detach();
+			}
 			this.composedSchemas.clear();
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelCloner.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelCloner.java
@@ -38,11 +38,12 @@ public class Syn2ModelCloner {
 		{
 			List<? extends SynItem> srcList = source.getItems();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcItem -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					Syn2Item srcItem = (Syn2Item) srcList.get(_idx);
 					Syn2Item tgtItem = (Syn2Item) target.createItem();
-					this.cloneItem((Syn2Item) srcItem, tgtItem);
+					this.cloneItem(srcItem, tgtItem);
 					target.addItem(tgtItem);
-				});
+				}
 			}
 		}
 		{
@@ -60,11 +61,11 @@ public class Syn2ModelCloner {
 		{
 			Map<String, ? extends SynPathItem> srcMap = source.getWebhooks();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(name -> {
+				for (String name : srcMap.keySet()) {
 					Syn2PathItem tgtItem = (Syn2PathItem) target.createPathItem();
 					this.clonePathItem((Syn2PathItem) srcMap.get(name), tgtItem);
 					target.addWebhook(name, tgtItem);
-				});
+				}
 			}
 		}
 		{
@@ -84,20 +85,22 @@ public class Syn2ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -116,20 +119,22 @@ public class Syn2ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -141,12 +146,13 @@ public class Syn2ModelCloner {
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -190,20 +196,22 @@ public class Syn2ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -221,11 +229,12 @@ public class Syn2ModelCloner {
 				}
 				if (srcUnion.isSchemaList()) {
 					List<Syn2Schema> clonedList = new ArrayList<>();
-					srcUnion.asSchemaList().forEach(srcItem -> {
+					for (int _idx = 0; _idx < srcUnion.asSchemaList().size(); _idx++) {
+						Syn2Schema srcItem = (Syn2Schema) srcUnion.asSchemaList().get(_idx);
 						Syn2Schema tgtItem = (Syn2Schema) target.createSchema();
-						this.cloneSchema((Syn2Schema) srcItem, tgtItem);
+						this.cloneSchema(srcItem, tgtItem);
 						clonedList.add(tgtItem);
-					});
+					}
 					@SuppressWarnings({"unchecked", "rawtypes"})
 					SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) clonedList);
 					target.setItems(unionValue);
@@ -238,7 +247,7 @@ public class Syn2ModelCloner {
 		{
 			Map<String, BooleanSchemaUnion> srcMap = source.getProperties();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					BooleanSchemaUnion srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn2Schema tgtItem = new Syn2SchemaImpl();
@@ -248,13 +257,14 @@ public class Syn2ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addProperty(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			List<BooleanSchemaUnion> srcList = source.getAllOf();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcUnion -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					BooleanSchemaUnion srcUnion = srcList.get(_idx);
 					if (srcUnion.isSchema()) {
 						Syn2Schema tgtItem = new Syn2SchemaImpl();
 						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
@@ -263,13 +273,13 @@ public class Syn2ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addAllOf(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, BooleanSchemaUnion> srcMap = source.getDefinitions();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					BooleanSchemaUnion srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn2Schema tgtItem = new Syn2SchemaImpl();
@@ -279,13 +289,13 @@ public class Syn2ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addDefinition(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, SchemaOrBoolean> srcMap = source.getNestedSchemas();
 			if (srcMap != null && !srcMap.isEmpty()) {
-				srcMap.keySet().forEach(key -> {
+				for (String key : srcMap.keySet()) {
 					SchemaOrBoolean srcUnion = srcMap.get(key);
 					if (srcUnion.isSchema()) {
 						Syn2Schema tgtItem = new Syn2SchemaImpl();
@@ -295,13 +305,14 @@ public class Syn2ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addNestedSchema(key, new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		{
 			List<SchemaOrBoolean> srcList = source.getComposedSchemas();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcUnion -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					SchemaOrBoolean srcUnion = srcList.get(_idx);
 					if (srcUnion.isSchema()) {
 						Syn2Schema tgtItem = new Syn2SchemaImpl();
 						this.cloneSchema((Syn2Schema) srcUnion.asSchema(), tgtItem);
@@ -310,7 +321,7 @@ public class Syn2ModelCloner {
 					if (srcUnion.isBoolean()) {
 						target.addComposedSchema(new BooleanUnionValueImpl(srcUnion.asBoolean()));
 					}
-				});
+				}
 			}
 		}
 		target.setMinLength(source.getMinLength());
@@ -325,20 +336,22 @@ public class Syn2ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -347,34 +360,37 @@ public class Syn2ModelCloner {
 		{
 			List<String> itemNames = source.getItemNames();
 			if (itemNames != null) {
-				itemNames.forEach(name -> {
+				for (int _idx = 0; _idx < itemNames.size(); _idx++) {
+					String name = itemNames.get(_idx);
 					Syn2PathItem srcItem = (Syn2PathItem) source.getItem(name);
 					if (srcItem != null) {
 						Syn2PathItem tgtItem = (Syn2PathItem) target.createPathItem();
 						this.clonePathItem(srcItem, tgtItem);
 						target.addItem(name, tgtItem);
 					}
-				});
+				}
 			}
 		}
 		{
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -410,20 +426,22 @@ public class Syn2ModelCloner {
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}
@@ -440,31 +458,34 @@ public class Syn2ModelCloner {
 		{
 			List<? extends SynItem> srcList = source.getParameters();
 			if (srcList != null && !srcList.isEmpty()) {
-				srcList.forEach(srcItem -> {
+				for (int _idx = 0; _idx < srcList.size(); _idx++) {
+					Syn2Item srcItem = (Syn2Item) srcList.get(_idx);
 					Syn2Item tgtItem = (Syn2Item) target.createItem();
-					this.cloneItem((Syn2Item) srcItem, tgtItem);
+					this.cloneItem(srcItem, tgtItem);
 					target.addParameter(tgtItem);
-				});
+				}
 			}
 		}
 		{
 			Map<String, JsonNode> srcMap = source.getExtensions();
 			if (srcMap != null && !srcMap.isEmpty()) {
 				List<String> keys = new java.util.ArrayList<>(srcMap.keySet());
-				keys.forEach(name -> {
+				for (int _idx = 0; _idx < keys.size(); _idx++) {
+					String name = keys.get(_idx);
 					target.addExtension(name, srcMap.get(name));
-				});
+				}
 			}
 		}
 		{
 			List<String> extraPropertyNames = source.getExtraPropertyNames();
 			if (extraPropertyNames != null) {
-				extraPropertyNames.forEach(name -> {
+				for (int _idx = 0; _idx < extraPropertyNames.size(); _idx++) {
+					String name = extraPropertyNames.get(_idx);
 					JsonNode value = source.getExtraProperty(name);
 					if (value != null) {
 						target.addExtraProperty(name, JsonUtil.clone(value));
 					}
-				});
+				}
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -617,12 +617,12 @@ public class Syn2ModelReader implements ModelReader {
 		} else if (JsonUtil.isArray(json)) {
 			List<JsonNode> array = JsonUtil.toList(json);
 			List<Syn2Schema> models = new ArrayList<>();
-			array.forEach(item -> {
-				ObjectNode object = JsonUtil.toObject(item);
+			for (int _idx = 0; _idx < array.size(); _idx++) {
+				ObjectNode object = JsonUtil.toObject(array.get(_idx));
 				Syn2Schema model = new Syn2SchemaImpl();
 				this.readSchema(object, model);
 				models.add(model);
-			});
+			}
 			@SuppressWarnings({"unchecked", "rawtypes"})
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -42,11 +42,12 @@ public class Syn2ModelWriter implements ModelWriter {
 			List<? extends SynItem> models = node.getItems();
 			if (models != null && !models.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				models.forEach(model -> {
+				for (int _idx = 0; _idx < models.size(); _idx++) {
+					SynItem model = models.get(_idx);
 					ObjectNode object = JsonUtil.objectNode();
 					this.writeItem((Syn2Item) model, object);
 					JsonUtil.addToArray(array, object);
-				});
+				}
 				JsonUtil.setProperty(json, "items", array);
 			}
 		}
@@ -56,11 +57,11 @@ public class Syn2ModelWriter implements ModelWriter {
 			Map<String, ? extends SynPathItem> models = node.getWebhooks();
 			if (models != null && !models.isEmpty()) {
 				ObjectNode object = JsonUtil.objectNode();
-				models.keySet().forEach(jsonName -> {
+				for (String jsonName : models.keySet()) {
 					ObjectNode jsonValue = JsonUtil.objectNode();
 					this.writePathItem((Syn2PathItem) models.get(jsonName), jsonValue);
 					JsonUtil.setProperty(object, jsonName, jsonValue);
-				});
+				}
 				JsonUtil.setProperty(json, "webhooks", object);
 			}
 		}
@@ -177,11 +178,11 @@ public class Syn2ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "properties", mapJson);
 			}
 		}
@@ -189,11 +190,12 @@ public class Syn2ModelWriter implements ModelWriter {
 			List<BooleanSchemaUnion> items = node.getAllOf();
 			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				items.forEach(item -> {
+				for (int _idx = 0; _idx < items.size(); _idx++) {
+					BooleanSchemaUnion item = items.get(_idx);
 					JsonNode value = this.writeBooleanSchemaUnion(item);
 					if (value != null)
 						array.add(value);
-				});
+				}
 				JsonUtil.setProperty(json, "allOf", array);
 			}
 		}
@@ -202,11 +204,11 @@ public class Syn2ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeBooleanSchemaUnion(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "definitions", mapJson);
 			}
 		}
@@ -215,11 +217,11 @@ public class Syn2ModelWriter implements ModelWriter {
 			if (items != null && !items.isEmpty()) {
 				ObjectNode mapJson = JsonUtil.objectNode();
 				Collection<String> keys = items.keySet();
-				keys.forEach(key -> {
+				for (String key : keys) {
 					JsonNode value = this.writeSchemaOrBoolean(items.get(key));
 					if (value != null)
 						JsonUtil.setProperty(mapJson, key, value);
-				});
+				}
 				JsonUtil.setProperty(json, "nestedSchemas", mapJson);
 			}
 		}
@@ -227,11 +229,12 @@ public class Syn2ModelWriter implements ModelWriter {
 			List<SchemaOrBoolean> items = node.getComposedSchemas();
 			if (items != null && !items.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				items.forEach(item -> {
+				for (int _idx = 0; _idx < items.size(); _idx++) {
+					SchemaOrBoolean item = items.get(_idx);
 					JsonNode value = this.writeSchemaOrBoolean(item);
 					if (value != null)
 						array.add(value);
-				});
+				}
 				JsonUtil.setProperty(json, "composedSchemas", array);
 			}
 		}
@@ -338,11 +341,12 @@ public class Syn2ModelWriter implements ModelWriter {
 			List<? extends SynItem> models = node.getParameters();
 			if (models != null && !models.isEmpty()) {
 				ArrayNode array = JsonUtil.arrayNode();
-				models.forEach(model -> {
+				for (int _idx = 0; _idx < models.size(); _idx++) {
+					SynItem model = models.get(_idx);
 					ObjectNode object = JsonUtil.objectNode();
 					this.writeItem((Syn2Item) model, object);
 					JsonUtil.addToArray(array, object);
-				});
+				}
 				JsonUtil.setProperty(json, "parameters", array);
 			}
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AbstractTraverser.java
@@ -87,14 +87,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 		if (items != null) {
 			traversalContext.pushProperty(propertyName);
 			List<String> keys = JsonUtil.collectionToList(items.keySet());
-			keys.forEach(key -> {
+			for (int _idx = 0; _idx < keys.size(); _idx++) {
+				String key = keys.get(_idx);
 				Any value = items.get(key);
 				if (value != null && value.isNode()) {
 					this.traversalContext.pushMapIndex(key);
 					this.doTraverseNode((Node) value);
 					this.traversalContext.pop();
 				}
-			});
+			}
 			this.traversalContext.pop();
 		}
 	}
@@ -107,14 +108,15 @@ public abstract class AbstractTraverser implements Traverser, Visitor {
 	protected void traverseMappedNode(MappedNode<? extends Node> mappedNode) {
 		if (mappedNode != null) {
 			List<String> names = JsonUtil.collectionToList(mappedNode.getItemNames());
-			names.forEach(name -> {
+			for (int _idx = 0; _idx < names.size(); _idx++) {
+				String name = names.get(_idx);
 				Node value = mappedNode.getItem(name);
 				if (value != null) {
 					this.traversalContext.pushMapIndex(name);
 					this.doTraverseNode(value);
 					this.traversalContext.pop();
 				}
-			});
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Added `generator/CLAUDE.md` — comprehensive style guide covering architecture, BodyBuilder conventions, method classes, JSweet compatibility, generated code style, and Java source style
- Converted all `.forEach(lambda)` patterns to `for` loops in generated/transpiled code (2387 → 1 remaining, which is a Jackson `Iterator.forEachRemaining` API call)

### forEach conversion scope
- 13 code block templates (reader/writer/cloner property blocks)
- 4 method classes (ClearMethod, MappedNodeMethods, ReaderMethod)
- 1 stage template (CreateClonersStage extra properties)
- 2 base classes (WriterUtil, AbstractTraverser)

## Context

C35 in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generator snapshot tests regenerated and passing
- [x] Generated output compiles (FullGeneratorTest)