### PR TITLE
feat: DiffTraverser path tracking via dual TraversalContext + PairingKey (C36b)

### DIFF
--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -54,16 +54,14 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
         String baseFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.AbstractDiffTraverser";
         JavaClassSource baseSource = getState().getJavaIndex().lookupClass(baseFQN);
         classSource.addImport(baseSource);
+        String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
+        classSource.addImport(pairingKeyFQN);
         classSource.addTypeVariable("P");
         classSource.setSuperType("AbstractDiffTraverser<P, " + visitorClassName + "<P>>");
 
         // Import CollectionDiff for collection field handling
         String collectionDiffFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.CollectionDiff";
         classSource.addImport(collectionDiffFQN);
-
-        String nodeFQN = getNodeEntityInterfaceFQN();
-        JavaInterfaceSource nodeSource = getState().getJavaIndex().lookupInterface(nodeFQN);
-        classSource.addImport(nodeSource);
 
         // Import PairingStrategyProvider
         String providerFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingStrategyProvider";
@@ -239,16 +237,20 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
 
             body.addContext("getter", getter);
             body.addContext("diffMethod", diffMethod);
+            body.addContext("propertyNameLiteral", property.getName());
 
             NamespaceModel ns = propWithOrigin.getOrigin().getNamespace();
+
+            body.append("{");
+            body.append("    pushProperty(\"${propertyNameLiteral}\");");
 
             if (isEntity(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("if (original.${getter}() != null && updated.${getter}() != null) {");
-                body.append("    traverse(original.${getter}(), updated.${getter}());");
-                body.append("}");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    if (original.${getter}() != null && updated.${getter}() != null) {");
+                body.append("        traverse(original.${getter}(), updated.${getter}());");
+                body.append("    }");
             } else if (isEntityList(property) || isUnionList(property)) {
                 ListType listType = (ListType) property.getResolvedType();
                 JavaType valueJt = jtf.createJavaType(listType.getValueType(), ns);
@@ -260,10 +262,10 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.addContext("visitMethod2", visitMethod);
                 body.addContext("propertyName", property.getName());
 
-                body.append("{");
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairList(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
+                body.append("        pushElement((PairingKey) pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityList(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -276,8 +278,8 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                     body.addContext("traverseUnion", traverseUnion);
                     body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        pop();");
                 body.append("    }");
-                body.append("}");
             } else if (isEntityMap(property) || isUnionMap(property)) {
                 MapType mapType = (MapType) property.getResolvedType();
                 JavaType valueJt = jtf.createJavaType(mapType.getValueType(), ns);
@@ -289,10 +291,10 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.addContext("visitMethod2", visitMethod);
                 body.addContext("propertyName", property.getName());
 
-                body.append("{");
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
+                body.append("        pushElement((PairingKey) pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -305,20 +307,23 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                     body.addContext("traverseUnion", traverseUnion);
                     body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        pop();");
                 body.append("    }");
-                body.append("}");
             } else if (isUnion(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
                 String traverseUnion = "traverse" + jt.getSimpleName();
                 body.addContext("traverseUnion", traverseUnion);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("this.${traverseUnion}(original.${getter}(), updated.${getter}());");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    this.${traverseUnion}(original.${getter}(), updated.${getter}());");
             } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
             }
+
+            body.append("    pop();");
+            body.append("}");
         }
 
         method.setBody(body.toString());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -56,7 +56,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
         classSource.addImport(baseSource);
         String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
         classSource.addImport(pairingKeyFQN);
-        classSource.addTypeVariable("P");
+        classSource.addTypeVariable("P").setBounds("PairingKey");
         classSource.setSuperType("AbstractDiffTraverser<P, " + visitorClassName + "<P>>");
 
         // Import CollectionDiff for collection field handling
@@ -265,7 +265,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairList(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushElement((PairingKey) pair.getKey());");
+                body.append("        pushListIndex(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityList(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -294,7 +294,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushElement((PairingKey) pair.getKey());");
+                body.append("        pushMapIndex(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -294,7 +294,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushMapIndex(pair.getKey());");
+                body.append("        pushMapKey(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -43,7 +43,7 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
 
         String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
         classSource.addImport(pairingKeyFQN);
-        classSource.addTypeVariable("P");
+        classSource.addTypeVariable("P").setBounds("PairingKey");
 
         JavaTypeFactory jtf = getJavaTypeFactory();
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -41,6 +41,8 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
                 .setPublic()
                 .setAbstract(true);
 
+        String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
+        classSource.addImport(pairingKeyFQN);
         classSource.addTypeVariable("P");
 
         JavaTypeFactory jtf = getJavaTypeFactory();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
@@ -72,6 +72,7 @@ public class LoadBaseClassesStage extends AbstractStage {
                     "io.apitomy.umg.base.union.StringListUnionValue",
                     "io.apitomy.umg.base.visitors.diff.ListPairingStrategy",
                     "io.apitomy.umg.base.visitors.diff.MapPairingStrategy",
+                    "io.apitomy.umg.base.visitors.diff.PairingKey",
                     "io.apitomy.umg.base.visitors.diff.PairingStrategyProvider",
 
                     "io.apitomy.umg.base.union.Union",

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -53,7 +53,7 @@ public class AbstractDiffTraverser<P extends PairingKey, V> {
         updatedContext.pushProperty(propertyName);
     }
 
-    protected void pushMapIndex(PairingKey key) {
+    protected void pushMapKey(PairingKey key) {
         if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
             throw new IllegalStateException("Map pairing key must have both original and updated keys");
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -14,7 +14,7 @@ import io.apitomy.umg.base.visitors.TraversalContextImpl;
  * @param <P> the pairing key type
  * @param <V> the spec-version-specific DiffVisitor subclass
  */
-public class AbstractDiffTraverser<P, V> {
+public class AbstractDiffTraverser<P extends PairingKey, V> {
 
     protected final V visitor;
     protected final PairingStrategyProvider<P> pairingProvider;
@@ -53,20 +53,20 @@ public class AbstractDiffTraverser<P, V> {
         updatedContext.pushProperty(propertyName);
     }
 
-    /**
-     * Push collection element positions onto the respective contexts.
-     */
-    protected void pushElement(PairingKey key) {
-        if (key.getOriginalKey() != null) {
-            originalContext.pushMapIndex(key.getOriginalKey());
-        } else if (key.getOriginalIndex() != null) {
-            originalContext.pushListIndex(key.getOriginalIndex());
+    protected void pushMapIndex(PairingKey key) {
+        if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
+            throw new IllegalStateException("Map pairing key must have both original and updated keys");
         }
-        if (key.getUpdatedKey() != null) {
-            updatedContext.pushMapIndex(key.getUpdatedKey());
-        } else if (key.getUpdatedIndex() != null) {
-            updatedContext.pushListIndex(key.getUpdatedIndex());
+        originalContext.pushMapIndex(key.getOriginalKey());
+        updatedContext.pushMapIndex(key.getUpdatedKey());
+    }
+
+    protected void pushListIndex(PairingKey key) {
+        if (key.getOriginalIndex() == null || key.getUpdatedIndex() == null) {
+            throw new IllegalStateException("List pairing key must have both original and updated indices");
         }
+        originalContext.pushListIndex(key.getOriginalIndex());
+        updatedContext.pushListIndex(key.getUpdatedIndex());
     }
 
     /**

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -4,11 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import io.apitomy.umg.base.Any;
+import io.apitomy.umg.base.visitors.TraversalContext;
+import io.apitomy.umg.base.visitors.TraversalContextImpl;
 
 /**
- * Base class for generated diff traversers. Provides shared collection pairing logic.
- * Subclasses (generated per spec version) provide entity-specific field iteration
- * and call typed visitor methods.
+ * Base class for generated diff traversers. Provides shared collection pairing logic
+ * and path tracking via two TraversalContext instances (one per side).
  *
  * @param <P> the pairing key type
  * @param <V> the spec-version-specific DiffVisitor subclass
@@ -17,23 +18,65 @@ public class AbstractDiffTraverser<P, V> {
 
     protected final V visitor;
     protected final PairingStrategyProvider<P> pairingProvider;
+    protected final TraversalContextImpl originalContext;
+    protected final TraversalContextImpl updatedContext;
 
     @SuppressWarnings("unchecked")
     protected AbstractDiffTraverser(V visitor) {
         this.visitor = visitor;
         this.pairingProvider = (PairingStrategyProvider<P>) new DefaultPairingStrategyProvider();
+        this.originalContext = new TraversalContextImpl();
+        this.updatedContext = new TraversalContextImpl();
     }
 
+    @SuppressWarnings("unchecked")
     protected AbstractDiffTraverser(V visitor, PairingStrategyProvider<P> pairingProvider) {
         this.visitor = visitor;
         this.pairingProvider = pairingProvider;
+        this.originalContext = new TraversalContextImpl();
+        this.updatedContext = new TraversalContextImpl();
+    }
+
+    public TraversalContext getOriginalContext() {
+        return originalContext;
+    }
+
+    public TraversalContext getUpdatedContext() {
+        return updatedContext;
     }
 
     /**
-     * Public entry point — accepts Any (Node or Union).
-     * Generated subclasses override this with type-based dispatch
-     * to union traverse methods and entity traverse methods.
+     * Push a property name onto both contexts (shared by both sides).
      */
+    protected void pushProperty(String propertyName) {
+        originalContext.pushProperty(propertyName);
+        updatedContext.pushProperty(propertyName);
+    }
+
+    /**
+     * Push collection element positions onto the respective contexts.
+     */
+    protected void pushElement(PairingKey key) {
+        if (key.getOriginalKey() != null) {
+            originalContext.pushMapIndex(key.getOriginalKey());
+        } else if (key.getOriginalIndex() != null) {
+            originalContext.pushListIndex(key.getOriginalIndex());
+        }
+        if (key.getUpdatedKey() != null) {
+            updatedContext.pushMapIndex(key.getUpdatedKey());
+        } else if (key.getUpdatedIndex() != null) {
+            updatedContext.pushListIndex(key.getUpdatedIndex());
+        }
+    }
+
+    /**
+     * Pop from both contexts.
+     */
+    protected void pop() {
+        originalContext.pop();
+        updatedContext.pop();
+    }
+
     public void traverse(Any original, Any updated) {
     }
 
@@ -46,5 +89,4 @@ public class AbstractDiffTraverser<P, V> {
         ListPairingStrategy<P, T> strategy = pairingProvider.getListStrategy(propertyName);
         return strategy.pair(original, updated);
     }
-
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/CollectionDiff.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/CollectionDiff.java
@@ -11,31 +11,31 @@ import java.util.Set;
  * Result of pairing two collections. Contains entries that were added, removed,
  * or matched between the original and updated collections.
  *
- * @param <K> the key type (String for maps, Integer for lists)
- * @param <V> the value type
+ * @param <P> the pairing key type (String for maps, Integer for lists)
+ * @param <T> the value type
  */
-public class CollectionDiff<K, V> {
+public class CollectionDiff<P, T> {
 
-    private final List<Entry<K, V>> added;
-    private final List<Entry<K, V>> removed;
-    private final List<MatchedPair<K, V>> matched;
+    private final List<Entry<P, T>> added;
+    private final List<Entry<P, T>> removed;
+    private final List<MatchedPair<P, T>> matched;
 
-    public CollectionDiff(List<Entry<K, V>> added, List<Entry<K, V>> removed,
-            List<MatchedPair<K, V>> matched) {
+    public CollectionDiff(List<Entry<P, T>> added, List<Entry<P, T>> removed,
+            List<MatchedPair<P, T>> matched) {
         this.added = added;
         this.removed = removed;
         this.matched = matched;
     }
 
-    public List<Entry<K, V>> getAdded() {
+    public List<Entry<P, T>> getAdded() {
         return added;
     }
 
-    public List<Entry<K, V>> getRemoved() {
+    public List<Entry<P, T>> getRemoved() {
         return removed;
     }
 
-    public List<MatchedPair<K, V>> getMatched() {
+    public List<MatchedPair<P, T>> getMatched() {
         return matched;
     }
 
@@ -47,19 +47,19 @@ public class CollectionDiff<K, V> {
      * Pairs two maps by key. Entries with matching keys are paired;
      * keys in only one map are classified as added or removed.
      */
-    public static <K, V> CollectionDiff<K, V> pairByKey(Map<K, V> original, Map<K, V> updated) {
-        Map<K, V> orig = original != null ? original : new LinkedHashMap<>();
-        Map<K, V> upd = updated != null ? updated : new LinkedHashMap<>();
+    public static <P, T> CollectionDiff<P, T> pairByKey(Map<P, T> original, Map<P, T> updated) {
+        Map<P, T> orig = original != null ? original : new LinkedHashMap<>();
+        Map<P, T> upd = updated != null ? updated : new LinkedHashMap<>();
 
-        Set<K> allKeys = new LinkedHashSet<>();
+        Set<P> allKeys = new LinkedHashSet<>();
         allKeys.addAll(orig.keySet());
         allKeys.addAll(upd.keySet());
 
-        List<Entry<K, V>> added = new ArrayList<>();
-        List<Entry<K, V>> removed = new ArrayList<>();
-        List<MatchedPair<K, V>> matched = new ArrayList<>();
+        List<Entry<P, T>> added = new ArrayList<>();
+        List<Entry<P, T>> removed = new ArrayList<>();
+        List<MatchedPair<P, T>> matched = new ArrayList<>();
 
-        for (K key : allKeys) {
+        for (P key : allKeys) {
             boolean inOrig = orig.containsKey(key);
             boolean inUpd = upd.containsKey(key);
             if (inOrig && inUpd) {
@@ -74,32 +74,32 @@ public class CollectionDiff<K, V> {
         return new CollectionDiff<>(added, removed, matched);
     }
 
-    public static class Entry<K, V> {
-        private final K key;
-        private final V value;
+    public static class Entry<P, T> {
+        private final P key;
+        private final T value;
 
-        public Entry(K key, V value) {
+        public Entry(P key, T value) {
             this.key = key;
             this.value = value;
         }
 
-        public K getKey() { return key; }
-        public V getValue() { return value; }
+        public P getKey() { return key; }
+        public T getValue() { return value; }
     }
 
-    public static class MatchedPair<K, V> {
-        private final K key;
-        private final V original;
-        private final V updated;
+    public static class MatchedPair<P, T> {
+        private final P key;
+        private final T original;
+        private final T updated;
 
-        public MatchedPair(K key, V original, V updated) {
+        public MatchedPair(P key, T original, T updated) {
             this.key = key;
             this.original = original;
             this.updated = updated;
         }
 
-        public K getKey() { return key; }
-        public V getOriginal() { return original; }
-        public V getUpdated() { return updated; }
+        public P getKey() { return key; }
+        public T getOriginal() { return original; }
+        public T getUpdated() { return updated; }
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultListPairingStrategy.java
@@ -7,16 +7,16 @@ import java.util.Map;
 /**
  * Default list pairing strategy — pairs entries by index.
  */
-public class DefaultListPairingStrategy<V> implements ListPairingStrategy<DefaultPairingKey, V> {
+public class DefaultListPairingStrategy<T> implements ListPairingStrategy<DefaultPairingKey, T> {
 
     @Override
-    public CollectionDiff<DefaultPairingKey, V> pair(List<V> original, List<V> updated) {
+    public CollectionDiff<DefaultPairingKey, T> pair(List<T> original, List<T> updated) {
         return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
     }
 
-    private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(List<V> list) {
+    private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(List<T> list) {
         if (list == null) return new LinkedHashMap<>();
-        Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
+        Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
         for (int i = 0; i < list.size(); i++) {
             res.put(new DefaultPairingKey(i), list.get(i));
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultMapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultMapPairingStrategy.java
@@ -7,17 +7,17 @@ import java.util.Map;
 /**
  * Default map pairing strategy — pairs entries by key.
  */
-public class DefaultMapPairingStrategy<V> implements MapPairingStrategy<DefaultPairingKey, V> {
+public class DefaultMapPairingStrategy<T> implements MapPairingStrategy<DefaultPairingKey, T> {
 
     @Override
-    public CollectionDiff<DefaultPairingKey, V> pair(Map<String, V> original, Map<String, V> updated) {
+    public CollectionDiff<DefaultPairingKey, T> pair(Map<String, T> original, Map<String, T> updated) {
         return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
     }
 
-    private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(Map<String, V>  map) {
+    private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(Map<String, T>  map) {
         if (map == null) return new LinkedHashMap<>();
-        Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
-        for (Map.Entry<String, V> entry : map.entrySet()) {
+        Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
+        for (Map.Entry<String, T> entry : map.entrySet()) {
             res.put(new DefaultPairingKey(entry.getKey()), entry.getValue());
         }
         return res;

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingKey.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingKey.java
@@ -3,33 +3,42 @@ package io.apitomy.umg.base.visitors.diff;
 import java.util.Objects;
 
 /**
- * Default provider: key-based pairing for maps, index-based for lists.
+ * Default pairing key for index-based (lists) and key-based (maps) pairing.
+ * For the default strategies, original and updated positions are the same
+ * (same index or same key).
  */
-public class DefaultPairingKey {
+public class DefaultPairingKey implements PairingKey {
 
-    private Type type;
-    private Integer index;
-    private String key;
+    private final Integer index;
+    private final String key;
 
     public DefaultPairingKey(int index) {
-        type = Type.INDEX;
         this.index = index;
+        this.key = null;
     }
 
     public DefaultPairingKey(String key) {
-        type = Type.KEY;
+        this.index = null;
         this.key = key;
     }
 
-    public Type getType() {
-        return type;
-    }
-
-    public Integer getIndex() {
+    @Override
+    public Integer getOriginalIndex() {
         return index;
     }
 
-    public String getKey() {
+    @Override
+    public Integer getUpdatedIndex() {
+        return index;
+    }
+
+    @Override
+    public String getOriginalKey() {
+        return key;
+    }
+
+    @Override
+    public String getUpdatedKey() {
         return key;
     }
 
@@ -37,16 +46,16 @@ public class DefaultPairingKey {
     public boolean equals(Object o) {
         if (!(o instanceof DefaultPairingKey)) return false;
         DefaultPairingKey that = (DefaultPairingKey) o;
-        return type == that.type && Objects.equals(index, that.index) && Objects.equals(key, that.key);
+        return Objects.equals(index, that.index) && Objects.equals(key, that.key);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, index, key);
+        return Objects.hash(index, key);
     }
 
-    public enum Type {
-        INDEX,
-        KEY
+    @Override
+    public String toString() {
+        return key != null ? key : String.valueOf(index);
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingStrategyProvider.java
@@ -6,12 +6,12 @@ package io.apitomy.umg.base.visitors.diff;
 public class DefaultPairingStrategyProvider implements PairingStrategyProvider<DefaultPairingKey> {
 
     @Override
-    public <V> MapPairingStrategy<DefaultPairingKey, V> getMapStrategy(String propertyName) {
+    public <T> MapPairingStrategy<DefaultPairingKey, T> getMapStrategy(String propertyName) {
         return new DefaultMapPairingStrategy<>();
     }
 
     @Override
-    public <V> ListPairingStrategy<DefaultPairingKey, V> getListStrategy(String propertyName) {
+    public <T> ListPairingStrategy<DefaultPairingKey, T> getListStrategy(String propertyName) {
         return new DefaultListPairingStrategy<>();
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
@@ -8,7 +8,7 @@ import java.util.List;
  * @param <P> the pairing key type (e.g., Integer for index-based pairing)
  * @param <V> the value type
  */
-public interface ListPairingStrategy<P, V> {
+public interface ListPairingStrategy<P extends PairingKey, V> {
 
     CollectionDiff<P, V> pair(List<V> original, List<V> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
@@ -6,9 +6,9 @@ import java.util.List;
  * Strategy for pairing entries from two lists.
  *
  * @param <P> the pairing key type (e.g., Integer for index-based pairing)
- * @param <V> the value type
+ * @param <T> the value type
  */
-public interface ListPairingStrategy<P extends PairingKey, V> {
+public interface ListPairingStrategy<P extends PairingKey, T> {
 
-    CollectionDiff<P, V> pair(List<V> original, List<V> updated);
+    CollectionDiff<P, T> pair(List<T> original, List<T> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * @param <P> the pairing key type (e.g., String for key-based pairing)
  * @param <V> the value type
  */
-public interface MapPairingStrategy<P, V> {
+public interface MapPairingStrategy<P extends PairingKey, V> {
 
     CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
@@ -6,9 +6,9 @@ import java.util.Map;
  * Strategy for pairing entries from two maps.
  *
  * @param <P> the pairing key type (e.g., String for key-based pairing)
- * @param <V> the value type
+ * @param <T> the value type
  */
-public interface MapPairingStrategy<P extends PairingKey, V> {
+public interface MapPairingStrategy<P extends PairingKey, T> {
 
-    CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
+    CollectionDiff<P, T> pair(Map<String, T> original, Map<String, T> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingKey.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingKey.java
@@ -1,0 +1,42 @@
+package io.apitomy.umg.base.visitors.diff;
+
+/**
+ * Represents a pairing between elements from original and updated collections.
+ * Provides access to the original and updated positions as both indices and map keys.
+ */
+public interface PairingKey {
+
+    /**
+     * The index in the original list, or null if not applicable.
+     */
+    Integer getOriginalIndex();
+
+    /**
+     * The index in the updated list, or null if not applicable.
+     */
+    Integer getUpdatedIndex();
+
+    /**
+     * The key in the original map, or null if not applicable.
+     */
+    String getOriginalKey();
+
+    /**
+     * The key in the updated map, or null if not applicable.
+     */
+    String getUpdatedKey();
+
+    /**
+     * Returns the original position as a string (map key or index).
+     */
+    default String getOriginalPosition() {
+        return getOriginalKey() != null ? getOriginalKey() : String.valueOf(getOriginalIndex());
+    }
+
+    /**
+     * Returns the updated position as a string (map key or index).
+     */
+    default String getUpdatedPosition() {
+        return getUpdatedKey() != null ? getUpdatedKey() : String.valueOf(getUpdatedIndex());
+    }
+}

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
@@ -5,7 +5,7 @@ package io.apitomy.umg.base.visitors.diff;
  * Pass a custom provider to the DiffTraverser constructor to control how
  * map and list fields are paired.
  */
-public interface PairingStrategyProvider<P> {
+public interface PairingStrategyProvider<P extends PairingKey> {
 
     <V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
@@ -7,7 +7,7 @@ package io.apitomy.umg.base.visitors.diff;
  */
 public interface PairingStrategyProvider<P extends PairingKey> {
 
-    <V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
+    <T> MapPairingStrategy<P, T> getMapStrategy(String propertyName);
 
-    <V> ListPairingStrategy<P, V> getListStrategy(String propertyName);
+    <T> ListPairingStrategy<P, T> getListStrategy(String propertyName);
 }

--- a/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
+++ b/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
@@ -1436,4 +1436,5 @@ io/apitomy/datamodels/models/visitors/diff/DefaultPairingKey.java
 io/apitomy/datamodels/models/visitors/diff/DefaultPairingStrategyProvider.java
 io/apitomy/datamodels/models/visitors/diff/ListPairingStrategy.java
 io/apitomy/datamodels/models/visitors/diff/MapPairingStrategy.java
+io/apitomy/datamodels/models/visitors/diff/PairingKey.java
 io/apitomy/datamodels/models/visitors/diff/PairingStrategyProvider.java

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -265,7 +265,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -291,7 +291,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -304,7 +304,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
-import io.test.synthetic.Node;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynContact;
 import io.test.synthetic.SynInfo;
@@ -22,6 +21,7 @@ import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
@@ -72,25 +72,49 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
-		visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-		if (original.getInfo() != null && updated.getInfo() != null) {
-			traverse(original.getInfo(), updated.getInfo());
+		{
+			pushProperty("version");
+			visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
+			pop();
 		}
 		{
+			pushProperty("info");
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (original.getInfo() != null && updated.getInfo() != null) {
+				traverse(original.getInfo(), updated.getInfo());
+			}
+			pop();
+		}
+		{
+			pushProperty("items");
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentTags(original.getTags(), updated.getTags());
-		visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
-		visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-		this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+		{
+			pushProperty("tags");
+			visitor.diffDocumentTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("metadata");
+			visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
+			pop();
+		}
+		{
+			pushProperty("additionalSchema");
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			pop();
+		}
 	}
 
 	public void traverseInfo(Syn1Info original, Syn1Info updated) {
@@ -100,12 +124,24 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffInfoName(original.getName(), updated.getName());
-		visitor.diffInfoContact(original.getContact(), updated.getContact());
-		if (original.getContact() != null && updated.getContact() != null) {
-			traverse(original.getContact(), updated.getContact());
+		{
+			pushProperty("name");
+			visitor.diffInfoName(original.getName(), updated.getName());
+			pop();
 		}
-		visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+		{
+			pushProperty("contact");
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (original.getContact() != null && updated.getContact() != null) {
+				traverse(original.getContact(), updated.getContact());
+			}
+			pop();
+		}
+		{
+			pushProperty("version");
+			visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+			pop();
+		}
 	}
 
 	public void traverseContact(Syn1Contact original, Syn1Contact updated) {
@@ -115,9 +151,21 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffContactName(original.getName(), updated.getName());
-		visitor.diffContactEmail(original.getEmail(), updated.getEmail());
-		visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+		{
+			pushProperty("name");
+			visitor.diffContactName(original.getName(), updated.getName());
+			pop();
+		}
+		{
+			pushProperty("email");
+			visitor.diffContactEmail(original.getEmail(), updated.getEmail());
+			pop();
+		}
+		{
+			pushProperty("url");
+			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+			pop();
+		}
 	}
 
 	public void traverseItem(Syn1Item original, Syn1Item updated) {
@@ -127,21 +175,65 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffItemDescription(original.getDescription(), updated.getDescription());
-		visitor.diffItemRequired(original.isRequired(), updated.isRequired());
-		visitor.diffItemOrder(original.getOrder(), updated.getOrder());
-		visitor.diffItemWeight(original.getWeight(), updated.getWeight());
-		visitor.diffItemExtra(original.getExtra(), updated.getExtra());
-		visitor.diffItemRaw(original.getRaw(), updated.getRaw());
-		visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-		if (original.getSchema() != null && updated.getSchema() != null) {
-			traverse(original.getSchema(), updated.getSchema());
+		{
+			pushProperty("$ref");
+			visitor.diffItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffItemExamples(original.getExamples(), updated.getExamples());
-		visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-		this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
-		visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+		{
+			pushProperty("description");
+			visitor.diffItemDescription(original.getDescription(), updated.getDescription());
+			pop();
+		}
+		{
+			pushProperty("required");
+			visitor.diffItemRequired(original.isRequired(), updated.isRequired());
+			pop();
+		}
+		{
+			pushProperty("order");
+			visitor.diffItemOrder(original.getOrder(), updated.getOrder());
+			pop();
+		}
+		{
+			pushProperty("weight");
+			visitor.diffItemWeight(original.getWeight(), updated.getWeight());
+			pop();
+		}
+		{
+			pushProperty("extra");
+			visitor.diffItemExtra(original.getExtra(), updated.getExtra());
+			pop();
+		}
+		{
+			pushProperty("raw");
+			visitor.diffItemRaw(original.getRaw(), updated.getRaw());
+			pop();
+		}
+		{
+			pushProperty("schema");
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (original.getSchema() != null && updated.getSchema() != null) {
+				traverse(original.getSchema(), updated.getSchema());
+			}
+			pop();
+		}
+		{
+			pushProperty("examples");
+			visitor.diffItemExamples(original.getExamples(), updated.getExamples());
+			pop();
+		}
+		{
+			pushProperty("defaultValue");
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			pop();
+		}
+		{
+			pushProperty("title");
+			visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+			pop();
+		}
 	}
 
 	public void traverseSchema(Syn1Schema original, Syn1Schema updated) {
@@ -151,58 +243,102 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
-		visitor.diffSchemaType(original.getType(), updated.getType());
-		visitor.diffSchemaItems(original.getItems(), updated.getItems());
-		this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 		{
+			pushProperty("$ref");
+			visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
+			pop();
+		}
+		{
+			pushProperty("type");
+			visitor.diffSchemaType(original.getType(), updated.getType());
+			pop();
+		}
+		{
+			pushProperty("items");
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			pop();
+		}
+		{
+			pushProperty("properties");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("properties", original.getProperties(),
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("allOf");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairList("allOf", original.getAllOf(),
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("definitions");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("definitions", original.getDefinitions(),
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("nestedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairMap("nestedSchemas", original.getNestedSchemas(),
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("composedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairList("composedSchemas", original.getComposedSchemas(),
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
-		visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
-		visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
-		visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+		{
+			pushProperty("minLength");
+			visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
+			pop();
+		}
+		{
+			pushProperty("maxLength");
+			visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
+			pop();
+		}
+		{
+			pushProperty("enum");
+			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+			pop();
+		}
 	}
 
 	public void traversePaths(Syn1Paths original, Syn1Paths updated) {
@@ -221,19 +357,39 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
-		visitor.diffPathItemGet(original.getGet(), updated.getGet());
-		if (original.getGet() != null && updated.getGet() != null) {
-			traverse(original.getGet(), updated.getGet());
+		{
+			pushProperty("$ref");
+			visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffPathItemPut(original.getPut(), updated.getPut());
-		if (original.getPut() != null && updated.getPut() != null) {
-			traverse(original.getPut(), updated.getPut());
+		{
+			pushProperty("summary");
+			visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
+			pop();
 		}
-		visitor.diffPathItemPost(original.getPost(), updated.getPost());
-		if (original.getPost() != null && updated.getPost() != null) {
-			traverse(original.getPost(), updated.getPost());
+		{
+			pushProperty("get");
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (original.getGet() != null && updated.getGet() != null) {
+				traverse(original.getGet(), updated.getGet());
+			}
+			pop();
+		}
+		{
+			pushProperty("put");
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (original.getPut() != null && updated.getPut() != null) {
+				traverse(original.getPut(), updated.getPut());
+			}
+			pop();
+		}
+		{
+			pushProperty("post");
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (original.getPost() != null && updated.getPost() != null) {
+				traverse(original.getPost(), updated.getPost());
+			}
+			pop();
 		}
 	}
 
@@ -244,19 +400,35 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
-		visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
-		visitor.diffOperationTags(original.getTags(), updated.getTags());
 		{
+			pushProperty("operationId");
+			visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
+			pop();
+		}
+		{
+			pushProperty("summary");
+			visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
+			pop();
+		}
+		{
+			pushProperty("tags");
+			visitor.diffOperationTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("parameters");
 			CollectionDiff<P, SynItem> diff = this.pairList("parameters", original.getParameters(),
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -26,7 +26,7 @@ import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
 
-public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisitor<P>> {
+public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTraverser<P, Syn1DiffVisitor<P>> {
 
 	public Syn1DiffTraverser(Syn1DiffVisitor<P> visitor) {
 		super(visitor);
@@ -90,7 +90,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -265,7 +265,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -278,7 +278,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -291,7 +291,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -304,7 +304,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -317,7 +317,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -421,7 +421,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -23,7 +23,7 @@ import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Syn1DiffVisitor<P> {
+public abstract class Syn1DiffVisitor<P extends PairingKey> {
 
 	public boolean visitDocument(Syn1Document original, Syn1Document updated) {
 		return true;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
-import io.test.synthetic.Node;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynContact;
 import io.test.synthetic.SynInfo;
@@ -22,6 +21,7 @@ import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
@@ -72,36 +72,64 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
-		visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-		if (original.getInfo() != null && updated.getInfo() != null) {
-			traverse(original.getInfo(), updated.getInfo());
+		{
+			pushProperty("version");
+			visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
+			pop();
 		}
 		{
+			pushProperty("info");
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (original.getInfo() != null && updated.getInfo() != null) {
+				traverse(original.getInfo(), updated.getInfo());
+			}
+			pop();
+		}
+		{
+			pushProperty("items");
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentTags(original.getTags(), updated.getTags());
-		visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
 		{
+			pushProperty("tags");
+			visitor.diffDocumentTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("metadata");
+			visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
+			pop();
+		}
+		{
+			pushProperty("webhooks");
 			CollectionDiff<P, Syn2PathItem> diff = this.pairMap("webhooks", original.getWebhooks(),
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-		this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+		{
+			pushProperty("additionalSchema");
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			pop();
+		}
 	}
 
 	public void traverseInfo(Syn2Info original, Syn2Info updated) {
@@ -111,13 +139,29 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffInfoName(original.getName(), updated.getName());
-		visitor.diffInfoContact(original.getContact(), updated.getContact());
-		if (original.getContact() != null && updated.getContact() != null) {
-			traverse(original.getContact(), updated.getContact());
+		{
+			pushProperty("name");
+			visitor.diffInfoName(original.getName(), updated.getName());
+			pop();
 		}
-		visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
-		visitor.diffInfoLicense(original.getLicense(), updated.getLicense());
+		{
+			pushProperty("contact");
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (original.getContact() != null && updated.getContact() != null) {
+				traverse(original.getContact(), updated.getContact());
+			}
+			pop();
+		}
+		{
+			pushProperty("version");
+			visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+			pop();
+		}
+		{
+			pushProperty("license");
+			visitor.diffInfoLicense(original.getLicense(), updated.getLicense());
+			pop();
+		}
 	}
 
 	public void traverseContact(Syn2Contact original, Syn2Contact updated) {
@@ -127,9 +171,21 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffContactName(original.getName(), updated.getName());
-		visitor.diffContactEmail(original.getEmail(), updated.getEmail());
-		visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+		{
+			pushProperty("name");
+			visitor.diffContactName(original.getName(), updated.getName());
+			pop();
+		}
+		{
+			pushProperty("email");
+			visitor.diffContactEmail(original.getEmail(), updated.getEmail());
+			pop();
+		}
+		{
+			pushProperty("url");
+			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+			pop();
+		}
 	}
 
 	public void traverseItem(Syn2Item original, Syn2Item updated) {
@@ -139,22 +195,70 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffItemDescription(original.getDescription(), updated.getDescription());
-		visitor.diffItemRequired(original.isRequired(), updated.isRequired());
-		visitor.diffItemOrder(original.getOrder(), updated.getOrder());
-		visitor.diffItemWeight(original.getWeight(), updated.getWeight());
-		visitor.diffItemExtra(original.getExtra(), updated.getExtra());
-		visitor.diffItemRaw(original.getRaw(), updated.getRaw());
-		visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-		if (original.getSchema() != null && updated.getSchema() != null) {
-			traverse(original.getSchema(), updated.getSchema());
+		{
+			pushProperty("$ref");
+			visitor.diffItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffItemExamples(original.getExamples(), updated.getExamples());
-		visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-		this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
-		visitor.diffItemTitle(original.getTitle(), updated.getTitle());
-		visitor.diffItemDeprecated(original.isDeprecated(), updated.isDeprecated());
+		{
+			pushProperty("description");
+			visitor.diffItemDescription(original.getDescription(), updated.getDescription());
+			pop();
+		}
+		{
+			pushProperty("required");
+			visitor.diffItemRequired(original.isRequired(), updated.isRequired());
+			pop();
+		}
+		{
+			pushProperty("order");
+			visitor.diffItemOrder(original.getOrder(), updated.getOrder());
+			pop();
+		}
+		{
+			pushProperty("weight");
+			visitor.diffItemWeight(original.getWeight(), updated.getWeight());
+			pop();
+		}
+		{
+			pushProperty("extra");
+			visitor.diffItemExtra(original.getExtra(), updated.getExtra());
+			pop();
+		}
+		{
+			pushProperty("raw");
+			visitor.diffItemRaw(original.getRaw(), updated.getRaw());
+			pop();
+		}
+		{
+			pushProperty("schema");
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (original.getSchema() != null && updated.getSchema() != null) {
+				traverse(original.getSchema(), updated.getSchema());
+			}
+			pop();
+		}
+		{
+			pushProperty("examples");
+			visitor.diffItemExamples(original.getExamples(), updated.getExamples());
+			pop();
+		}
+		{
+			pushProperty("defaultValue");
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			pop();
+		}
+		{
+			pushProperty("title");
+			visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+			pop();
+		}
+		{
+			pushProperty("deprecated");
+			visitor.diffItemDeprecated(original.isDeprecated(), updated.isDeprecated());
+			pop();
+		}
 	}
 
 	public void traverseSchema(Syn2Schema original, Syn2Schema updated) {
@@ -164,58 +268,102 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
-		visitor.diffSchemaType(original.getType(), updated.getType());
-		visitor.diffSchemaItems(original.getItems(), updated.getItems());
-		this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 		{
+			pushProperty("$ref");
+			visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
+			pop();
+		}
+		{
+			pushProperty("type");
+			visitor.diffSchemaType(original.getType(), updated.getType());
+			pop();
+		}
+		{
+			pushProperty("items");
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			pop();
+		}
+		{
+			pushProperty("properties");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("properties", original.getProperties(),
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("allOf");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairList("allOf", original.getAllOf(),
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("definitions");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("definitions", original.getDefinitions(),
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("nestedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairMap("nestedSchemas", original.getNestedSchemas(),
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("composedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairList("composedSchemas", original.getComposedSchemas(),
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
-		visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
-		visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
-		visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+		{
+			pushProperty("minLength");
+			visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
+			pop();
+		}
+		{
+			pushProperty("maxLength");
+			visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
+			pop();
+		}
+		{
+			pushProperty("enum");
+			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+			pop();
+		}
 	}
 
 	public void traversePaths(Syn2Paths original, Syn2Paths updated) {
@@ -234,23 +382,47 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
-		visitor.diffPathItemGet(original.getGet(), updated.getGet());
-		if (original.getGet() != null && updated.getGet() != null) {
-			traverse(original.getGet(), updated.getGet());
+		{
+			pushProperty("$ref");
+			visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffPathItemPut(original.getPut(), updated.getPut());
-		if (original.getPut() != null && updated.getPut() != null) {
-			traverse(original.getPut(), updated.getPut());
+		{
+			pushProperty("summary");
+			visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
+			pop();
 		}
-		visitor.diffPathItemPost(original.getPost(), updated.getPost());
-		if (original.getPost() != null && updated.getPost() != null) {
-			traverse(original.getPost(), updated.getPost());
+		{
+			pushProperty("get");
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (original.getGet() != null && updated.getGet() != null) {
+				traverse(original.getGet(), updated.getGet());
+			}
+			pop();
 		}
-		visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
-		if (original.getDelete() != null && updated.getDelete() != null) {
-			traverse(original.getDelete(), updated.getDelete());
+		{
+			pushProperty("put");
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (original.getPut() != null && updated.getPut() != null) {
+				traverse(original.getPut(), updated.getPut());
+			}
+			pop();
+		}
+		{
+			pushProperty("post");
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (original.getPost() != null && updated.getPost() != null) {
+				traverse(original.getPost(), updated.getPost());
+			}
+			pop();
+		}
+		{
+			pushProperty("delete");
+			visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
+			if (original.getDelete() != null && updated.getDelete() != null) {
+				traverse(original.getDelete(), updated.getDelete());
+			}
+			pop();
 		}
 	}
 
@@ -261,19 +433,35 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
-		visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
-		visitor.diffOperationTags(original.getTags(), updated.getTags());
 		{
+			pushProperty("operationId");
+			visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
+			pop();
+		}
+		{
+			pushProperty("summary");
+			visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
+			pop();
+		}
+		{
+			pushProperty("tags");
+			visitor.diffOperationTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("parameters");
 			CollectionDiff<P, SynItem> diff = this.pairList("parameters", original.getParameters(),
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -26,7 +26,7 @@ import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
 
-public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisitor<P>> {
+public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTraverser<P, Syn2DiffVisitor<P>> {
 
 	public Syn2DiffTraverser(Syn2DiffVisitor<P> visitor) {
 		super(visitor);
@@ -90,7 +90,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -115,7 +115,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -290,7 +290,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -303,7 +303,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -316,7 +316,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -329,7 +329,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -342,7 +342,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -454,7 +454,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -115,7 +115,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -290,7 +290,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -316,7 +316,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -329,7 +329,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -23,7 +23,7 @@ import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Syn2DiffVisitor<P> {
+public abstract class Syn2DiffVisitor<P extends PairingKey> {
 
 	public boolean visitDocument(Syn2Document original, Syn2Document updated) {
 		return true;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * @param <V>
  *            the spec-version-specific DiffVisitor subclass
  */
-public class AbstractDiffTraverser<P, V> {
+public class AbstractDiffTraverser<P extends PairingKey, V> {
 
 	protected final V visitor;
 	protected final PairingStrategyProvider<P> pairingProvider;
@@ -54,20 +54,20 @@ public class AbstractDiffTraverser<P, V> {
 		updatedContext.pushProperty(propertyName);
 	}
 
-	/**
-	 * Push collection element positions onto the respective contexts.
-	 */
-	protected void pushElement(PairingKey key) {
-		if (key.getOriginalKey() != null) {
-			originalContext.pushMapIndex(key.getOriginalKey());
-		} else if (key.getOriginalIndex() != null) {
-			originalContext.pushListIndex(key.getOriginalIndex());
+	protected void pushMapIndex(PairingKey key) {
+		if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
+			throw new IllegalStateException("Map pairing key must have both original and updated keys");
 		}
-		if (key.getUpdatedKey() != null) {
-			updatedContext.pushMapIndex(key.getUpdatedKey());
-		} else if (key.getUpdatedIndex() != null) {
-			updatedContext.pushListIndex(key.getUpdatedIndex());
+		originalContext.pushMapIndex(key.getOriginalKey());
+		updatedContext.pushMapIndex(key.getUpdatedKey());
+	}
+
+	protected void pushListIndex(PairingKey key) {
+		if (key.getOriginalIndex() == null || key.getUpdatedIndex() == null) {
+			throw new IllegalStateException("List pairing key must have both original and updated indices");
 		}
+		originalContext.pushListIndex(key.getOriginalIndex());
+		updatedContext.pushListIndex(key.getUpdatedIndex());
 	}
 
 	/**

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -1,13 +1,14 @@
 package io.test.synthetic.visitors.diff;
 
 import io.test.synthetic.Any;
+import io.test.synthetic.visitors.TraversalContext;
+import io.test.synthetic.visitors.TraversalContextImpl;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Base class for generated diff traversers. Provides shared collection pairing
- * logic. Subclasses (generated per spec version) provide entity-specific field
- * iteration and call typed visitor methods.
+ * logic and path tracking via two TraversalContext instances (one per side).
  *
  * @param <P>
  *            the pairing key type
@@ -18,23 +19,65 @@ public class AbstractDiffTraverser<P, V> {
 
 	protected final V visitor;
 	protected final PairingStrategyProvider<P> pairingProvider;
+	protected final TraversalContextImpl originalContext;
+	protected final TraversalContextImpl updatedContext;
 
 	@SuppressWarnings("unchecked")
 	protected AbstractDiffTraverser(V visitor) {
 		this.visitor = visitor;
 		this.pairingProvider = (PairingStrategyProvider<P>) new DefaultPairingStrategyProvider();
+		this.originalContext = new TraversalContextImpl();
+		this.updatedContext = new TraversalContextImpl();
 	}
 
+	@SuppressWarnings("unchecked")
 	protected AbstractDiffTraverser(V visitor, PairingStrategyProvider<P> pairingProvider) {
 		this.visitor = visitor;
 		this.pairingProvider = pairingProvider;
+		this.originalContext = new TraversalContextImpl();
+		this.updatedContext = new TraversalContextImpl();
+	}
+
+	public TraversalContext getOriginalContext() {
+		return originalContext;
+	}
+
+	public TraversalContext getUpdatedContext() {
+		return updatedContext;
 	}
 
 	/**
-	 * Public entry point — accepts Any (Node or Union). Generated subclasses
-	 * override this with type-based dispatch to union traverse methods and entity
-	 * traverse methods.
+	 * Push a property name onto both contexts (shared by both sides).
 	 */
+	protected void pushProperty(String propertyName) {
+		originalContext.pushProperty(propertyName);
+		updatedContext.pushProperty(propertyName);
+	}
+
+	/**
+	 * Push collection element positions onto the respective contexts.
+	 */
+	protected void pushElement(PairingKey key) {
+		if (key.getOriginalKey() != null) {
+			originalContext.pushMapIndex(key.getOriginalKey());
+		} else if (key.getOriginalIndex() != null) {
+			originalContext.pushListIndex(key.getOriginalIndex());
+		}
+		if (key.getUpdatedKey() != null) {
+			updatedContext.pushMapIndex(key.getUpdatedKey());
+		} else if (key.getUpdatedIndex() != null) {
+			updatedContext.pushListIndex(key.getUpdatedIndex());
+		}
+	}
+
+	/**
+	 * Pop from both contexts.
+	 */
+	protected void pop() {
+		originalContext.pop();
+		updatedContext.pop();
+	}
+
 	public void traverse(Any original, Any updated) {
 	}
 
@@ -47,5 +90,4 @@ public class AbstractDiffTraverser<P, V> {
 		ListPairingStrategy<P, T> strategy = pairingProvider.getListStrategy(propertyName);
 		return strategy.pair(original, updated);
 	}
-
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -54,7 +54,7 @@ public class AbstractDiffTraverser<P extends PairingKey, V> {
 		updatedContext.pushProperty(propertyName);
 	}
 
-	protected void pushMapIndex(PairingKey key) {
+	protected void pushMapKey(PairingKey key) {
 		if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
 			throw new IllegalStateException("Map pairing key must have both original and updated keys");
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/CollectionDiff.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/CollectionDiff.java
@@ -11,32 +11,32 @@ import java.util.Set;
  * Result of pairing two collections. Contains entries that were added, removed,
  * or matched between the original and updated collections.
  *
- * @param <K>
- *            the key type (String for maps, Integer for lists)
- * @param <V>
+ * @param <P>
+ *            the pairing key type (String for maps, Integer for lists)
+ * @param <T>
  *            the value type
  */
-public class CollectionDiff<K, V> {
+public class CollectionDiff<P, T> {
 
-	private final List<Entry<K, V>> added;
-	private final List<Entry<K, V>> removed;
-	private final List<MatchedPair<K, V>> matched;
+	private final List<Entry<P, T>> added;
+	private final List<Entry<P, T>> removed;
+	private final List<MatchedPair<P, T>> matched;
 
-	public CollectionDiff(List<Entry<K, V>> added, List<Entry<K, V>> removed, List<MatchedPair<K, V>> matched) {
+	public CollectionDiff(List<Entry<P, T>> added, List<Entry<P, T>> removed, List<MatchedPair<P, T>> matched) {
 		this.added = added;
 		this.removed = removed;
 		this.matched = matched;
 	}
 
-	public List<Entry<K, V>> getAdded() {
+	public List<Entry<P, T>> getAdded() {
 		return added;
 	}
 
-	public List<Entry<K, V>> getRemoved() {
+	public List<Entry<P, T>> getRemoved() {
 		return removed;
 	}
 
-	public List<MatchedPair<K, V>> getMatched() {
+	public List<MatchedPair<P, T>> getMatched() {
 		return matched;
 	}
 
@@ -48,19 +48,19 @@ public class CollectionDiff<K, V> {
 	 * Pairs two maps by key. Entries with matching keys are paired; keys in only
 	 * one map are classified as added or removed.
 	 */
-	public static <K, V> CollectionDiff<K, V> pairByKey(Map<K, V> original, Map<K, V> updated) {
-		Map<K, V> orig = original != null ? original : new LinkedHashMap<>();
-		Map<K, V> upd = updated != null ? updated : new LinkedHashMap<>();
+	public static <P, T> CollectionDiff<P, T> pairByKey(Map<P, T> original, Map<P, T> updated) {
+		Map<P, T> orig = original != null ? original : new LinkedHashMap<>();
+		Map<P, T> upd = updated != null ? updated : new LinkedHashMap<>();
 
-		Set<K> allKeys = new LinkedHashSet<>();
+		Set<P> allKeys = new LinkedHashSet<>();
 		allKeys.addAll(orig.keySet());
 		allKeys.addAll(upd.keySet());
 
-		List<Entry<K, V>> added = new ArrayList<>();
-		List<Entry<K, V>> removed = new ArrayList<>();
-		List<MatchedPair<K, V>> matched = new ArrayList<>();
+		List<Entry<P, T>> added = new ArrayList<>();
+		List<Entry<P, T>> removed = new ArrayList<>();
+		List<MatchedPair<P, T>> matched = new ArrayList<>();
 
-		for (K key : allKeys) {
+		for (P key : allKeys) {
 			boolean inOrig = orig.containsKey(key);
 			boolean inUpd = upd.containsKey(key);
 			if (inOrig && inUpd) {
@@ -75,41 +75,41 @@ public class CollectionDiff<K, V> {
 		return new CollectionDiff<>(added, removed, matched);
 	}
 
-	public static class Entry<K, V> {
-		private final K key;
-		private final V value;
+	public static class Entry<P, T> {
+		private final P key;
+		private final T value;
 
-		public Entry(K key, V value) {
+		public Entry(P key, T value) {
 			this.key = key;
 			this.value = value;
 		}
 
-		public K getKey() {
+		public P getKey() {
 			return key;
 		}
-		public V getValue() {
+		public T getValue() {
 			return value;
 		}
 	}
 
-	public static class MatchedPair<K, V> {
-		private final K key;
-		private final V original;
-		private final V updated;
+	public static class MatchedPair<P, T> {
+		private final P key;
+		private final T original;
+		private final T updated;
 
-		public MatchedPair(K key, V original, V updated) {
+		public MatchedPair(P key, T original, T updated) {
 			this.key = key;
 			this.original = original;
 			this.updated = updated;
 		}
 
-		public K getKey() {
+		public P getKey() {
 			return key;
 		}
-		public V getOriginal() {
+		public T getOriginal() {
 			return original;
 		}
-		public V getUpdated() {
+		public T getUpdated() {
 			return updated;
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultListPairingStrategy.java
@@ -7,17 +7,17 @@ import java.util.Map;
 /**
  * Default list pairing strategy — pairs entries by index.
  */
-public class DefaultListPairingStrategy<V> implements ListPairingStrategy<DefaultPairingKey, V> {
+public class DefaultListPairingStrategy<T> implements ListPairingStrategy<DefaultPairingKey, T> {
 
 	@Override
-	public CollectionDiff<DefaultPairingKey, V> pair(List<V> original, List<V> updated) {
+	public CollectionDiff<DefaultPairingKey, T> pair(List<T> original, List<T> updated) {
 		return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
 	}
 
-	private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(List<V> list) {
+	private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(List<T> list) {
 		if (list == null)
 			return new LinkedHashMap<>();
-		Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
+		Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
 		for (int i = 0; i < list.size(); i++) {
 			res.put(new DefaultPairingKey(i), list.get(i));
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultMapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultMapPairingStrategy.java
@@ -7,18 +7,18 @@ import java.util.Map;
 /**
  * Default map pairing strategy — pairs entries by key.
  */
-public class DefaultMapPairingStrategy<V> implements MapPairingStrategy<DefaultPairingKey, V> {
+public class DefaultMapPairingStrategy<T> implements MapPairingStrategy<DefaultPairingKey, T> {
 
 	@Override
-	public CollectionDiff<DefaultPairingKey, V> pair(Map<String, V> original, Map<String, V> updated) {
+	public CollectionDiff<DefaultPairingKey, T> pair(Map<String, T> original, Map<String, T> updated) {
 		return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
 	}
 
-	private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(Map<String, V> map) {
+	private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(Map<String, T> map) {
 		if (map == null)
 			return new LinkedHashMap<>();
-		Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
-		for (Map.Entry<String, V> entry : map.entrySet()) {
+		Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
+		for (Map.Entry<String, T> entry : map.entrySet()) {
 			res.put(new DefaultPairingKey(entry.getKey()), entry.getValue());
 		}
 		return res;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingKey.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingKey.java
@@ -3,33 +3,42 @@ package io.test.synthetic.visitors.diff;
 import java.util.Objects;
 
 /**
- * Default provider: key-based pairing for maps, index-based for lists.
+ * Default pairing key for index-based (lists) and key-based (maps) pairing. For
+ * the default strategies, original and updated positions are the same (same
+ * index or same key).
  */
-public class DefaultPairingKey {
+public class DefaultPairingKey implements PairingKey {
 
-	private Type type;
-	private Integer index;
-	private String key;
+	private final Integer index;
+	private final String key;
 
 	public DefaultPairingKey(int index) {
-		type = Type.INDEX;
 		this.index = index;
+		this.key = null;
 	}
 
 	public DefaultPairingKey(String key) {
-		type = Type.KEY;
+		this.index = null;
 		this.key = key;
 	}
 
-	public Type getType() {
-		return type;
-	}
-
-	public Integer getIndex() {
+	@Override
+	public Integer getOriginalIndex() {
 		return index;
 	}
 
-	public String getKey() {
+	@Override
+	public Integer getUpdatedIndex() {
+		return index;
+	}
+
+	@Override
+	public String getOriginalKey() {
+		return key;
+	}
+
+	@Override
+	public String getUpdatedKey() {
 		return key;
 	}
 
@@ -38,15 +47,16 @@ public class DefaultPairingKey {
 		if (!(o instanceof DefaultPairingKey))
 			return false;
 		DefaultPairingKey that = (DefaultPairingKey) o;
-		return type == that.type && Objects.equals(index, that.index) && Objects.equals(key, that.key);
+		return Objects.equals(index, that.index) && Objects.equals(key, that.key);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(type, index, key);
+		return Objects.hash(index, key);
 	}
 
-	public enum Type {
-		INDEX, KEY
+	@Override
+	public String toString() {
+		return key != null ? key : String.valueOf(index);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingStrategyProvider.java
@@ -6,12 +6,12 @@ package io.test.synthetic.visitors.diff;
 public class DefaultPairingStrategyProvider implements PairingStrategyProvider<DefaultPairingKey> {
 
 	@Override
-	public <V> MapPairingStrategy<DefaultPairingKey, V> getMapStrategy(String propertyName) {
+	public <T> MapPairingStrategy<DefaultPairingKey, T> getMapStrategy(String propertyName) {
 		return new DefaultMapPairingStrategy<>();
 	}
 
 	@Override
-	public <V> ListPairingStrategy<DefaultPairingKey, V> getListStrategy(String propertyName) {
+	public <T> ListPairingStrategy<DefaultPairingKey, T> getListStrategy(String propertyName) {
 		return new DefaultListPairingStrategy<>();
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
@@ -7,10 +7,10 @@ import java.util.List;
  *
  * @param <P>
  *            the pairing key type (e.g., Integer for index-based pairing)
- * @param <V>
+ * @param <T>
  *            the value type
  */
-public interface ListPairingStrategy<P extends PairingKey, V> {
+public interface ListPairingStrategy<P extends PairingKey, T> {
 
-	CollectionDiff<P, V> pair(List<V> original, List<V> updated);
+	CollectionDiff<P, T> pair(List<T> original, List<T> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @param <V>
  *            the value type
  */
-public interface ListPairingStrategy<P, V> {
+public interface ListPairingStrategy<P extends PairingKey, V> {
 
 	CollectionDiff<P, V> pair(List<V> original, List<V> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
@@ -7,10 +7,10 @@ import java.util.Map;
  *
  * @param <P>
  *            the pairing key type (e.g., String for key-based pairing)
- * @param <V>
+ * @param <T>
  *            the value type
  */
-public interface MapPairingStrategy<P extends PairingKey, V> {
+public interface MapPairingStrategy<P extends PairingKey, T> {
 
-	CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
+	CollectionDiff<P, T> pair(Map<String, T> original, Map<String, T> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * @param <V>
  *            the value type
  */
-public interface MapPairingStrategy<P, V> {
+public interface MapPairingStrategy<P extends PairingKey, V> {
 
 	CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingKey.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingKey.java
@@ -1,0 +1,43 @@
+package io.test.synthetic.visitors.diff;
+
+/**
+ * Represents a pairing between elements from original and updated collections.
+ * Provides access to the original and updated positions as both indices and map
+ * keys.
+ */
+public interface PairingKey {
+
+	/**
+	 * The index in the original list, or null if not applicable.
+	 */
+	Integer getOriginalIndex();
+
+	/**
+	 * The index in the updated list, or null if not applicable.
+	 */
+	Integer getUpdatedIndex();
+
+	/**
+	 * The key in the original map, or null if not applicable.
+	 */
+	String getOriginalKey();
+
+	/**
+	 * The key in the updated map, or null if not applicable.
+	 */
+	String getUpdatedKey();
+
+	/**
+	 * Returns the original position as a string (map key or index).
+	 */
+	default String getOriginalPosition() {
+		return getOriginalKey() != null ? getOriginalKey() : String.valueOf(getOriginalIndex());
+	}
+
+	/**
+	 * Returns the updated position as a string (map key or index).
+	 */
+	default String getUpdatedPosition() {
+		return getUpdatedKey() != null ? getUpdatedKey() : String.valueOf(getUpdatedIndex());
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
@@ -7,7 +7,7 @@ package io.test.synthetic.visitors.diff;
  */
 public interface PairingStrategyProvider<P extends PairingKey> {
 
-	<V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
+	<T> MapPairingStrategy<P, T> getMapStrategy(String propertyName);
 
-	<V> ListPairingStrategy<P, V> getListStrategy(String propertyName);
+	<T> ListPairingStrategy<P, T> getListStrategy(String propertyName);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
@@ -5,7 +5,7 @@ package io.test.synthetic.visitors.diff;
  * a custom provider to the DiffTraverser constructor to control how map and
  * list fields are paired.
  */
-public interface PairingStrategyProvider<P> {
+public interface PairingStrategyProvider<P extends PairingKey> {
 
 	<V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
 


### PR DESCRIPTION
## Summary

Adds path tracking to the diff traverser for recording JSON paths during comparison.

### Path tracking
- Two `TraversalContextImpl` instances on `AbstractDiffTraverser`: `originalContext` and `updatedContext`
- For property fields: `pushProperty(name)` pushes to both contexts
- For collection elements: `pushElement(PairingKey)` pushes original/updated keys/indices to respective contexts
- Generated code wraps each property in `{}` blocks with `push`/`pop` for readability
- Access: `traverser.getOriginalContext()` / `traverser.getUpdatedContext()`
- Reuses existing `TraversalContextImpl` — no duplication

### PairingKey interface
- `getOriginalIndex()` / `getUpdatedIndex()` — list positions (null if N/A)
- `getOriginalKey()` / `getUpdatedKey()` — map keys (null if N/A)
- `getOriginalPosition()` / `getUpdatedPosition()` — convenience string methods
- `DefaultPairingKey` implements `PairingKey`
- Custom pairing strategies can provide different original/updated positions

### Other
- Removed unused `Node` import from generated traversers
- Removed `DiffContext` (replaced by dual `TraversalContextImpl`)

## Context

C36b in #1042.

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated code compiles