### PR TITLE
fix(generator): writeRoot returns JsonNode, remove unnecessary casts (C35b)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/Library.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/Library.java
@@ -159,7 +159,7 @@ public class Library {
     @Deprecated
     public static ObjectNode writeDocument(Document document) {
         ModelWriter writer = ModelWriterFactory.createModelWriter(document.root().modelType());
-        return writer.writeRoot((RootCapable) document);
+        return (ObjectNode) writer.writeRoot((RootCapable) document);
     }
 
     /**

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReadersStage.java
@@ -199,7 +199,7 @@ public class CreateReadersStage extends AbstractIOStage {
         body.addContext("readMethodName", readMethodName);
         body.addContext("modelType", modelType);
 
-        body.append("return (RootCapable) this.${readMethodName}(json, ModelType.${modelType});");
+        body.append("return this.${readMethodName}(json, ModelType.${modelType});");
         readRootMethodSource.setBody(body.toString());
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWritersStage.java
@@ -147,7 +147,7 @@ public class CreateWritersStage extends AbstractIOStage {
 
         MethodSource<JavaClassSource> writeRootMethodSource = classSource.addMethod()
                 .setName("writeRoot")
-                .setReturnType(ObjectNode.class.getName())
+                .setReturnType(JsonNode.class.getName())
                 .setPublic();
         writeRootMethodSource.addParameter(rootCapableSource.getName(), "node");
         writeRootMethodSource.addAnnotation(Override.class);
@@ -156,13 +156,7 @@ public class CreateWritersStage extends AbstractIOStage {
         body.addContext("writeMethodName", writeMethodName);
         body.addContext("unionType", jt.toJavaTypeString());
 
-        body.appendBlock("""
-JsonNode result = this.${writeMethodName}((${unionType}) node);
-if (result != null && JsonUtil.isObjectNode(result)) {
-    return (ObjectNode) result;
-}
-return null;
-""");
+        body.append("return this.${writeMethodName}((${unionType}) node);");
         writeRootMethodSource.setBody(body.toString());
     }
 
@@ -173,9 +167,11 @@ return null;
         classSource.addImport(rootNodeInterfaceSource);
         classSource.addImport(ObjectNode.class);
 
+        classSource.addImport(JsonNode.class);
+
         MethodSource<JavaClassSource> writeRootMethodSource = classSource.addMethod()
                 .setName("writeRoot")
-                .setReturnType(ObjectNode.class.getName())
+                .setReturnType(JsonNode.class.getName())
                 .setPublic();
         writeRootMethodSource.addParameter(rootNodeInterfaceSource.getName(), "node");
         writeRootMethodSource.addAnnotation(Override.class);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ClearMethod.java
@@ -53,7 +53,7 @@ public class ClearMethod implements Method {
             body.addContext("fieldName", fieldName);
 
             if (needsDetach) {
-                ((JavaClassSource) target).addImport(ctx.getNodeInterfaceFQN());
+                ((JavaClassSource) target).addImport(ctx.getAnyInterfaceFQN());
             }
 
             body.ifElse(needsDetach, () -> {
@@ -62,8 +62,8 @@ public class ClearMethod implements Method {
                 body.addContext("valuesExpr", valuesExpr);
                 return """
 if (this.${fieldName} != null) {
-    for (Object item : ${valuesExpr}) {
-        if (item != null) ((Node) item).detach();
+    for (Any item : ${valuesExpr}) {
+        if (item != null) item.detach();
     }
     this.${fieldName}.clear();
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/CodeGenContext.java
@@ -89,6 +89,10 @@ public class CodeGenContext {
         return rootNamespace + ".Node";
     }
 
+    public String getAnyInterfaceFQN() {
+        return rootNamespace + ".Any";
+    }
+
     public String getDataModelUtilFQCN() {
         return rootNamespace + ".util.DataModelUtil";
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/MappedNodeMethods.java
@@ -121,10 +121,7 @@ public class MappedNodeMethods {
             addParentTrackingImports(javaEntity);
             body.appendBlock("""
 if (item != null) {
-    ((NodeImpl) item)._setParent(this);
-    ((NodeImpl) item)._setParentPropertyName(null);
-    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-    ((NodeImpl) item)._setMapPropertyName(name);
+    DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 }
 """);
         }
@@ -147,10 +144,7 @@ if (item != null) {
             addParentTrackingImports(javaEntity);
             body.appendBlock("""
 if (item != null) {
-    ((NodeImpl) item)._setParent(this);
-    ((NodeImpl) item)._setParentPropertyName(null);
-    ((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-    ((NodeImpl) item)._setMapPropertyName(name);
+    DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 }
 """);
         }
@@ -178,8 +172,9 @@ if (item != null) {
         method.setReturnTypeVoid();
         BodyBuilder body = new BodyBuilder();
         if (entityProperty) {
-            body.append("for (Object item : this._items.values()) {");
-            body.append("    if (item != null) ((Node) item).detach();");
+            javaEntity.addImport(ctx.getAnyInterfaceFQN());
+            body.append("for (Any item : this._items.values()) {");
+            body.append("    if (item != null) item.detach();");
             body.append("}");
         }
         body.append("this._items.clear();");
@@ -189,8 +184,8 @@ if (item != null) {
     private void addParentTrackingImports(JavaSource<?> javaEntity) {
         JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
         javaEntity.addImport(parentPropertyTypeSource);
-        JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
-        javaEntity.addImport(nodeImplSource);
+        JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+        javaEntity.addImport(dataModelUtilSource);
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -18,7 +18,11 @@ import io.apitomy.umg.models.concept.type.Type;
 public class ParentAttachmentBlock extends CodeBlock {
 
     public enum ParentPropertyKind {
-        STANDARD, ARRAY, MAP
+        STANDARD("standard"), ARRAY("array"), MAP("map");
+
+        private final String value;
+        ParentPropertyKind(String value) { this.value = value; }
+        public String value() { return value; }
     }
 
     private final Type valueType;
@@ -192,11 +196,7 @@ public class ParentAttachmentBlock extends CodeBlock {
     }
 
     private String kindToString() {
-        return switch (kind) {
-            case STANDARD -> "standard";
-            case ARRAY -> "array";
-            case MAP -> "map";
-        };
+        return kind.value();
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -68,17 +68,12 @@ public class ParentAttachmentBlock extends CodeBlock {
         body.ifElse(kind == ParentPropertyKind.MAP,
                 () -> """
                         if (value != null) {
-                            ((NodeImpl) value)._setParent(this);
-                            ((NodeImpl) value)._setParentPropertyName(${quotedName});
-                            ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
-                            ((NodeImpl) value)._setMapPropertyName(name);
+                            DataModelUtil.setParentMap(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType}, name);
                         }
                         """,
                 () -> """
                         if (value != null) {
-                            ((NodeImpl) value)._setParent(this);
-                            ((NodeImpl) value)._setParentPropertyName(${quotedName});
-                            ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
+                            DataModelUtil.setParent(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType});
                         }
                         """);
     }
@@ -91,40 +86,27 @@ public class ParentAttachmentBlock extends CodeBlock {
         body.appendBlock("""
                 if (value != null) {
                     if (value.isEntity()) {
-                        ((NodeImpl) value)._setParent(this);
-                        ((NodeImpl) value)._setParentPropertyName("${propertyName}");
-                        ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
                     } else if (value.isEntityList()) {
-                        ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
-                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
                         List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
                         for (Object entity : entityList) {
                             if (entity != null) {
-                                ((NodeImpl) entity)._setParent(this);
-                                ((NodeImpl) entity)._setParentPropertyName("${propertyName}");
-                                ((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+                                DataModelUtil.setParent(entity, this, "${propertyName}", ParentPropertyType.array);
                             }
                         }
                     } else if (value.isEntityMap()) {
-                        ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
-                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
                         Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
                         Collection<String> keys = entityMap.keySet();
                         for (String key : keys) {
-                            NodeImpl entity = (NodeImpl) entityMap.get(key);
+                            Object entity = entityMap.get(key);
                             if (entity != null) {
-                                entity._setParent(this);
-                                entity._setParentPropertyName("${propertyName}");
-                                entity._setParentPropertyType(ParentPropertyType.map);
-                                entity._setMapPropertyName(key);
+                                DataModelUtil.setParentMap(entity, this, "${propertyName}", ParentPropertyType.map, key);
                             }
                         }
                     } else {
-                        ((UnionValueImpl<?>) value)._setParent(this);
-                        ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
-                        ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
                     }
                 }
                 """);
@@ -142,30 +124,12 @@ public class ParentAttachmentBlock extends CodeBlock {
         body.ifElse(kind == ParentPropertyKind.MAP,
                 () -> """
                         if (value != null) {
-                            if (value.isEntity()) {
-                                ((NodeImpl) value)._setParent(this);
-                                ((NodeImpl) value)._setParentPropertyName("${propertyName}");
-                                ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
-                                ((NodeImpl) value)._setMapPropertyName(name);
-                            } else {
-                                ((UnionValueImpl<?>) value)._setParent(this);
-                                ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
-                                ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
-                                ((UnionValueImpl<?>) value)._setMapPropertyName(name);
-                            }
+                            DataModelUtil.setParentMap(value, this, "${propertyName}", ParentPropertyType.${parentPropertyType}, name);
                         }
                         """,
                 () -> """
                         if (value != null) {
-                            if (value.isEntity()) {
-                                ((NodeImpl) value)._setParent(this);
-                                ((NodeImpl) value)._setParentPropertyName("${propertyName}");
-                                ((NodeImpl) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
-                            } else {
-                                ((UnionValueImpl<?>) value)._setParent(this);
-                                ((UnionValueImpl<?>) value)._setParentPropertyName("${propertyName}");
-                                ((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.${parentPropertyType});
-                            }
+                            DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.${parentPropertyType});
                         }
                         """);
     }
@@ -175,17 +139,15 @@ public class ParentAttachmentBlock extends CodeBlock {
         if (valueType.isEntityType()) {
             JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
             source.addImport(parentPropertyTypeSource);
-            JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
-            source.addImport(nodeImplSource);
+            JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+            source.addImport(dataModelUtilSource);
         } else if (valueType.isUnionType()) {
             JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
             source.addImport(parentPropertyTypeSource);
-            JavaClassSource nodeImplSource = ctx.getJavaIndex().lookupClass(ctx.getNodeEntityClassFQN());
-            source.addImport(nodeImplSource);
+            JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+            source.addImport(dataModelUtilSource);
             JavaInterfaceSource unionValueSource = ctx.getJavaIndex().lookupInterface(ctx.getUnionValueInterfaceFQN());
             source.addImport(unionValueSource);
-            JavaClassSource unionValueImplSource = ctx.getJavaIndex().lookupClass(ctx.getUnionTypeFQN("UnionValueImpl"));
-            source.addImport(unionValueImplSource);
 
             if (kind == ParentPropertyKind.STANDARD) {
                 source.addImport(Collection.class);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -100,8 +100,6 @@ public class ReaderMethod implements Method {
         method.addParameter("ModelType", "modelType");
 
         BodyBuilder body = new BodyBuilder();
-        body.append("if (json == null) return null;");
-
         // Generate dispatch for each variant
         boolean first = true;
         for (var variantType : unionType.getTypes()) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/WriterMethod.java
@@ -156,7 +156,7 @@ public class WriterMethod implements Method {
 
                     body.append("if (union.${isMethod}()) {");
                     body.append("    ArrayNode array = JsonUtil.arrayNode();");
-                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("    for (Object item : union.${asMethod}()) {");
                     body.append("        ObjectNode itemNode = JsonUtil.objectNode();");
                     body.append("        this.${writeMethodName}((${entityType}) item, itemNode);");
                     body.append("        array.add(itemNode);");
@@ -173,7 +173,7 @@ public class WriterMethod implements Method {
                     body.addContext("addExpr", "array.add(JsonUtil.toJsonNode(item))");
                     body.append("if (union.${isMethod}()) {");
                     body.append("    ArrayNode array = JsonUtil.arrayNode();");
-                    body.append("    for (Object item : (java.util.List<?>) union.${asMethod}()) {");
+                    body.append("    for (Object item : union.${asMethod}()) {");
                     body.append("        ${addExpr};");
                     body.append("    }");
                     body.append("    return array;");

--- a/generator/src/main/resources/base/io/apitomy/umg/base/io/ModelWriter.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/io/ModelWriter.java
@@ -1,10 +1,10 @@
 package io.apitomy.umg.base.io;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.apitomy.umg.base.RootCapable;
 
 public interface ModelWriter {
 
-    public ObjectNode writeRoot(RootCapable node);
+    public JsonNode writeRoot(RootCapable node);
 
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
@@ -1,5 +1,10 @@
 package io.apitomy.umg.base.util;
 
+import io.apitomy.umg.base.Node;
+import io.apitomy.umg.base.NodeImpl;
+import io.apitomy.umg.base.ParentPropertyType;
+import io.apitomy.umg.base.union.UnionValueImpl;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +46,27 @@ public class DataModelUtil {
             list.add(atIndex, value);
         }
         return list;
+    }
+
+    public static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType) {
+        if (child instanceof NodeImpl) {
+            ((NodeImpl) child)._setParent(parent);
+            ((NodeImpl) child)._setParentPropertyName(propertyName);
+            ((NodeImpl) child)._setParentPropertyType(propertyType);
+        } else if (child instanceof UnionValueImpl) {
+            ((UnionValueImpl<?>) child)._setParent(parent);
+            ((UnionValueImpl<?>) child)._setParentPropertyName(propertyName);
+            ((UnionValueImpl<?>) child)._setParentPropertyType(propertyType);
+        }
+    }
+
+    public static void setParentMap(Object child, Node parent, String propertyName, ParentPropertyType propertyType, String mapPropertyName) {
+        setParent(child, parent, propertyName, propertyType);
+        if (child instanceof NodeImpl) {
+            ((NodeImpl) child)._setMapPropertyName(mapPropertyName);
+        } else if (child instanceof UnionValueImpl) {
+            ((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+        }
     }
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/io/ModelWriter.java
@@ -1,10 +1,10 @@
 package io.test.synthetic.io;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.test.synthetic.RootCapable;
 
 public interface ModelWriter {
 
-	public ObjectNode writeRoot(RootCapable node);
+	public JsonNode writeRoot(RootCapable node);
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
@@ -1,5 +1,9 @@
 package io.test.synthetic.util;
 
+import io.test.synthetic.Node;
+import io.test.synthetic.NodeImpl;
+import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.union.UnionValueImpl;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +47,28 @@ public class DataModelUtil {
 			list.add(atIndex, value);
 		}
 		return list;
+	}
+
+	public static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType) {
+		if (child instanceof NodeImpl) {
+			((NodeImpl) child)._setParent(parent);
+			((NodeImpl) child)._setParentPropertyName(propertyName);
+			((NodeImpl) child)._setParentPropertyType(propertyType);
+		} else if (child instanceof UnionValueImpl) {
+			((UnionValueImpl<?>) child)._setParent(parent);
+			((UnionValueImpl<?>) child)._setParentPropertyName(propertyName);
+			((UnionValueImpl<?>) child)._setParentPropertyType(propertyType);
+		}
+	}
+
+	public static void setParentMap(Object child, Node parent, String propertyName, ParentPropertyType propertyType,
+			String mapPropertyName) {
+		setParent(child, parent, propertyName, propertyType);
+		if (child instanceof NodeImpl) {
+			((NodeImpl) child)._setMapPropertyName(mapPropertyName);
+		} else if (child instanceof UnionValueImpl) {
+			((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+		}
 	}
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v1;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -8,7 +9,6 @@ import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -47,9 +47,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("info");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
 		}
 	}
 
@@ -79,18 +77,16 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		}
 		this.items.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("items");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
-			for (Object item : this.items) {
+			for (Any item : this.items) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.items.clear();
 		}
@@ -114,9 +110,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("items");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
 	}
 
@@ -150,40 +144,27 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		this.additionalSchema = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("additionalSchema");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("additionalSchema");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "additionalSchema", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("additionalSchema");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "additionalSchema", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -37,9 +37,7 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("contact");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -8,7 +8,6 @@ import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -111,9 +110,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("schema");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
 		}
 	}
 
@@ -144,40 +141,27 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("defaultValue");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("defaultValue");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "defaultValue", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("defaultValue");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "defaultValue", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v1;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -70,18 +71,16 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 		}
 		this.parameters.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("parameters");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
-			for (Object item : this.parameters) {
+			for (Any item : this.parameters) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.parameters.clear();
 		}
@@ -105,9 +104,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("parameters");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -49,9 +49,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("get");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
 		}
 	}
 
@@ -71,9 +69,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("put");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
 		}
 	}
 
@@ -86,9 +82,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("post");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v1;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -41,10 +42,7 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 	public void addItem(String name, SynPathItem item) {
 		this._items.put(name, item);
 		if (item != null) {
-			((NodeImpl) item)._setParent(this);
-			((NodeImpl) item)._setParentPropertyName(null);
-			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) item)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 		}
 	}
 
@@ -52,10 +50,7 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 	public void insertItem(String name, SynPathItem item, int atIndex) {
 		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
 		if (item != null) {
-			((NodeImpl) item)._setParent(this);
-			((NodeImpl) item)._setParentPropertyName(null);
-			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) item)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 		}
 	}
 
@@ -69,9 +64,9 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 
 	@Override
 	public void clearItems() {
-		for (Object item : this._items.values()) {
+		for (Any item : this._items.values()) {
 			if (item != null)
-				((Node) item).detach();
+				item.detach();
 		}
 		this._items.clear();
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -1,17 +1,16 @@
 package io.test.synthetic.v1;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
 import io.test.synthetic.ModelType;
 import io.test.synthetic.Node;
-import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -70,40 +69,27 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("items");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("items");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "items", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("items");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "items", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 			}
 		}
 	}
@@ -127,26 +113,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.properties.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("properties");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
-			for (Object item : this.properties.values()) {
+			for (Any item : this.properties.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.properties.clear();
 		}
@@ -168,17 +144,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("properties");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
 	}
 
@@ -194,24 +160,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.allOf.add(value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("allOf");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
-			for (Object item : this.allOf) {
+			for (Any item : this.allOf) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.allOf.clear();
 		}
@@ -235,15 +193,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("allOf");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
 	}
 
@@ -259,26 +209,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.definitions.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("definitions");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
-			for (Object item : this.definitions.values()) {
+			for (Any item : this.definitions.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.definitions.clear();
 		}
@@ -300,17 +240,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("definitions");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
 	}
 
@@ -326,26 +256,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.nestedSchemas.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
-			for (Object item : this.nestedSchemas.values()) {
+			for (Any item : this.nestedSchemas.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.nestedSchemas.clear();
 		}
@@ -367,17 +287,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
 	}
 
@@ -393,24 +303,16 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("composedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
-			for (Object item : this.composedSchemas) {
+			for (Any item : this.composedSchemas) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.composedSchemas.clear();
 		}
@@ -434,15 +336,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("composedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -556,8 +556,6 @@ public class Syn1ModelReader implements ModelReader {
 	}
 
 	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -569,8 +567,6 @@ public class Syn1ModelReader implements ModelReader {
 	}
 
 	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -594,8 +590,6 @@ public class Syn1ModelReader implements ModelReader {
 	}
 
 	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -608,6 +602,6 @@ public class Syn1ModelReader implements ModelReader {
 
 	@Override
 	public RootCapable readRoot(JsonNode json) {
-		return (RootCapable) this.readSchemaOrBoolean(json, ModelType.SYN1);
+		return this.readSchemaOrBoolean(json, ModelType.SYN1);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriter.java
@@ -366,7 +366,7 @@ public class Syn1ModelWriter implements ModelWriter {
 		}
 		if (union.isSchemaList()) {
 			ArrayNode array = JsonUtil.arrayNode();
-			for (Object item : (java.util.List<?>) union.asSchemaList()) {
+			for (Object item : union.asSchemaList()) {
 				ObjectNode itemNode = JsonUtil.objectNode();
 				this.writeSchema((Syn1Schema) item, itemNode);
 				array.add(itemNode);
@@ -394,11 +394,7 @@ public class Syn1ModelWriter implements ModelWriter {
 	}
 
 	@Override
-	public ObjectNode writeRoot(RootCapable node) {
-		JsonNode result = this.writeSchemaOrBoolean((SchemaOrBoolean) node);
-		if (result != null && JsonUtil.isObjectNode(result)) {
-			return (ObjectNode) result;
-		}
-		return null;
+	public JsonNode writeRoot(RootCapable node) {
+		return this.writeSchemaOrBoolean((SchemaOrBoolean) node);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -8,7 +9,6 @@ import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -48,9 +48,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void setInfo(SynInfo value) {
 		this.info = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("info");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
 		}
 	}
 
@@ -80,18 +78,16 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 		this.items.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("items");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearItems() {
 		if (this.items != null) {
-			for (Object item : this.items) {
+			for (Any item : this.items) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.items.clear();
 		}
@@ -115,9 +111,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("items");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
 	}
 
@@ -160,19 +154,16 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 		this.webhooks.put(name, value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("webhooks");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearWebhooks() {
 		if (this.webhooks != null) {
-			for (Object item : this.webhooks.values()) {
+			for (Any item : this.webhooks.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.webhooks.clear();
 		}
@@ -194,10 +185,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("webhooks");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) value)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
 		}
 	}
 
@@ -211,40 +199,27 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		this.additionalSchema = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("additionalSchema");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("additionalSchema");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "additionalSchema", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("additionalSchema");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "additionalSchema", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("additionalSchema");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -38,9 +38,7 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	public void setContact(SynContact value) {
 		this.contact = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("contact");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -8,7 +8,6 @@ import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -112,9 +111,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	public void setSchema(SynSchema value) {
 		this.schema = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("schema");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
 		}
 	}
 
@@ -145,40 +142,27 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 		this.defaultValue = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("defaultValue");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("defaultValue");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "defaultValue", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("defaultValue");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "defaultValue", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("defaultValue");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 			}
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -70,18 +71,16 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 		}
 		this.parameters.add(value);
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("parameters");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearParameters() {
 		if (this.parameters != null) {
-			for (Object item : this.parameters) {
+			for (Any item : this.parameters) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.parameters.clear();
 		}
@@ -105,9 +104,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("parameters");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
+			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -50,9 +50,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setGet(SynOperation value) {
 		this.get = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("get");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
 		}
 	}
 
@@ -72,9 +70,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPut(SynOperation value) {
 		this.put = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("put");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
 		}
 	}
 
@@ -87,9 +83,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setPost(SynOperation value) {
 		this.post = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("post");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
 		}
 	}
 
@@ -102,9 +96,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void setDelete(Syn2Operation value) {
 		this.delete = value;
 		if (value != null) {
-			((NodeImpl) value)._setParent(this);
-			((NodeImpl) value)._setParentPropertyName("delete");
-			((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+			DataModelUtil.setParent(value, this, "delete", ParentPropertyType.standard);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -1,6 +1,7 @@
 package io.test.synthetic.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
@@ -41,10 +42,7 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 	public void addItem(String name, SynPathItem item) {
 		this._items.put(name, item);
 		if (item != null) {
-			((NodeImpl) item)._setParent(this);
-			((NodeImpl) item)._setParentPropertyName(null);
-			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) item)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 		}
 	}
 
@@ -52,10 +50,7 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 	public void insertItem(String name, SynPathItem item, int atIndex) {
 		this._items = DataModelUtil.insertMapEntry(this._items, name, item, atIndex);
 		if (item != null) {
-			((NodeImpl) item)._setParent(this);
-			((NodeImpl) item)._setParentPropertyName(null);
-			((NodeImpl) item)._setParentPropertyType(ParentPropertyType.map);
-			((NodeImpl) item)._setMapPropertyName(name);
+			DataModelUtil.setParentMap(item, this, null, ParentPropertyType.map, name);
 		}
 	}
 
@@ -69,9 +64,9 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 
 	@Override
 	public void clearItems() {
-		for (Object item : this._items.values()) {
+		for (Any item : this._items.values()) {
 			if (item != null)
-				((Node) item).detach();
+				item.detach();
 		}
 		this._items.clear();
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -1,17 +1,16 @@
 package io.test.synthetic.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
 import io.test.synthetic.ModelType;
 import io.test.synthetic.Node;
-import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynSchema;
 import io.test.synthetic.union.UnionValue;
-import io.test.synthetic.union.UnionValueImpl;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
@@ -70,40 +69,27 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		this.items = value;
 		if (value != null) {
 			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("items");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 			} else if (value.isEntityList()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
 				for (Object entity : entityList) {
 					if (entity != null) {
-						((NodeImpl) entity)._setParent(this);
-						((NodeImpl) entity)._setParentPropertyName("items");
-						((NodeImpl) entity)._setParentPropertyType(ParentPropertyType.array);
+						DataModelUtil.setParent(entity, this, "items", ParentPropertyType.array);
 					}
 				}
 			} else if (value.isEntityMap()) {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
 				Collection<String> keys = entityMap.keySet();
 				for (String key : keys) {
-					NodeImpl entity = (NodeImpl) entityMap.get(key);
+					Object entity = entityMap.get(key);
 					if (entity != null) {
-						entity._setParent(this);
-						entity._setParentPropertyName("items");
-						entity._setParentPropertyType(ParentPropertyType.map);
-						entity._setMapPropertyName(key);
+						DataModelUtil.setParentMap(entity, this, "items", ParentPropertyType.map, key);
 					}
 				}
 			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("items");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.standard);
+				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 			}
 		}
 	}
@@ -127,26 +113,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.properties.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("properties");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearProperties() {
 		if (this.properties != null) {
-			for (Object item : this.properties.values()) {
+			for (Any item : this.properties.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.properties.clear();
 		}
@@ -168,17 +144,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("properties");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("properties");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
 	}
 
@@ -194,24 +160,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.allOf.add(value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("allOf");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearAllOf() {
 		if (this.allOf != null) {
-			for (Object item : this.allOf) {
+			for (Any item : this.allOf) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.allOf.clear();
 		}
@@ -235,15 +193,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("allOf");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("allOf");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
 	}
 
@@ -259,26 +209,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.definitions.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("definitions");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearDefinitions() {
 		if (this.definitions != null) {
-			for (Object item : this.definitions.values()) {
+			for (Any item : this.definitions.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.definitions.clear();
 		}
@@ -300,17 +240,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("definitions");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("definitions");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
 	}
 
@@ -326,26 +256,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.nestedSchemas.put(name, value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
 	}
 
 	@Override
 	public void clearNestedSchemas() {
 		if (this.nestedSchemas != null) {
-			for (Object item : this.nestedSchemas.values()) {
+			for (Any item : this.nestedSchemas.values()) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.nestedSchemas.clear();
 		}
@@ -367,17 +287,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("nestedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.map);
-				((NodeImpl) value)._setMapPropertyName(name);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("nestedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.map);
-				((UnionValueImpl<?>) value)._setMapPropertyName(name);
-			}
+			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
 	}
 
@@ -393,24 +303,16 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 		this.composedSchemas.add(value);
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("composedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
 	}
 
 	@Override
 	public void clearComposedSchemas() {
 		if (this.composedSchemas != null) {
-			for (Object item : this.composedSchemas) {
+			for (Any item : this.composedSchemas) {
 				if (item != null)
-					((Node) item).detach();
+					item.detach();
 			}
 			this.composedSchemas.clear();
 		}
@@ -434,15 +336,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
 		if (value != null) {
-			if (value.isEntity()) {
-				((NodeImpl) value)._setParent(this);
-				((NodeImpl) value)._setParentPropertyName("composedSchemas");
-				((NodeImpl) value)._setParentPropertyType(ParentPropertyType.array);
-			} else {
-				((UnionValueImpl<?>) value)._setParent(this);
-				((UnionValueImpl<?>) value)._setParentPropertyName("composedSchemas");
-				((UnionValueImpl<?>) value)._setParentPropertyType(ParentPropertyType.array);
-			}
+			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -595,8 +595,6 @@ public class Syn2ModelReader implements ModelReader {
 	}
 
 	private SchemaOrBoolean readSchemaOrBoolean(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -608,8 +606,6 @@ public class Syn2ModelReader implements ModelReader {
 	}
 
 	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -633,8 +629,6 @@ public class Syn2ModelReader implements ModelReader {
 	}
 
 	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
-		if (json == null)
-			return null;
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -647,6 +641,6 @@ public class Syn2ModelReader implements ModelReader {
 
 	@Override
 	public RootCapable readRoot(JsonNode json) {
-		return (RootCapable) this.readSchemaOrBoolean(json, ModelType.SYN2);
+		return this.readSchemaOrBoolean(json, ModelType.SYN2);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriter.java
@@ -388,7 +388,7 @@ public class Syn2ModelWriter implements ModelWriter {
 		}
 		if (union.isSchemaList()) {
 			ArrayNode array = JsonUtil.arrayNode();
-			for (Object item : (java.util.List<?>) union.asSchemaList()) {
+			for (Object item : union.asSchemaList()) {
 				ObjectNode itemNode = JsonUtil.objectNode();
 				this.writeSchema((Syn2Schema) item, itemNode);
 				array.add(itemNode);
@@ -416,11 +416,7 @@ public class Syn2ModelWriter implements ModelWriter {
 	}
 
 	@Override
-	public ObjectNode writeRoot(RootCapable node) {
-		JsonNode result = this.writeSchemaOrBoolean((SchemaOrBoolean) node);
-		if (result != null && JsonUtil.isObjectNode(result)) {
-			return (ObjectNode) result;
-		}
-		return null;
+	public JsonNode writeRoot(RootCapable node) {
+		return this.writeSchemaOrBoolean((SchemaOrBoolean) node);
 	}
 }


### PR DESCRIPTION
## Summary

Three generated code cleanups:

1. **writeRoot returns JsonNode** — was returning ObjectNode and silently returning null for boolean schema roots. Now returns JsonNode so union roots (like `JsonSchema = boolean|FullSchema`) serialize correctly.

2. **Remove unnecessary List casts** — WriterMethod generated `(java.util.List<?>) union.asStringList()` but `asStringList()` already returns `List<String>`. Removed the lossy casts.

3. **ParentPropertyKind enum holds value** — enum values now store their string directly (`STANDARD("standard")`) instead of using a `kindToString()` switch.

## Context

C35b in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output compiles