### PR TITLE
refactor(generator): insert cleanup, JsonType enum, conditional ModelType (C35b)

### DIFF
--- a/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
+++ b/data-models/src/main/ts/src/io/apitomy/datamodels/models/util/JsonUtil.ts
@@ -103,53 +103,23 @@ export class JsonUtil {
         return value;
     }
 
-    public static allMatch(array: any, expectedType: string): boolean {
+    public static allMatch(array: any, expectedType: JsonUtil.JsonType): boolean {
         if (array == null || !Array.isArray(array)) {
             return false;
         }
         for (let i: number = 0; i < array.length; i++) {
-            const item: any = array[i];
-            if (expectedType === "string") {
-                if (typeof item !== "string") return false;
-            } else if (expectedType === "boolean") {
-                if (typeof item !== "boolean") return false;
-            } else if (expectedType === "number") {
-                if (typeof item !== "number") return false;
-            } else if (expectedType === "integer") {
-                if (typeof item !== "number" || !Number.isInteger(item)) return false;
-            } else if (expectedType === "object") {
-                if (typeof item !== "object" || Array.isArray(item)) return false;
-            } else if (expectedType === "any") {
-                if (item == null) return false;
-            } else {
-                return false;
-            }
+            if (!expectedType.matches(array[i])) return false;
         }
         return true;
     }
 
-    public static allValuesMatch(obj: any, expectedType: string): boolean {
+    public static allValuesMatch(obj: any, expectedType: JsonUtil.JsonType): boolean {
         if (obj == null) {
             return false;
         }
         const fieldNames: string[] = JsonUtil.keys(obj);
         for (let i: number = 0; i < fieldNames.length; i++) {
-            const item: any = obj[fieldNames[i]];
-            if (expectedType === "string") {
-                if (typeof item !== "string") return false;
-            } else if (expectedType === "boolean") {
-                if (typeof item !== "boolean") return false;
-            } else if (expectedType === "number") {
-                if (typeof item !== "number") return false;
-            } else if (expectedType === "integer") {
-                if (typeof item !== "number" || !Number.isInteger(item)) return false;
-            } else if (expectedType === "object") {
-                if (typeof item !== "object" || Array.isArray(item)) return false;
-            } else if (expectedType === "any") {
-                if (item == null) return false;
-            } else {
-                return false;
-            }
+            if (!expectedType.matches(obj[fieldNames[i]])) return false;
         }
         return true;
     }
@@ -254,4 +224,25 @@ export class JsonUtil {
         return value;
     }
 
+}
+
+export namespace JsonUtil {
+    export class JsonType {
+        public static STRING: JsonType = new JsonType((v: any) => typeof v === "string");
+        public static BOOLEAN: JsonType = new JsonType((v: any) => typeof v === "boolean");
+        public static NUMBER: JsonType = new JsonType((v: any) => typeof v === "number");
+        public static INTEGER: JsonType = new JsonType((v: any) => typeof v === "number" && Number.isInteger(v));
+        public static OBJECT: JsonType = new JsonType((v: any) => typeof v === "object" && !Array.isArray(v));
+        public static ANY: JsonType = new JsonType((v: any) => v != null);
+
+        private readonly matcher: (value: any) => boolean;
+
+        private constructor(matcher: (value: any) => boolean) {
+            this.matcher = matcher;
+        }
+
+        public matches(node: any): boolean {
+            return this.matcher(node);
+        }
+    }
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
@@ -95,29 +95,24 @@ public class InsertMethod implements Method {
             body.addContext("propertyName", propertyName);
 
             if (isEntityValue || isPrimitiveValue || isUnionValue) {
+                JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
+                target.addImport(dataModelUtilSource);
+
                 body.ifElse(resolvedType.isMapType(), () -> {
-                    JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
-                    target.addImport(dataModelUtilSource);
                     target.addImport(LinkedHashMap.class);
                     return """
 if (this.${fieldName} == null) {
     this.${fieldName} = new LinkedHashMap<>();
-    this.${fieldName}.put(name, value);
-} else {
-    this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);
 }
+this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value, atIndex);
 """;
                 }, () -> {
-                    JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
-                    target.addImport(dataModelUtilSource);
                     target.addImport(ArrayList.class);
                     return """
 if (this.${fieldName} == null) {
     this.${fieldName} = new ArrayList<>();
-    this.${fieldName}.add(value);
-} else {
-    this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);
 }
+this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);
 """;
                 });
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
@@ -118,7 +118,7 @@ this.${fieldName} = DataModelUtil.insertMapEntry(this.${fieldName}, name, value,
 if (this.${fieldName} == null) {
     this.${fieldName} = new ArrayList<>();
 }
-this.${fieldName} = DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);
+DataModelUtil.insertListEntry(this.${fieldName}, value, atIndex);
 """;
                 });
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/InsertMethod.java
@@ -79,6 +79,12 @@ public class InsertMethod implements Method {
         method.addParameter(jt.toJavaTypeString(), "value");
         method.addParameter("int", "atIndex");
 
+        method.getJavaDoc()
+                .setText("Inserts an item at the given index.")
+                .addTagValue("@param", "atIndex insertion position: &lt;= 0 inserts at the beginning, "
+                        + "&gt;= size inserts at the end, otherwise inserts at the given position "
+                        + "shifting existing items to the right");
+
         if (target instanceof JavaClassSource) {
             method.addAnnotation(Override.class);
             addImportsTo(target);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ParentAttachmentBlock.java
@@ -1,19 +1,15 @@
 package io.apitomy.umg.pipe.java.method;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
-import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 
 import io.apitomy.umg.models.concept.type.Type;
 
 /**
- * Generates parent tracking code for entity/union types. The generated code varies based
- * on the type and the parent-property-type (standard, array, map).
+ * Generates parent tracking code for entity/union types via DataModelUtil.setParent.
  */
 public class ParentAttachmentBlock extends CodeBlock {
 
@@ -30,12 +26,6 @@ public class ParentAttachmentBlock extends CodeBlock {
     private final ParentPropertyKind kind;
     private final CodeGenContext ctx;
 
-    /**
-     * @param valueType the resolved type of the value being attached
-     * @param propertyName the property name for _setParentPropertyName, or null for mapped-node methods
-     * @param kind determines the ParentPropertyType enum value (standard/array/map)
-     * @param ctx stage context for FQN lookups
-     */
     public ParentAttachmentBlock(Type valueType, String propertyName, ParentPropertyKind kind,
             CodeGenContext ctx) {
         this.valueType = valueType;
@@ -46,119 +36,28 @@ public class ParentAttachmentBlock extends CodeBlock {
 
     @Override
     public void appendTo(BodyBuilder body) {
-        if (valueType.isEntityType()) {
-            appendEntityAttachment(body);
-        } else if (valueType.isUnionType()) {
-            if (kind == ParentPropertyKind.STANDARD) {
-                appendUnionStandardAttachment(body);
-            } else {
-                appendUnionCollectionAttachment(body);
-            }
+        if (!valueType.isEntityType() && !valueType.isUnionType()) {
+            return;
         }
-        // PrimitiveType: no parent tracking needed
-    }
 
-    private void appendEntityAttachment(BodyBuilder body) {
-        String parentPropertyType = kindToString();
         String quotedName = propertyName != null ? "\"" + propertyName + "\"" : "null";
         body.addContext(Map.of(
                 "quotedName", quotedName,
-                "parentPropertyType", parentPropertyType
+                "parentPropertyType", kind.value()
         ));
-        body.ifElse(kind == ParentPropertyKind.MAP,
-                () -> """
-                        if (value != null) {
-                            DataModelUtil.setParentMap(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType}, name);
-                        }
-                        """,
-                () -> """
-                        if (value != null) {
-                            DataModelUtil.setParent(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType});
-                        }
-                        """);
-    }
 
-    /**
-     * Union attachment for setter (standard) - has full isEntity/isEntityList/isEntityMap/else dispatch.
-     */
-    private void appendUnionStandardAttachment(BodyBuilder body) {
-        body.addContext("propertyName", propertyName);
-        body.appendBlock("""
-                if (value != null) {
-                    if (value.isEntity()) {
-                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
-                    } else if (value.isEntityList()) {
-                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
-                        List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-                        for (Object entity : entityList) {
-                            if (entity != null) {
-                                DataModelUtil.setParent(entity, this, "${propertyName}", ParentPropertyType.array);
-                            }
-                        }
-                    } else if (value.isEntityMap()) {
-                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
-                        Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-                        Collection<String> keys = entityMap.keySet();
-                        for (String key : keys) {
-                            Object entity = entityMap.get(key);
-                            if (entity != null) {
-                                DataModelUtil.setParentMap(entity, this, "${propertyName}", ParentPropertyType.map, key);
-                            }
-                        }
-                    } else {
-                        DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.standard);
-                    }
-                }
-                """);
-    }
-
-    /**
-     * Union attachment for array/map collection methods - simpler isEntity/else dispatch.
-     */
-    private void appendUnionCollectionAttachment(BodyBuilder body) {
-        String parentPropertyType = kindToString();
-        body.addContext(Map.of(
-                "propertyName", propertyName,
-                "parentPropertyType", parentPropertyType
-        ));
         body.ifElse(kind == ParentPropertyKind.MAP,
-                () -> """
-                        if (value != null) {
-                            DataModelUtil.setParentMap(value, this, "${propertyName}", ParentPropertyType.${parentPropertyType}, name);
-                        }
-                        """,
-                () -> """
-                        if (value != null) {
-                            DataModelUtil.setParent(value, this, "${propertyName}", ParentPropertyType.${parentPropertyType});
-                        }
-                        """);
+                () -> "DataModelUtil.setParentMap(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType}, name);",
+                () -> "DataModelUtil.setParent(value, this, ${quotedName}, ParentPropertyType.${parentPropertyType});");
     }
 
     @Override
     public void addImportsTo(JavaSource<?> source) {
-        if (valueType.isEntityType()) {
+        if (valueType.isEntityType() || valueType.isUnionType()) {
             JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
             source.addImport(parentPropertyTypeSource);
             JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
             source.addImport(dataModelUtilSource);
-        } else if (valueType.isUnionType()) {
-            JavaEnumSource parentPropertyTypeSource = ctx.getJavaIndex().lookupEnum(ctx.getParentPropertyTypeEnumFQN());
-            source.addImport(parentPropertyTypeSource);
-            JavaClassSource dataModelUtilSource = ctx.getJavaIndex().lookupClass(ctx.getDataModelUtilFQCN());
-            source.addImport(dataModelUtilSource);
-            JavaInterfaceSource unionValueSource = ctx.getJavaIndex().lookupInterface(ctx.getUnionValueInterfaceFQN());
-            source.addImport(unionValueSource);
-
-            if (kind == ParentPropertyKind.STANDARD) {
-                source.addImport(Collection.class);
-                source.addImport(List.class);
-                source.addImport(Map.class);
-            }
         }
     }
-
-    private String kindToString() {
-        return kind.value();
-    }
-
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeUtil.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/PrimitiveTypeUtil.java
@@ -136,25 +136,23 @@ public final class PrimitiveTypeUtil {
     }
 
     /**
-     * Determines the expected type string for {@code JsonUtil.allMatch} / {@code JsonUtil.allValuesMatch}.
-     * E.g. String → "string", Boolean → "boolean", ObjectNode → "object", JsonNode → "any".
+     * Determines the JsonUtil.JsonType enum constant name for {@code JsonUtil.allMatch} / {@code JsonUtil.allValuesMatch}.
+     * E.g. String → "STRING", Boolean → "BOOLEAN", ObjectNode → "OBJECT", JsonNode → "ANY".
      */
     public static String determineExpectedTypeString(Type primitiveType, CodeGenContext ctx) {
         Class<?> _class = primitiveTypeToClass(primitiveType);
         if (ObjectNode.class.equals(_class)) {
-            return "object";
+            return "OBJECT";
         } else if (JsonNode.class.equals(_class)) {
-            return "any";
+            return "ANY";
         } else if (String.class.equals(_class)) {
-            return "string";
+            return "STRING";
         } else if (Boolean.class.equals(_class)) {
-            return "boolean";
-        } else if (Number.class.equals(_class)) {
-            return "number";
-        } else if (Integer.class.equals(_class)) {
-            return "number";
+            return "BOOLEAN";
+        } else if (Number.class.equals(_class) || Integer.class.equals(_class)) {
+            return "NUMBER";
         }
-        return "any";
+        return "ANY";
     }
 
     /**

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/ReaderMethod.java
@@ -89,17 +89,24 @@ public class ReaderMethod implements Method {
         readerClassSource.addImport(ObjectNode.class);
         jt.addImportsTo(readerClassSource);
 
-        JavaEnumSource modelTypeEnum = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
-        readerClassSource.addImport(modelTypeEnum);
+        boolean isRootUnion = unionType.isRoot();
+
+        if (isRootUnion) {
+            JavaEnumSource modelTypeEnum = ctx.getJavaIndex().lookupEnum(ctx.getModelTypeEnumFQN());
+            readerClassSource.addImport(modelTypeEnum);
+        }
 
         MethodSource<JavaClassSource> method = readerClassSource.addMethod()
                 .setName(methodName)
                 .setReturnType(jt.toJavaTypeString())
                 .setPrivate();
         method.addParameter("JsonNode", "json");
-        method.addParameter("ModelType", "modelType");
+        if (isRootUnion) {
+            method.addParameter("ModelType", "modelType");
+        }
 
         BodyBuilder body = new BodyBuilder();
+        body.addContext("modelTypeArg", isRootUnion ? "modelType" : "null");
         // Generate dispatch for each variant
         boolean first = true;
         for (var variantType : unionType.getTypes()) {
@@ -161,7 +168,7 @@ public class ReaderMethod implements Method {
                 first = false;
 
                 body.append("if (JsonUtil.${isMethod}(json)) {");
-                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json), modelType);");
+                body.append("    return new ${unionValueClass}(JsonUtil.${toMethod}(json), ${modelTypeArg});");
                 body.append("}");
             } else if (variantType instanceof ListType listType
                     && listType.getValueType() instanceof EntityType listEntityType) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadListPropertyBlock.java
@@ -58,7 +58,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.appendBlock("""
 {
     JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
-    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, "${expectedType}")) {
+    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, JsonUtil.JsonType.${expectedType})) {
         List<${elementValueType}> items = new ArrayList<>();
         List<JsonNode> _nodes = JsonUtil.toList(${varName});
         for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -91,7 +91,7 @@ public class ReadListPropertyBlock extends CodeBlock {
             body.appendBlock("""
 {
     JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
-    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, "object")) {
+    if (JsonUtil.isArray(${varName}) && JsonUtil.allMatch(${varName}, JsonUtil.JsonType.OBJECT)) {
         List<JsonNode> _nodes = JsonUtil.toList(${varName});
         for (int _i = 0; _i < _nodes.size(); _i++) {
             ObjectNode object = JsonUtil.toObject(_nodes.get(_i));

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadMapPropertyBlock.java
@@ -61,7 +61,7 @@ public class ReadMapPropertyBlock extends CodeBlock {
             body.appendBlock("""
 {
     JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
-    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch(JsonUtil.toObject(${varName}), "${expectedType}")) {
+    if (JsonUtil.isObject(${varName}) && JsonUtil.allValuesMatch(JsonUtil.toObject(${varName}), JsonUtil.JsonType.${expectedType})) {
         Map<String, ${elementValueType}> items = new LinkedHashMap<>();
         List<String> _keys = JsonUtil.keys(JsonUtil.toObject(${varName}));
         for (int _i = 0; _i < _keys.size(); _i++) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadRegexPropertyBlock.java
@@ -138,7 +138,7 @@ public class ReadRegexPropertyBlock extends CodeBlock {
     for (int _i = 0; _i < propertyNames.size(); _i++) {
         String name = propertyNames.get(_i);
         JsonNode _val = JsonUtil.getProperty(json, name);
-        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, "${expectedType}")) {
+        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, JsonUtil.JsonType.${expectedType})) {
             List<${elementValueType}> items = new ArrayList<>();
             List<JsonNode> _nodes = JsonUtil.toList(_val);
             for (int _j = 0; _j < _nodes.size(); _j++) {
@@ -173,7 +173,7 @@ public class ReadRegexPropertyBlock extends CodeBlock {
     for (int _i = 0; _i < propertyNames.size(); _i++) {
         String name = propertyNames.get(_i);
         JsonNode _val = JsonUtil.getProperty(json, name);
-        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, "${expectedType}")) {
+        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, JsonUtil.JsonType.${expectedType})) {
             Map<String, ${elementValueType}> items = new LinkedHashMap<>();
             List<String> _keys = JsonUtil.keys((ObjectNode) _val);
             for (int _j = 0; _j < _keys.size(); _j++) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadStarPropertyBlock.java
@@ -130,7 +130,7 @@ public class ReadStarPropertyBlock extends CodeBlock {
     for (int _i = 0; _i < propertyNames.size(); _i++) {
         String name = propertyNames.get(_i);
         JsonNode _val = JsonUtil.getProperty(json, name);
-        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, "${expectedType}")) {
+        if (JsonUtil.isArray(_val) && JsonUtil.allMatch(_val, JsonUtil.JsonType.${expectedType})) {
             List<${elementValueType}> items = new ArrayList<>();
             List<JsonNode> _nodes = JsonUtil.toList(_val);
             for (int _j = 0; _j < _nodes.size(); _j++) {
@@ -163,7 +163,7 @@ public class ReadStarPropertyBlock extends CodeBlock {
     for (int _i = 0; _i < propertyNames.size(); _i++) {
         String name = propertyNames.get(_i);
         JsonNode _val = JsonUtil.getProperty(json, name);
-        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, "${expectedType}")) {
+        if (JsonUtil.isObject(_val) && JsonUtil.allValuesMatch((ObjectNode) _val, JsonUtil.JsonType.${expectedType})) {
             Map<String, ${elementValueType}> items = new LinkedHashMap<>();
             List<String> _keys = JsonUtil.keys((ObjectNode) _val);
             for (int _j = 0; _j < _keys.size(); _j++) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionListPropertyBlock.java
@@ -49,7 +49,8 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getName())).getName(),
                 "readMethodName", readMethodName,
                 "unionJavaType", valueJt.toJavaTypeString(),
-                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"),
+                "readMethodExtraArgs", listType.getValueType().isRoot() ? ", null" : ""
         ));
 
         body.appendBlock("""
@@ -60,7 +61,7 @@ public class ReadUnionListPropertyBlock extends CodeBlock {
                         List<${unionJavaType}> _items = new ArrayList<>();
                         boolean _valid = true;
                         for (int _i = 0; _i < _nodes.size(); _i++) {
-                            ${unionJavaType} _result = this.${readMethodName}(_nodes.get(_i), null);
+                            ${unionJavaType} _result = this.${readMethodName}(_nodes.get(_i)${readMethodExtraArgs});
                             if (_result == null) { _valid = false; break; }
                             _items.add(_result);
                         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -49,7 +49,8 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
                 "addMethodName", new AddMethod(prop.getCtx().singularize(property.getName())).getName(),
                 "readMethodName", readMethodName,
                 "unionJavaType", valueJt.toJavaTypeString(),
-                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"),
+                "readMethodExtraArgs", mapType.getValueType().isRoot() ? ", null" : ""
         ));
 
         body.appendBlock("""
@@ -62,7 +63,7 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
                             String _key = _keys.get(_i);
                             JsonNode _val = JsonUtil.getProperty(_obj, _key);
                             if (JsonUtil.isJsonNode(_val)) {
-                                ${unionJavaType} model = this.${readMethodName}(_val, null);
+                                ${unionJavaType} model = this.${readMethodName}(_val${readMethodExtraArgs});
                                 if (model != null) node.${addMethodName}(_key, model);
                             }
                         }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionMapPropertyBlock.java
@@ -59,15 +59,23 @@ public class ReadUnionMapPropertyBlock extends CodeBlock {
                     if (JsonUtil.isObject(${varName})) {
                         ObjectNode _obj = JsonUtil.toObject(${varName});
                         List<String> _keys = JsonUtil.keys(_obj);
+                        java.util.LinkedHashMap<String, ${unionJavaType}> _items = new java.util.LinkedHashMap<>();
+                        boolean _valid = true;
                         for (int _i = 0; _i < _keys.size(); _i++) {
                             String _key = _keys.get(_i);
                             JsonNode _val = JsonUtil.getProperty(_obj, _key);
                             if (JsonUtil.isJsonNode(_val)) {
                                 ${unionJavaType} model = this.${readMethodName}(_val${readMethodExtraArgs});
-                                if (model != null) node.${addMethodName}(_key, model);
+                                if (model == null) { _valid = false; break; }
+                                _items.put(_key, model);
                             }
                         }
-                        JsonUtil.removeProperty(json, "${propertyName}");
+                        if (_valid) {
+                            for (String _key : _items.keySet()) {
+                                node.${addMethodName}(_key, _items.get(_key));
+                            }
+                            JsonUtil.removeProperty(json, "${propertyName}");
+                        }
                     }
                 }
                 """);

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/method/reader/ReadUnionPropertyBlock.java
@@ -42,14 +42,15 @@ public class ReadUnionPropertyBlock extends CodeBlock {
                 "propertyName", property.getName(),
                 "setterMethodName", prop.getSetterName(),
                 "readMethodName", readMethodName,
-                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_")
+                "varName", "_" + property.getName().replaceAll("[^a-zA-Z0-9]", "_"),
+                "readMethodExtraArgs", resolved.isRoot() ? ", null" : ""
         ));
 
         body.appendBlock("""
                 {
                     JsonNode ${varName} = JsonUtil.getProperty(json, "${propertyName}");
                     if (JsonUtil.isJsonNode(${varName})) {
-                        node.${setterMethodName}(this.${readMethodName}(${varName}, null));
+                        node.${setterMethodName}(this.${readMethodName}(${varName}${readMethodExtraArgs}));
                         JsonUtil.removeProperty(json, "${propertyName}");
                     }
                 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
@@ -34,7 +34,7 @@ public class DataModelUtil {
         return newMap;
     }
 
-    public static <V> List<V> insertListEntry(List<V> list, V value, int atIndex) {
+    public static <V> void insertListEntry(List<V> list, V value, int atIndex) {
         if (atIndex >= list.size()) {
             list.add(value);
         } else if (atIndex < 0) {
@@ -42,7 +42,6 @@ public class DataModelUtil {
         } else {
             list.add(atIndex, value);
         }
-        return list;
     }
 
     /**

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/DataModelUtil.java
@@ -3,8 +3,11 @@ package io.apitomy.umg.base.util;
 import io.apitomy.umg.base.Node;
 import io.apitomy.umg.base.NodeImpl;
 import io.apitomy.umg.base.ParentPropertyType;
+import io.apitomy.umg.base.union.Union;
+import io.apitomy.umg.base.union.UnionValue;
 import io.apitomy.umg.base.union.UnionValueImpl;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,21 +15,15 @@ import java.util.Map;
 public class DataModelUtil {
 
     public static <V> Map<String, V> insertMapEntry(Map<String, V> map, String key, V value, int atIndex) {
-        // If the new key is present, then return without modification.
         if (map.containsKey(key)) {
             return map;
         }
-        // If the map isn't an LHM then ordering can't be maintained anyway
-        // If the atIndex is null then we're trying to undo a command that was persisted prior to this functionality being added
-        // If the atIndex is >= the map size it has to go at the end anyway
         if (!(map instanceof LinkedHashMap) || atIndex >= map.size()){
             map.put(key, value);
             return map;
         }
 
         final LinkedHashMap<String, V> newMap = new LinkedHashMap<>();
-        // In order to maintain ordering of the elements when replacing a key in a LinkedHashMap,
-        // create a new instance and populate it in insertion order
         int index = 0;
         for (Map.Entry<String, V> entry : map.entrySet()) {
             if (index++ == atIndex) {
@@ -48,24 +45,58 @@ public class DataModelUtil {
         return list;
     }
 
+    /**
+     * Sets parent tracking metadata on a child node or union value.
+     * For unions containing entity lists or maps, also sets parent on the nested entities.
+     */
     public static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType) {
+        setParent(child, parent, propertyName, propertyType, null);
+    }
+
+    public static void setParentMap(Object child, Node parent, String propertyName, ParentPropertyType propertyType, String mapPropertyName) {
+        setParent(child, parent, propertyName, propertyType, mapPropertyName);
+    }
+
+    private static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType, String mapPropertyName) {
+        if (child == null) return;
+
         if (child instanceof NodeImpl) {
             ((NodeImpl) child)._setParent(parent);
             ((NodeImpl) child)._setParentPropertyName(propertyName);
             ((NodeImpl) child)._setParentPropertyType(propertyType);
+            if (mapPropertyName != null) {
+                ((NodeImpl) child)._setMapPropertyName(mapPropertyName);
+            }
         } else if (child instanceof UnionValueImpl) {
             ((UnionValueImpl<?>) child)._setParent(parent);
             ((UnionValueImpl<?>) child)._setParentPropertyName(propertyName);
             ((UnionValueImpl<?>) child)._setParentPropertyType(propertyType);
+            if (mapPropertyName != null) {
+                ((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+            }
         }
-    }
 
-    public static void setParentMap(Object child, Node parent, String propertyName, ParentPropertyType propertyType, String mapPropertyName) {
-        setParent(child, parent, propertyName, propertyType);
-        if (child instanceof NodeImpl) {
-            ((NodeImpl) child)._setMapPropertyName(mapPropertyName);
-        } else if (child instanceof UnionValueImpl) {
-            ((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+        // Set parent relationship on nested Any values within union entity lists/maps
+        if (child instanceof Union) {
+            Union union = (Union) child;
+            if (union.isEntityList()) {
+                List<?> entityList = (List<?>) ((UnionValue<?>) union).getValue();
+                for (int i = 0; i < entityList.size(); i++) {
+                    Object entity = entityList.get(i);
+                    if (entity != null) {
+                        setParent(entity, parent, propertyName, ParentPropertyType.array, null);
+                    }
+                }
+            } else if (union.isEntityMap()) {
+                Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) union).getValue();
+                Collection<String> keys = entityMap.keySet();
+                for (String key : keys) {
+                    Object entity = entityMap.get(key);
+                    if (entity != null) {
+                        setParent(entity, parent, propertyName, ParentPropertyType.map, key);
+                    }
+                }
+            }
         }
     }
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/util/JsonUtil.java
@@ -155,53 +155,39 @@ public class JsonUtil {
         return object;
     }
 
-    public static boolean allMatch(JsonNode array, String expectedType) {
+    public enum JsonType {
+        STRING, BOOLEAN, NUMBER, INTEGER, OBJECT, ANY;
+
+        public boolean matches(JsonNode node) {
+            switch (this) {
+                case STRING:  return node.isTextual();
+                case BOOLEAN: return node.isBoolean();
+                case NUMBER:  return node.isNumber();
+                case INTEGER: return node.isInt();
+                case OBJECT:  return node.isObject();
+                case ANY:     return !node.isNull();
+                default:      return false;
+            }
+        }
+    }
+
+    public static boolean allMatch(JsonNode array, JsonType expectedType) {
         if (array == null || !array.isArray()) {
             return false;
         }
         ArrayNode arrayNode = (ArrayNode) array;
         for (int i = 0; i < arrayNode.size(); i++) {
-            JsonNode item = arrayNode.get(i);
-            if ("string".equals(expectedType)) {
-                if (!item.isTextual()) return false;
-            } else if ("boolean".equals(expectedType)) {
-                if (!item.isBoolean()) return false;
-            } else if ("number".equals(expectedType)) {
-                if (!item.isNumber()) return false;
-            } else if ("integer".equals(expectedType)) {
-                if (!item.isInt()) return false;
-            } else if ("object".equals(expectedType)) {
-                if (!item.isObject()) return false;
-            } else if ("any".equals(expectedType)) {
-                if (item.isNull()) return false;
-            } else {
-                return false;
-            }
+            if (!expectedType.matches(arrayNode.get(i))) return false;
         }
         return true;
     }
 
-    public static boolean allValuesMatch(ObjectNode obj, String expectedType) {
+    public static boolean allValuesMatch(ObjectNode obj, JsonType expectedType) {
         if (obj == null) {
             return false;
         }
         for (String fieldName : keys(obj)) {
-            JsonNode item = obj.get(fieldName);
-            if ("string".equals(expectedType)) {
-                if (!item.isTextual()) return false;
-            } else if ("boolean".equals(expectedType)) {
-                if (!item.isBoolean()) return false;
-            } else if ("number".equals(expectedType)) {
-                if (!item.isNumber()) return false;
-            } else if ("integer".equals(expectedType)) {
-                if (!item.isInt()) return false;
-            } else if ("object".equals(expectedType)) {
-                if (!item.isObject()) return false;
-            } else if ("any".equals(expectedType)) {
-                if (item.isNull()) return false;
-            } else {
-                return false;
-            }
+            if (!expectedType.matches(obj.get(fieldName))) return false;
         }
         return true;
     }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynDocument.java
@@ -25,6 +25,14 @@ public interface SynDocument extends Node {
 
 	public void removeItem(SynItem value);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertItem(SynItem value, int atIndex);
 
 	public Map<String, String> getMetadata();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynExtensible.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynExtensible.java
@@ -13,5 +13,13 @@ public interface SynExtensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynOperation.java
@@ -18,6 +18,14 @@ public interface SynOperation extends Node {
 
 	public void removeParameter(SynItem value);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertParameter(SynItem value, int atIndex);
 
 	public String getSummary();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/SynSchema.java
@@ -16,6 +16,14 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaSchemaLis
 
 	public void removeAllOf(BooleanSchemaUnion value);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex);
 
 	public List<SchemaOrBoolean> getComposedSchemas();
@@ -26,6 +34,14 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaSchemaLis
 
 	public void removeComposedSchema(SchemaOrBoolean value);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertComposedSchema(SchemaOrBoolean value, int atIndex);
 
 	public Map<String, BooleanSchemaUnion> getDefinitions();
@@ -36,6 +52,14 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaSchemaLis
 
 	public void removeDefinition(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex);
 
 	public List<JsonNode> getEnum();
@@ -62,6 +86,14 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaSchemaLis
 
 	public void removeNestedSchema(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex);
 
 	public Map<String, BooleanSchemaUnion> getProperties();
@@ -72,6 +104,14 @@ public interface SynSchema extends Node, SchemaOrBoolean, BooleanSchemaSchemaLis
 
 	public void removeProperty(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex);
 
 	public String getType();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
@@ -33,7 +33,7 @@ public class DataModelUtil {
 		return newMap;
 	}
 
-	public static <V> List<V> insertListEntry(List<V> list, V value, int atIndex) {
+	public static <V> void insertListEntry(List<V> list, V value, int atIndex) {
 		if (atIndex >= list.size()) {
 			list.add(value);
 		} else if (atIndex < 0) {
@@ -41,7 +41,6 @@ public class DataModelUtil {
 		} else {
 			list.add(atIndex, value);
 		}
-		return list;
 	}
 
 	/**

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/DataModelUtil.java
@@ -3,7 +3,10 @@ package io.test.synthetic.util;
 import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
+import io.test.synthetic.union.Union;
+import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.union.UnionValueImpl;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,23 +14,15 @@ import java.util.Map;
 public class DataModelUtil {
 
 	public static <V> Map<String, V> insertMapEntry(Map<String, V> map, String key, V value, int atIndex) {
-		// If the new key is present, then return without modification.
 		if (map.containsKey(key)) {
 			return map;
 		}
-		// If the map isn't an LHM then ordering can't be maintained anyway
-		// If the atIndex is null then we're trying to undo a command that was persisted
-		// prior to this functionality being added
-		// If the atIndex is >= the map size it has to go at the end anyway
 		if (!(map instanceof LinkedHashMap) || atIndex >= map.size()) {
 			map.put(key, value);
 			return map;
 		}
 
 		final LinkedHashMap<String, V> newMap = new LinkedHashMap<>();
-		// In order to maintain ordering of the elements when replacing a key in a
-		// LinkedHashMap,
-		// create a new instance and populate it in insertion order
 		int index = 0;
 		for (Map.Entry<String, V> entry : map.entrySet()) {
 			if (index++ == atIndex) {
@@ -49,25 +44,61 @@ public class DataModelUtil {
 		return list;
 	}
 
+	/**
+	 * Sets parent tracking metadata on a child node or union value. For unions
+	 * containing entity lists or maps, also sets parent on the nested entities.
+	 */
 	public static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType) {
-		if (child instanceof NodeImpl) {
-			((NodeImpl) child)._setParent(parent);
-			((NodeImpl) child)._setParentPropertyName(propertyName);
-			((NodeImpl) child)._setParentPropertyType(propertyType);
-		} else if (child instanceof UnionValueImpl) {
-			((UnionValueImpl<?>) child)._setParent(parent);
-			((UnionValueImpl<?>) child)._setParentPropertyName(propertyName);
-			((UnionValueImpl<?>) child)._setParentPropertyType(propertyType);
-		}
+		setParent(child, parent, propertyName, propertyType, null);
 	}
 
 	public static void setParentMap(Object child, Node parent, String propertyName, ParentPropertyType propertyType,
 			String mapPropertyName) {
-		setParent(child, parent, propertyName, propertyType);
+		setParent(child, parent, propertyName, propertyType, mapPropertyName);
+	}
+
+	private static void setParent(Object child, Node parent, String propertyName, ParentPropertyType propertyType,
+			String mapPropertyName) {
+		if (child == null)
+			return;
+
 		if (child instanceof NodeImpl) {
-			((NodeImpl) child)._setMapPropertyName(mapPropertyName);
+			((NodeImpl) child)._setParent(parent);
+			((NodeImpl) child)._setParentPropertyName(propertyName);
+			((NodeImpl) child)._setParentPropertyType(propertyType);
+			if (mapPropertyName != null) {
+				((NodeImpl) child)._setMapPropertyName(mapPropertyName);
+			}
 		} else if (child instanceof UnionValueImpl) {
-			((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+			((UnionValueImpl<?>) child)._setParent(parent);
+			((UnionValueImpl<?>) child)._setParentPropertyName(propertyName);
+			((UnionValueImpl<?>) child)._setParentPropertyType(propertyType);
+			if (mapPropertyName != null) {
+				((UnionValueImpl<?>) child)._setMapPropertyName(mapPropertyName);
+			}
+		}
+
+		// Set parent relationship on nested Any values within union entity lists/maps
+		if (child instanceof Union) {
+			Union union = (Union) child;
+			if (union.isEntityList()) {
+				List<?> entityList = (List<?>) ((UnionValue<?>) union).getValue();
+				for (int i = 0; i < entityList.size(); i++) {
+					Object entity = entityList.get(i);
+					if (entity != null) {
+						setParent(entity, parent, propertyName, ParentPropertyType.array, null);
+					}
+				}
+			} else if (union.isEntityMap()) {
+				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) union).getValue();
+				Collection<String> keys = entityMap.keySet();
+				for (String key : keys) {
+					Object entity = entityMap.get(key);
+					if (entity != null) {
+						setParent(entity, parent, propertyName, ParentPropertyType.map, key);
+					}
+				}
+			}
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/util/JsonUtil.java
@@ -152,65 +152,48 @@ public class JsonUtil {
 		return object;
 	}
 
-	public static boolean allMatch(JsonNode array, String expectedType) {
+	public enum JsonType {
+		STRING, BOOLEAN, NUMBER, INTEGER, OBJECT, ANY;
+
+		public boolean matches(JsonNode node) {
+			switch (this) {
+				case STRING :
+					return node.isTextual();
+				case BOOLEAN :
+					return node.isBoolean();
+				case NUMBER :
+					return node.isNumber();
+				case INTEGER :
+					return node.isInt();
+				case OBJECT :
+					return node.isObject();
+				case ANY :
+					return !node.isNull();
+				default :
+					return false;
+			}
+		}
+	}
+
+	public static boolean allMatch(JsonNode array, JsonType expectedType) {
 		if (array == null || !array.isArray()) {
 			return false;
 		}
 		ArrayNode arrayNode = (ArrayNode) array;
 		for (int i = 0; i < arrayNode.size(); i++) {
-			JsonNode item = arrayNode.get(i);
-			if ("string".equals(expectedType)) {
-				if (!item.isTextual())
-					return false;
-			} else if ("boolean".equals(expectedType)) {
-				if (!item.isBoolean())
-					return false;
-			} else if ("number".equals(expectedType)) {
-				if (!item.isNumber())
-					return false;
-			} else if ("integer".equals(expectedType)) {
-				if (!item.isInt())
-					return false;
-			} else if ("object".equals(expectedType)) {
-				if (!item.isObject())
-					return false;
-			} else if ("any".equals(expectedType)) {
-				if (item.isNull())
-					return false;
-			} else {
+			if (!expectedType.matches(arrayNode.get(i)))
 				return false;
-			}
 		}
 		return true;
 	}
 
-	public static boolean allValuesMatch(ObjectNode obj, String expectedType) {
+	public static boolean allValuesMatch(ObjectNode obj, JsonType expectedType) {
 		if (obj == null) {
 			return false;
 		}
 		for (String fieldName : keys(obj)) {
-			JsonNode item = obj.get(fieldName);
-			if ("string".equals(expectedType)) {
-				if (!item.isTextual())
-					return false;
-			} else if ("boolean".equals(expectedType)) {
-				if (!item.isBoolean())
-					return false;
-			} else if ("number".equals(expectedType)) {
-				if (!item.isNumber())
-					return false;
-			} else if ("integer".equals(expectedType)) {
-				if (!item.isInt())
-					return false;
-			} else if ("object".equals(expectedType)) {
-				if (!item.isObject())
-					return false;
-			} else if ("any".equals(expectedType)) {
-				if (item.isNull())
-					return false;
-			} else {
+			if (!expectedType.matches(obj.get(fieldName)))
 				return false;
-			}
 		}
 		return true;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Document.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Document.java
@@ -14,5 +14,13 @@ public interface Syn1Document extends SynDocument, Syn1Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -101,6 +101,14 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertItem(SynItem value, int atIndex) {
 		if (this.items == null) {
@@ -194,6 +202,14 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -105,10 +105,8 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void insertItem(SynItem value, int atIndex) {
 		if (this.items == null) {
 			this.items = new ArrayList<>();
-			this.items.add(value);
-		} else {
-			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
+		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
@@ -200,10 +198,8 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -8,12 +8,10 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,9 +44,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public void setInfo(SynInfo value) {
 		this.info = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -76,9 +72,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 			this.items = new ArrayList<>();
 		}
 		this.items.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 
 	@Override
@@ -115,9 +109,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 			this.items = new ArrayList<>();
 		}
 		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 
 	@Override
@@ -148,31 +140,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 	@Override
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "additionalSchema", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "additionalSchema", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1DocumentImpl.java
@@ -108,7 +108,7 @@ public class Syn1DocumentImpl extends NodeImpl implements Syn1Document {
 		if (this.items == null) {
 			this.items = new ArrayList<>();
 		}
-		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
+		DataModelUtil.insertListEntry(this.items, value, atIndex);
 		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Info.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Info.java
@@ -14,5 +14,13 @@ public interface Syn1Info extends SynInfo, Syn1Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -85,6 +85,14 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -89,10 +89,8 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1InfoImpl.java
@@ -36,9 +36,7 @@ public class Syn1InfoImpl extends NodeImpl implements Syn1Info {
 	@Override
 	public void setContact(SynContact value) {
 		this.contact = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Item.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Item.java
@@ -18,5 +18,13 @@ public interface Syn1Item extends SynItem, Syn1Extensible, Syn1Referenceable {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -203,6 +203,14 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -7,11 +7,9 @@ import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,9 +107,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	@Override
 	public void setSchema(SynSchema value) {
 		this.schema = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -139,31 +135,7 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	@Override
 	public void setDefaultValue(BooleanSchemaUnion value) {
 		this.defaultValue = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "defaultValue", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "defaultValue", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1ItemImpl.java
@@ -207,10 +207,8 @@ public class Syn1ItemImpl extends NodeImpl implements Syn1Item {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Operation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Operation.java
@@ -14,5 +14,13 @@ public interface Syn1Operation extends SynOperation, Syn1Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -106,7 +106,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 		if (this.parameters == null) {
 			this.parameters = new ArrayList<>();
 		}
-		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
+		DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -95,6 +95,14 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertParameter(SynItem value, int atIndex) {
 		if (this.parameters == null) {
@@ -133,6 +141,14 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -99,10 +99,8 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	public void insertParameter(SynItem value, int atIndex) {
 		if (this.parameters == null) {
 			this.parameters = new ArrayList<>();
-			this.parameters.add(value);
-		} else {
-			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
+		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
@@ -139,10 +137,8 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1OperationImpl.java
@@ -70,9 +70,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 			this.parameters = new ArrayList<>();
 		}
 		this.parameters.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 
 	@Override
@@ -109,9 +107,7 @@ public class Syn1OperationImpl extends NodeImpl implements Syn1Operation {
 			this.parameters = new ArrayList<>();
 		}
 		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItem.java
@@ -18,5 +18,13 @@ public interface Syn1PathItem extends SynPathItem, Syn1Extensible, Syn1Reference
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -48,9 +48,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	@Override
 	public void setGet(SynOperation value) {
 		this.get = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -68,9 +66,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	@Override
 	public void setPut(SynOperation value) {
 		this.put = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -81,9 +77,7 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	@Override
 	public void setPost(SynOperation value) {
 		this.post = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -117,10 +117,8 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathItemImpl.java
@@ -113,6 +113,14 @@ public class Syn1PathItemImpl extends NodeImpl implements Syn1PathItem {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Paths.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Paths.java
@@ -14,5 +14,13 @@ public interface Syn1Paths extends SynPaths, Syn1Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -105,6 +105,14 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1PathsImpl.java
@@ -109,10 +109,8 @@ public class Syn1PathsImpl extends NodeImpl implements Syn1Paths {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Schema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1Schema.java
@@ -19,5 +19,13 @@ public interface Syn1Schema extends RootCapable, SynSchema, Syn1Extensible, Syn1
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -139,10 +139,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.properties == null) {
 			this.properties = new LinkedHashMap<>();
-			this.properties.put(name, value);
-		} else {
-			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
+		this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
@@ -188,10 +186,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
 		if (this.allOf == null) {
 			this.allOf = new ArrayList<>();
-			this.allOf.add(value);
-		} else {
-			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
+		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
@@ -235,10 +231,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.definitions == null) {
 			this.definitions = new LinkedHashMap<>();
-			this.definitions.put(name, value);
-		} else {
-			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
+		this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
@@ -282,10 +276,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
 		if (this.nestedSchemas == null) {
 			this.nestedSchemas = new LinkedHashMap<>();
-			this.nestedSchemas.put(name, value);
-		} else {
-			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
+		this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
@@ -331,10 +323,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
 		if (this.composedSchemas == null) {
 			this.composedSchemas = new ArrayList<>();
-			this.composedSchemas.add(value);
-		} else {
-			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
+		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
@@ -401,10 +391,8 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -10,12 +10,10 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynSchema;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v1.visitors.Syn1Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,31 +65,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 	@Override
 	public void setItems(BooleanSchemaSchemaListUnion value) {
 		this.items = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "items", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "items", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -112,9 +86,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -149,9 +121,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -165,9 +135,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
 	@Override
@@ -204,9 +172,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
 	@Override
@@ -220,9 +186,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -257,9 +221,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -273,9 +235,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -310,9 +270,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -326,9 +284,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.composedSchemas = new ArrayList<>();
 		}
 		this.composedSchemas.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 
 	@Override
@@ -365,9 +321,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 			this.composedSchemas = new ArrayList<>();
 		}
 		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -171,7 +171,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		if (this.allOf == null) {
 			this.allOf = new ArrayList<>();
 		}
-		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
+		DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
@@ -320,7 +320,7 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		if (this.composedSchemas == null) {
 			this.composedSchemas = new ArrayList<>();
 		}
-		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
+		DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/Syn1SchemaImpl.java
@@ -135,6 +135,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.properties == null) {
@@ -182,6 +190,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
 		if (this.allOf == null) {
@@ -227,6 +243,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.definitions == null) {
@@ -272,6 +296,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
 		if (this.nestedSchemas == null) {
@@ -319,6 +351,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
 		if (this.composedSchemas == null) {
@@ -387,6 +427,14 @@ public class Syn1SchemaImpl extends RootCapableImpl implements Syn1Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -291,16 +291,26 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_properties)) {
 				ObjectNode _obj = JsonUtil.toObject(_properties);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, BooleanSchemaUnion> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
-						if (model != null)
-							node.addProperty(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "properties");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addProperty(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "properties");
+				}
 			}
 		}
 		{
@@ -330,16 +340,26 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_definitions)) {
 				ObjectNode _obj = JsonUtil.toObject(_definitions);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, BooleanSchemaUnion> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
-						if (model != null)
-							node.addDefinition(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "definitions");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addDefinition(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "definitions");
+				}
 			}
 		}
 		{
@@ -347,16 +367,26 @@ public class Syn1ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_nestedSchemas)) {
 				ObjectNode _obj = JsonUtil.toObject(_nestedSchemas);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, SchemaOrBoolean> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						SchemaOrBoolean model = this.readSchemaOrBoolean(_val, null);
-						if (model != null)
-							node.addNestedSchema(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "nestedSchemas");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addNestedSchema(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "nestedSchemas");
+				}
 			}
 		}
 		{

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -46,7 +46,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
-			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
+			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, JsonUtil.JsonType.OBJECT)) {
 				List<JsonNode> _nodes = JsonUtil.toList(_items);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
 					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
@@ -59,7 +59,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _tags = JsonUtil.getProperty(json, "tags");
-			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, JsonUtil.JsonType.STRING)) {
 				List<String> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_tags);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -71,7 +71,8 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
-			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), "string")) {
+			if (JsonUtil.isObject(_metadata)
+					&& JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), JsonUtil.JsonType.STRING)) {
 				Map<String, String> items = new LinkedHashMap<>();
 				List<String> _keys = JsonUtil.keys(JsonUtil.toObject(_metadata));
 				for (int _i = 0; _i < _keys.size(); _i++) {
@@ -225,7 +226,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _examples = JsonUtil.getProperty(json, "examples");
-			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, "any")) {
+			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, JsonUtil.JsonType.ANY)) {
 				List<JsonNode> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_examples);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -396,7 +397,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _enum = JsonUtil.getProperty(json, "enum");
-			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, "any")) {
+			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, JsonUtil.JsonType.ANY)) {
 				List<JsonNode> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_enum);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -518,7 +519,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _tags = JsonUtil.getProperty(json, "tags");
-			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, JsonUtil.JsonType.STRING)) {
 				List<String> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_tags);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -530,7 +531,7 @@ public class Syn1ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _parameters = JsonUtil.getProperty(json, "parameters");
-			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
+			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, JsonUtil.JsonType.OBJECT)) {
 				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
 					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReader.java
@@ -239,7 +239,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
 			if (JsonUtil.isJsonNode(_defaultValue)) {
-				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
+				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue));
 				JsonUtil.removeProperty(json, "defaultValue");
 			}
 		}
@@ -282,7 +282,7 @@ public class Syn1ModelReader implements ModelReader {
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
 			if (JsonUtil.isJsonNode(_items)) {
-				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
+				node.setItems(this.readBooleanSchemaSchemaListUnion(_items));
 				JsonUtil.removeProperty(json, "items");
 			}
 		}
@@ -295,7 +295,7 @@ public class Syn1ModelReader implements ModelReader {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
 						if (model != null)
 							node.addProperty(_key, model);
 					}
@@ -310,7 +310,7 @@ public class Syn1ModelReader implements ModelReader {
 				List<BooleanSchemaUnion> _items = new ArrayList<>();
 				boolean _valid = true;
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i), null);
+					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i));
 					if (_result == null) {
 						_valid = false;
 						break;
@@ -334,7 +334,7 @@ public class Syn1ModelReader implements ModelReader {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
 						if (model != null)
 							node.addDefinition(_key, model);
 					}
@@ -567,7 +567,7 @@ public class Syn1ModelReader implements ModelReader {
 		return null;
 	}
 
-	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -585,18 +585,18 @@ public class Syn1ModelReader implements ModelReader {
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), null);
 		}
 		return null;
 	}
 
-	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn1Schema node = new Syn1SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), null);
 		}
 		return null;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Document.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Document.java
@@ -16,6 +16,14 @@ public interface Syn2Document extends SynDocument, Syn2Extensible {
 
 	public void removeWebhook(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertWebhook(String name, Syn2PathItem value, int atIndex);
 
 	public Map<String, JsonNode> getExtensions();
@@ -26,5 +34,13 @@ public interface Syn2Document extends SynDocument, Syn2Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -102,6 +102,14 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertItem(SynItem value, int atIndex) {
 		if (this.items == null) {
@@ -174,6 +182,14 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertWebhook(String name, Syn2PathItem value, int atIndex) {
 		if (this.webhooks == null) {
@@ -247,6 +263,14 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -106,10 +106,8 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void insertItem(SynItem value, int atIndex) {
 		if (this.items == null) {
 			this.items = new ArrayList<>();
-			this.items.add(value);
-		} else {
-			this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		}
+		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 		}
@@ -180,10 +178,8 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void insertWebhook(String name, Syn2PathItem value, int atIndex) {
 		if (this.webhooks == null) {
 			this.webhooks = new LinkedHashMap<>();
-			this.webhooks.put(name, value);
-		} else {
-			this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
 		}
+		this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
 		}
@@ -255,10 +251,8 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -8,12 +8,10 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynInfo;
 import io.test.synthetic.SynItem;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,9 +45,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void setInfo(SynInfo value) {
 		this.info = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "info", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -77,9 +73,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.items = new ArrayList<>();
 		}
 		this.items.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 
 	@Override
@@ -116,9 +110,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.items = new ArrayList<>();
 		}
 		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 
 	@Override
@@ -159,9 +151,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.webhooks = new LinkedHashMap<>();
 		}
 		this.webhooks.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -196,9 +186,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 			this.webhooks = new LinkedHashMap<>();
 		}
 		this.webhooks = DataModelUtil.insertMapEntry(this.webhooks, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "webhooks", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -209,31 +197,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 	@Override
 	public void setAdditionalSchema(SchemaOrBoolean value) {
 		this.additionalSchema = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "additionalSchema", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "additionalSchema", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "additionalSchema", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2DocumentImpl.java
@@ -109,7 +109,7 @@ public class Syn2DocumentImpl extends NodeImpl implements Syn2Document {
 		if (this.items == null) {
 			this.items = new ArrayList<>();
 		}
-		this.items = DataModelUtil.insertListEntry(this.items, value, atIndex);
+		DataModelUtil.insertListEntry(this.items, value, atIndex);
 		DataModelUtil.setParent(value, this, "items", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Info.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Info.java
@@ -18,5 +18,13 @@ public interface Syn2Info extends SynInfo, Syn2Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -37,9 +37,7 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	@Override
 	public void setContact(SynContact value) {
 		this.contact = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "contact", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -96,6 +96,14 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2InfoImpl.java
@@ -100,10 +100,8 @@ public class Syn2InfoImpl extends NodeImpl implements Syn2Info {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Item.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Item.java
@@ -22,5 +22,13 @@ public interface Syn2Item extends SynItem, Syn2Extensible, Syn2Referenceable {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -7,11 +7,9 @@ import io.test.synthetic.Node;
 import io.test.synthetic.NodeImpl;
 import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.SynSchema;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,9 +108,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	@Override
 	public void setSchema(SynSchema value) {
 		this.schema = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "schema", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -140,31 +136,7 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	@Override
 	public void setDefaultValue(BooleanSchemaUnion value) {
 		this.defaultValue = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "defaultValue", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "defaultValue", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "defaultValue", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -218,10 +218,8 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2ItemImpl.java
@@ -214,6 +214,14 @@ public class Syn2ItemImpl extends NodeImpl implements Syn2Item {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Operation.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Operation.java
@@ -14,5 +14,13 @@ public interface Syn2Operation extends SynOperation, Syn2Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -99,10 +99,8 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	public void insertParameter(SynItem value, int atIndex) {
 		if (this.parameters == null) {
 			this.parameters = new ArrayList<>();
-			this.parameters.add(value);
-		} else {
-			this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		}
+		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 		}
@@ -139,10 +137,8 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -70,9 +70,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 			this.parameters = new ArrayList<>();
 		}
 		this.parameters.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 
 	@Override
@@ -109,9 +107,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 			this.parameters = new ArrayList<>();
 		}
 		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -95,6 +95,14 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertParameter(SynItem value, int atIndex) {
 		if (this.parameters == null) {
@@ -133,6 +141,14 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2OperationImpl.java
@@ -106,7 +106,7 @@ public class Syn2OperationImpl extends NodeImpl implements Syn2Operation {
 		if (this.parameters == null) {
 			this.parameters = new ArrayList<>();
 		}
-		this.parameters = DataModelUtil.insertListEntry(this.parameters, value, atIndex);
+		DataModelUtil.insertListEntry(this.parameters, value, atIndex);
 		DataModelUtil.setParent(value, this, "parameters", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItem.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItem.java
@@ -24,5 +24,13 @@ public interface Syn2PathItem extends SynPathItem, Syn2Extensible, Syn2Reference
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -131,10 +131,8 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -49,9 +49,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	@Override
 	public void setGet(SynOperation value) {
 		this.get = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "get", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -69,9 +67,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	@Override
 	public void setPut(SynOperation value) {
 		this.put = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "put", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -82,9 +78,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	@Override
 	public void setPost(SynOperation value) {
 		this.post = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "post", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -95,9 +89,7 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 	@Override
 	public void setDelete(Syn2Operation value) {
 		this.delete = value;
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "delete", ParentPropertyType.standard);
-		}
+		DataModelUtil.setParent(value, this, "delete", ParentPropertyType.standard);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathItemImpl.java
@@ -127,6 +127,14 @@ public class Syn2PathItemImpl extends NodeImpl implements Syn2PathItem {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Paths.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Paths.java
@@ -14,5 +14,13 @@ public interface Syn2Paths extends SynPaths, Syn2Extensible {
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -105,6 +105,14 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2PathsImpl.java
@@ -109,10 +109,8 @@ public class Syn2PathsImpl extends NodeImpl implements Syn2Paths {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Schema.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2Schema.java
@@ -19,5 +19,13 @@ public interface Syn2Schema extends RootCapable, SynSchema, Syn2Extensible, Syn2
 
 	public void removeExtension(String name);
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	public void insertExtension(String name, JsonNode value, int atIndex);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -10,12 +10,10 @@ import io.test.synthetic.ParentPropertyType;
 import io.test.synthetic.RootCapableImpl;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynSchema;
-import io.test.synthetic.union.UnionValue;
 import io.test.synthetic.util.DataModelUtil;
 import io.test.synthetic.v2.visitors.Syn2Visitor;
 import io.test.synthetic.visitors.Visitor;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,31 +65,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	@Override
 	public void setItems(BooleanSchemaSchemaListUnion value) {
 		this.items = value;
-		if (value != null) {
-			if (value.isEntity()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-			} else if (value.isEntityList()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-				List<?> entityList = (List<?>) ((UnionValue<?>) value).getValue();
-				for (Object entity : entityList) {
-					if (entity != null) {
-						DataModelUtil.setParent(entity, this, "items", ParentPropertyType.array);
-					}
-				}
-			} else if (value.isEntityMap()) {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-				Map<String, ?> entityMap = (Map<String, ?>) ((UnionValue<?>) value).getValue();
-				Collection<String> keys = entityMap.keySet();
-				for (String key : keys) {
-					Object entity = entityMap.get(key);
-					if (entity != null) {
-						DataModelUtil.setParentMap(entity, this, "items", ParentPropertyType.map, key);
-					}
-				}
-			} else {
-				DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
-			}
-		}
+		DataModelUtil.setParent(value, this, "items", ParentPropertyType.standard);
 	}
 
 	@Override
@@ -112,9 +86,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -149,9 +121,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.properties = new LinkedHashMap<>();
 		}
 		this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -165,9 +135,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
 	@Override
@@ -204,9 +172,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.allOf = new ArrayList<>();
 		}
 		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
 	@Override
@@ -220,9 +186,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -257,9 +221,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.definitions = new LinkedHashMap<>();
 		}
 		this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -273,9 +235,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas.put(name, value);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -310,9 +270,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.nestedSchemas = new LinkedHashMap<>();
 		}
 		this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
-		}
+		DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 	}
 
 	@Override
@@ -326,9 +284,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.composedSchemas = new ArrayList<>();
 		}
 		this.composedSchemas.add(value);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 
 	@Override
@@ -365,9 +321,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 			this.composedSchemas = new ArrayList<>();
 		}
 		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
-		if (value != null) {
-			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
-		}
+		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -171,7 +171,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		if (this.allOf == null) {
 			this.allOf = new ArrayList<>();
 		}
-		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
+		DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 	}
 
@@ -320,7 +320,7 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		if (this.composedSchemas == null) {
 			this.composedSchemas = new ArrayList<>();
 		}
-		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
+		DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -135,6 +135,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.properties == null) {
@@ -182,6 +190,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
 		if (this.allOf == null) {
@@ -227,6 +243,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.definitions == null) {
@@ -272,6 +296,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
 		if (this.nestedSchemas == null) {
@@ -319,6 +351,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
 		if (this.composedSchemas == null) {
@@ -387,6 +427,14 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 		}
 	}
 
+	/**
+	 * Inserts an item at the given index.
+	 * 
+	 * @param atIndex
+	 *            insertion position: &lt;= 0 inserts at the beginning, &gt;= size
+	 *            inserts at the end, otherwise inserts at the given position
+	 *            shifting existing items to the right
+	 */
 	@Override
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/Syn2SchemaImpl.java
@@ -139,10 +139,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertProperty(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.properties == null) {
 			this.properties = new LinkedHashMap<>();
-			this.properties.put(name, value);
-		} else {
-			this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		}
+		this.properties = DataModelUtil.insertMapEntry(this.properties, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "properties", ParentPropertyType.map, name);
 		}
@@ -188,10 +186,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertAllOf(BooleanSchemaUnion value, int atIndex) {
 		if (this.allOf == null) {
 			this.allOf = new ArrayList<>();
-			this.allOf.add(value);
-		} else {
-			this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		}
+		this.allOf = DataModelUtil.insertListEntry(this.allOf, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "allOf", ParentPropertyType.array);
 		}
@@ -235,10 +231,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertDefinition(String name, BooleanSchemaUnion value, int atIndex) {
 		if (this.definitions == null) {
 			this.definitions = new LinkedHashMap<>();
-			this.definitions.put(name, value);
-		} else {
-			this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		}
+		this.definitions = DataModelUtil.insertMapEntry(this.definitions, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "definitions", ParentPropertyType.map, name);
 		}
@@ -282,10 +276,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertNestedSchema(String name, SchemaOrBoolean value, int atIndex) {
 		if (this.nestedSchemas == null) {
 			this.nestedSchemas = new LinkedHashMap<>();
-			this.nestedSchemas.put(name, value);
-		} else {
-			this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		}
+		this.nestedSchemas = DataModelUtil.insertMapEntry(this.nestedSchemas, name, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParentMap(value, this, "nestedSchemas", ParentPropertyType.map, name);
 		}
@@ -331,10 +323,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertComposedSchema(SchemaOrBoolean value, int atIndex) {
 		if (this.composedSchemas == null) {
 			this.composedSchemas = new ArrayList<>();
-			this.composedSchemas.add(value);
-		} else {
-			this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		}
+		this.composedSchemas = DataModelUtil.insertListEntry(this.composedSchemas, value, atIndex);
 		if (value != null) {
 			DataModelUtil.setParent(value, this, "composedSchemas", ParentPropertyType.array);
 		}
@@ -401,10 +391,8 @@ public class Syn2SchemaImpl extends RootCapableImpl implements Syn2Schema {
 	public void insertExtension(String name, JsonNode value, int atIndex) {
 		if (this.extensions == null) {
 			this.extensions = new LinkedHashMap<>();
-			this.extensions.put(name, value);
-		} else {
-			this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 		}
+		this.extensions = DataModelUtil.insertMapEntry(this.extensions, name, value, atIndex);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -46,7 +46,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
-			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, "object")) {
+			if (JsonUtil.isArray(_items) && JsonUtil.allMatch(_items, JsonUtil.JsonType.OBJECT)) {
 				List<JsonNode> _nodes = JsonUtil.toList(_items);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
 					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));
@@ -59,7 +59,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _tags = JsonUtil.getProperty(json, "tags");
-			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, JsonUtil.JsonType.STRING)) {
 				List<String> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_tags);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -71,7 +71,8 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _metadata = JsonUtil.getProperty(json, "metadata");
-			if (JsonUtil.isObject(_metadata) && JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), "string")) {
+			if (JsonUtil.isObject(_metadata)
+					&& JsonUtil.allValuesMatch(JsonUtil.toObject(_metadata), JsonUtil.JsonType.STRING)) {
 				Map<String, String> items = new LinkedHashMap<>();
 				List<String> _keys = JsonUtil.keys(JsonUtil.toObject(_metadata));
 				for (int _i = 0; _i < _keys.size(); _i++) {
@@ -249,7 +250,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _examples = JsonUtil.getProperty(json, "examples");
-			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, "any")) {
+			if (JsonUtil.isArray(_examples) && JsonUtil.allMatch(_examples, JsonUtil.JsonType.ANY)) {
 				List<JsonNode> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_examples);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -427,7 +428,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _enum = JsonUtil.getProperty(json, "enum");
-			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, "any")) {
+			if (JsonUtil.isArray(_enum) && JsonUtil.allMatch(_enum, JsonUtil.JsonType.ANY)) {
 				List<JsonNode> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_enum);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -557,7 +558,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _tags = JsonUtil.getProperty(json, "tags");
-			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, "string")) {
+			if (JsonUtil.isArray(_tags) && JsonUtil.allMatch(_tags, JsonUtil.JsonType.STRING)) {
 				List<String> items = new ArrayList<>();
 				List<JsonNode> _nodes = JsonUtil.toList(_tags);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
@@ -569,7 +570,7 @@ public class Syn2ModelReader implements ModelReader {
 		}
 		{
 			JsonNode _parameters = JsonUtil.getProperty(json, "parameters");
-			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, "object")) {
+			if (JsonUtil.isArray(_parameters) && JsonUtil.allMatch(_parameters, JsonUtil.JsonType.OBJECT)) {
 				List<JsonNode> _nodes = JsonUtil.toList(_parameters);
 				for (int _i = 0; _i < _nodes.size(); _i++) {
 					ObjectNode object = JsonUtil.toObject(_nodes.get(_i));

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -263,7 +263,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _defaultValue = JsonUtil.getProperty(json, "defaultValue");
 			if (JsonUtil.isJsonNode(_defaultValue)) {
-				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue, null));
+				node.setDefaultValue(this.readBooleanSchemaUnion(_defaultValue));
 				JsonUtil.removeProperty(json, "defaultValue");
 			}
 		}
@@ -313,7 +313,7 @@ public class Syn2ModelReader implements ModelReader {
 		{
 			JsonNode _items = JsonUtil.getProperty(json, "items");
 			if (JsonUtil.isJsonNode(_items)) {
-				node.setItems(this.readBooleanSchemaSchemaListUnion(_items, null));
+				node.setItems(this.readBooleanSchemaSchemaListUnion(_items));
 				JsonUtil.removeProperty(json, "items");
 			}
 		}
@@ -326,7 +326,7 @@ public class Syn2ModelReader implements ModelReader {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
 						if (model != null)
 							node.addProperty(_key, model);
 					}
@@ -341,7 +341,7 @@ public class Syn2ModelReader implements ModelReader {
 				List<BooleanSchemaUnion> _items = new ArrayList<>();
 				boolean _valid = true;
 				for (int _i = 0; _i < _nodes.size(); _i++) {
-					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i), null);
+					BooleanSchemaUnion _result = this.readBooleanSchemaUnion(_nodes.get(_i));
 					if (_result == null) {
 						_valid = false;
 						break;
@@ -365,7 +365,7 @@ public class Syn2ModelReader implements ModelReader {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
-						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val, null);
+						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
 						if (model != null)
 							node.addDefinition(_key, model);
 					}
@@ -606,7 +606,7 @@ public class Syn2ModelReader implements ModelReader {
 		return null;
 	}
 
-	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json, ModelType modelType) {
+	private BooleanSchemaSchemaListUnion readBooleanSchemaSchemaListUnion(JsonNode json) {
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
@@ -624,18 +624,18 @@ public class Syn2ModelReader implements ModelReader {
 			SchemaListUnionValueImpl unionValue = new SchemaListUnionValueImpl((List) models);
 			return unionValue;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), null);
 		}
 		return null;
 	}
 
-	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json, ModelType modelType) {
+	private BooleanSchemaUnion readBooleanSchemaUnion(JsonNode json) {
 		if (JsonUtil.isObjectWithProperty(json, "type")) {
 			Syn2Schema node = new Syn2SchemaImpl();
 			this.readSchema((ObjectNode) json, node);
 			return node;
 		} else if (JsonUtil.isBoolean(json)) {
-			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), modelType);
+			return new BooleanUnionValueImpl(JsonUtil.toBoolean(json), null);
 		}
 		return null;
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReader.java
@@ -322,16 +322,26 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_properties)) {
 				ObjectNode _obj = JsonUtil.toObject(_properties);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, BooleanSchemaUnion> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
-						if (model != null)
-							node.addProperty(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "properties");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addProperty(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "properties");
+				}
 			}
 		}
 		{
@@ -361,16 +371,26 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_definitions)) {
 				ObjectNode _obj = JsonUtil.toObject(_definitions);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, BooleanSchemaUnion> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						BooleanSchemaUnion model = this.readBooleanSchemaUnion(_val);
-						if (model != null)
-							node.addDefinition(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "definitions");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addDefinition(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "definitions");
+				}
 			}
 		}
 		{
@@ -378,16 +398,26 @@ public class Syn2ModelReader implements ModelReader {
 			if (JsonUtil.isObject(_nestedSchemas)) {
 				ObjectNode _obj = JsonUtil.toObject(_nestedSchemas);
 				List<String> _keys = JsonUtil.keys(_obj);
+				java.util.LinkedHashMap<String, SchemaOrBoolean> _items = new java.util.LinkedHashMap<>();
+				boolean _valid = true;
 				for (int _i = 0; _i < _keys.size(); _i++) {
 					String _key = _keys.get(_i);
 					JsonNode _val = JsonUtil.getProperty(_obj, _key);
 					if (JsonUtil.isJsonNode(_val)) {
 						SchemaOrBoolean model = this.readSchemaOrBoolean(_val, null);
-						if (model != null)
-							node.addNestedSchema(_key, model);
+						if (model == null) {
+							_valid = false;
+							break;
+						}
+						_items.put(_key, model);
 					}
 				}
-				JsonUtil.removeProperty(json, "nestedSchemas");
+				if (_valid) {
+					for (String _key : _items.keySet()) {
+						node.addNestedSchema(_key, _items.get(_key));
+					}
+					JsonUtil.removeProperty(json, "nestedSchemas");
+				}
 			}
 		}
 		{


### PR DESCRIPTION
## Summary

Continued C35b generated code cleanup:

1. **Insert method** — separate null init from insert call (insertMapEntry/insertListEntry already handle empty collections)

2. **JsonUtil.JsonType enum** — replaces string-based type dispatch in `allMatch`/`allValuesMatch`. Eliminates duplicated if/else chains. TS JsonUtil synced with namespace-based `JsonType` class.

3. **Conditional ModelType parameter** — union reader methods only include `ModelType` parameter when the union type is marked as root. Non-root unions (e.g. `string|[string]`) no longer carry the unused parameter.
   - `readJsonSchema(JsonNode json, ModelType modelType)` — root union, keeps param
   - `readStringStringListUnion(JsonNode json)` — non-root, no param

## Context

C35b continuation in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated output compiles