### PR TITLE
feat: compound JSON Schema + ConversionTraverser infrastructure (C41c/G26)

### DIFF
--- a/data-models/pom.xml
+++ b/data-models/pom.xml
@@ -194,6 +194,9 @@
                                 <exclude>**/visitors/diff/**</exclude>
                                 <exclude>**/*DiffTraverser.java</exclude>
                                 <exclude>**/*DiffVisitor.java</exclude>
+                                <exclude>**/visitors/convert/**</exclude>
+                                <exclude>**/*ConversionTraverser.java</exclude>
+                                <exclude>**/*ConversionVisitor.java</exclude>
                             </excludes>
                         </configuration>
                         <executions>

--- a/data-models/src/main/resources/specs/json-schema.yaml
+++ b/data-models/src/main/resources/specs/json-schema.yaml
@@ -9,3 +9,4 @@ versions:
   - $ref: ./json-schema/json-schema-draft-7.yaml
   - $ref: ./json-schema/json-schema-2019-09.yaml
   - $ref: ./json-schema/json-schema-2020-12.yaml
+  - $ref: ./json-schema/json-schema-compound.yaml

--- a/data-models/src/main/resources/specs/json-schema/json-schema-2019-09.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-2019-09.yaml
@@ -7,6 +7,7 @@ prefix: JM201909
 namespace: io.apitomy.datamodels.models.jsonschema.modern.v201909
 majorVersionPrefix: JM
 majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.modern
+conversionTarget: compound
 
 traits:
   - name: Referenceable

--- a/data-models/src/main/resources/specs/json-schema/json-schema-2020-12.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-2020-12.yaml
@@ -7,6 +7,7 @@ prefix: JM202012
 namespace: io.apitomy.datamodels.models.jsonschema.modern.v202012
 majorVersionPrefix: JM
 majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.modern
+conversionTarget: compound
 
 traits:
   - name: Referenceable

--- a/data-models/src/main/resources/specs/json-schema/json-schema-compound.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-compound.yaml
@@ -1,0 +1,214 @@
+name: JSON Schema Compound
+version: compound
+versions:
+  - version: compound
+    url: https://json-schema.org/
+prefix: JC
+namespace: io.apitomy.datamodels.models.jsonschema.compound
+majorVersionPrefix: JC
+majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.compound
+
+# Synthetic compound schema merging all properties from all JSON Schema drafts
+# (draft-4, draft-6, draft-7, 2019-09, 2020-12) into a single entity.
+# Used for cross-version compatibility checking — converters map each draft
+# version to this compound type, then the diff visitor compares compound-to-compound.
+
+traits:
+  - name: Referenceable
+    properties:
+      - name: '$ref'
+        type: string
+
+typeAliases:
+  - name: JsonSchema
+    type: boolean|FullSchema
+  - name: Dependency
+    type: FullSchema|[string]
+
+root:
+  type: JsonSchema
+
+entities:
+  - name: FullSchema
+    traits:
+      - Referenceable
+    properties:
+      # --- Identification (superset of id, $id, $anchor, $schema, $comment) ---
+      - name: id
+        type: string
+        # d4 only; renamed to $id in d6+
+      - name: '$id'
+        type: string
+        # d6+
+      - name: '$schema'
+        type: string
+      - name: '$anchor'
+        type: string
+        # 2019-09+
+      - name: '$comment'
+        type: string
+        # d7+
+
+      # --- Dynamic references (2019-09, 2020-12) ---
+      - name: '$recursiveRef'
+        type: string
+        # 2019-09 only
+      - name: '$recursiveAnchor'
+        type: boolean
+        # 2019-09 only
+      - name: '$dynamicRef'
+        type: string
+        # 2020-12 only
+      - name: '$dynamicAnchor'
+        type: string
+        # 2020-12 only
+
+      # --- Metadata ---
+      - name: title
+        type: string
+      - name: description
+        type: string
+      - name: default
+        type: any
+      - name: examples
+        type: '[any]'
+        # d6+
+      - name: readOnly
+        type: boolean
+        # d7+
+      - name: writeOnly
+        type: boolean
+        # d7+
+      - name: deprecated
+        type: boolean
+        # 2019-09+
+
+      # --- Definitions (superset of definitions, $defs) ---
+      - name: definitions
+        type: '{JsonSchema}'
+        # d4-d7
+      - name: '$defs'
+        type: '{JsonSchema}'
+        # 2019-09+
+
+      # --- Type & enum ---
+      - name: type
+        type: 'string|[string]'
+      - name: enum
+        type: '[any]'
+      - name: const
+        type: any
+        # d6+
+      - name: format
+        type: string
+
+      # --- Composition ---
+      - name: allOf
+        type: '[JsonSchema]'
+      - name: anyOf
+        type: '[JsonSchema]'
+      - name: oneOf
+        type: '[JsonSchema]'
+      - name: not
+        type: JsonSchema
+
+      # --- Conditionals (d7+) ---
+      - name: if
+        type: JsonSchema
+      - name: then
+        type: JsonSchema
+      - name: else
+        type: JsonSchema
+
+      # --- Numeric validation ---
+      - name: multipleOf
+        type: number
+      - name: minimum
+        type: number
+      - name: maximum
+        type: number
+      # exclusiveMinimum/Maximum use the widest type (boolean in d4, number in d6+)
+      # Converters map d4 boolean to the compound union type
+      - name: exclusiveMinimum
+        type: 'boolean|number'
+      - name: exclusiveMaximum
+        type: 'boolean|number'
+
+      # --- String validation ---
+      - name: minLength
+        type: integer
+      - name: maxLength
+        type: integer
+      - name: pattern
+        type: string
+      - name: contentMediaType
+        type: string
+        # d7+
+      - name: contentEncoding
+        type: string
+        # d7+
+      - name: contentSchema
+        type: JsonSchema
+        # 2019-09+
+
+      # --- Array validation ---
+      # items uses the widest type (union of all forms across drafts)
+      - name: items
+        type: 'boolean|FullSchema|[FullSchema]'
+      - name: additionalItems
+        type: JsonSchema
+        # d4-2019-09
+      - name: prefixItems
+        type: '[JsonSchema]'
+        # 2020-12 only
+      - name: minItems
+        type: integer
+      - name: maxItems
+        type: integer
+      - name: uniqueItems
+        type: boolean
+      - name: contains
+        type: JsonSchema
+        # d6+
+      - name: minContains
+        type: integer
+        # 2020-12 only
+      - name: maxContains
+        type: integer
+        # 2020-12 only
+      - name: unevaluatedItems
+        type: JsonSchema
+        # 2020-12 only
+
+      # --- Object validation ---
+      - name: properties
+        type: '{JsonSchema}'
+      - name: patternProperties
+        type: '{JsonSchema}'
+      - name: additionalProperties
+        type: JsonSchema
+      - name: required
+        type: '[string]'
+      - name: minProperties
+        type: integer
+      - name: maxProperties
+        type: integer
+      - name: dependencies
+        type: '{Dependency}'
+        # d4-d7
+      - name: dependentSchemas
+        type: '{JsonSchema}'
+        # 2019-09+
+      - name: dependentRequired
+        type: '{any}'
+        # 2019-09+
+      - name: propertyNames
+        type: JsonSchema
+        # d6+
+      - name: unevaluatedProperties
+        type: JsonSchema
+        # 2020-12 only
+
+    propertyOrder:
+      - $Referenceable
+      - $this

--- a/data-models/src/main/resources/specs/json-schema/json-schema-draft-4.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-draft-4.yaml
@@ -7,6 +7,7 @@ prefix: JD4
 namespace: io.apitomy.datamodels.models.jsonschema.draft.draft4
 majorVersionPrefix: JD
 majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.draft
+conversionTarget: compound
 
 traits:
   - name: Referenceable

--- a/data-models/src/main/resources/specs/json-schema/json-schema-draft-6.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-draft-6.yaml
@@ -7,6 +7,7 @@ prefix: JD6
 namespace: io.apitomy.datamodels.models.jsonschema.draft.draft6
 majorVersionPrefix: JD
 majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.draft
+conversionTarget: compound
 
 traits:
   - name: Referenceable

--- a/data-models/src/main/resources/specs/json-schema/json-schema-draft-7.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-draft-7.yaml
@@ -7,6 +7,7 @@ prefix: JD7
 namespace: io.apitomy.datamodels.models.jsonschema.draft.draft7
 majorVersionPrefix: JD
 majorVersionNamespace: io.apitomy.datamodels.models.jsonschema.draft
+conversionTarget: compound
 
 traits:
   - name: Referenceable

--- a/generator/src/main/java/io/apitomy/umg/UnifiedModelGenerator.java
+++ b/generator/src/main/java/io/apitomy/umg/UnifiedModelGenerator.java
@@ -58,6 +58,8 @@ import io.apitomy.umg.pipe.java.CreateReaderFactoryStage;
 import io.apitomy.umg.pipe.java.CreateReadersStage;
 import io.apitomy.umg.pipe.java.CreateTestFixturesStage;
 import io.apitomy.umg.pipe.java.CreateTraitInterfacesStage;
+import io.apitomy.umg.pipe.java.CreateConversionTraversersStage;
+import io.apitomy.umg.pipe.java.CreateConversionVisitorsStage;
 import io.apitomy.umg.pipe.java.CreateDiffTraversersStage;
 import io.apitomy.umg.pipe.java.CreateDiffVisitorsStage;
 import io.apitomy.umg.pipe.java.CreateTraversersStage;
@@ -167,6 +169,8 @@ public class UnifiedModelGenerator {
         pipe.addStage(new CreateTraversersStage());
         pipe.addStage(new CreateDiffVisitorsStage());
         pipe.addStage(new CreateDiffTraversersStage());
+        pipe.addStage(new CreateConversionVisitorsStage());
+        pipe.addStage(new CreateConversionTraversersStage());
         pipe.addStage(new CreateReaderFactoryStage());
         pipe.addStage(new CreateWriterFactoryStage());
         pipe.addStage(new CreateClonerFactoryStage());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionTraversersStage.java
@@ -47,7 +47,7 @@ public class CreateConversionTraversersStage extends AbstractJavaStage {
         }
 
         String packageName = getTraverserPackageName(specVer);
-        String className = specVer.getPrefix() + "ConversionTraverser";
+        String className = specVer.getPrefix() + "To" + targetSpecVer.getPrefix() + "ConversionTraverser";
 
         debug("Creating conversion traverser: " + className);
 
@@ -57,7 +57,7 @@ public class CreateConversionTraversersStage extends AbstractJavaStage {
                 .setPublic();
 
         // Resolve the generated per-spec visitor
-        String visitorClassName = specVer.getPrefix() + "ConversionVisitor";
+        String visitorClassName = specVer.getPrefix() + "To" + targetSpecVer.getPrefix() + "ConversionVisitor";
         String visitorFQN = packageName + "." + visitorClassName;
         JavaClassSource visitorSource = getState().getJavaIndex().lookupClass(visitorFQN);
         classSource.addImport(visitorSource);
@@ -256,7 +256,7 @@ public class CreateConversionTraversersStage extends AbstractJavaStage {
         body.append("if (source == null) return null;");
         body.addContext("visitMethod", "visit" + entityName);
         body.addContext("returnType", returnType);
-        body.append(returnType + " target = (" + returnType + ") visitor.${visitMethod}(source);");
+        body.append(returnType + " target = visitor.${visitMethod}(source);");
         body.append("if (target == null) return null;");
 
         for (PropertyModelWithOrigin propWithOrigin : sourceProperties) {
@@ -474,7 +474,14 @@ public class CreateConversionTraversersStage extends AbstractJavaStage {
         BodyBuilder body = new BodyBuilder();
         body.append("if (source == null) return null;");
 
-        // For entity variants: convert via the entity converter
+        // Let visitor transform the union value before recursing (e.g., true → {})
+        String visitorConvertMethod = "convert" + unionTypeName;
+        body.addContext("visitorConvertMethod", visitorConvertMethod);
+        body.addContext("unionType", unionJt.toJavaTypeString());
+        body.append("${unionType} converted = visitor.${visitorConvertMethod}(source);");
+        body.append("if (converted == null) return null;");
+
+        // For entity variants: recurse into the converted value
         for (var variantType : unionType.getTypes()) {
             if (variantType.isEntityType()) {
                 var entity = ((io.apitomy.umg.models.concept.type.EntityType) variantType).getEntity();
@@ -487,16 +494,20 @@ public class CreateConversionTraversersStage extends AbstractJavaStage {
                     classSource.addImport(entityInterface);
                     body.addContext("entityType", entityInterface.getName());
                     body.addContext("convertEntity", "convert" + entity.getName());
-                    body.append("if (source instanceof ${entityType}) {");
-                    body.append("    return ${convertEntity}((${entityType}) source);");
+                    body.append("if (converted instanceof ${entityType}) {");
+                    body.append("    return ${convertEntity}((${entityType}) converted);");
                     body.append("}");
                 }
             }
         }
 
-        // For primitive variants, pass through
+        // For primitive variants, return the visitor-converted value
         body.addContext("returnType", returnType);
-        body.append("return (" + returnType + ") source;");
+        if (returnType.equals(unionJt.toJavaTypeString())) {
+            body.append("return converted;");
+        } else {
+            body.append("return (" + returnType + ") converted;");
+        }
 
         method.setBody(body.toString());
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionTraversersStage.java
@@ -1,0 +1,532 @@
+package io.apitomy.umg.pipe.java;
+
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.java.type.JavaType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
+import io.apitomy.umg.pipe.java.method.BodyBuilder;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+import io.apitomy.umg.pipe.java.method.GetterMethod;
+
+/**
+ * Creates a ConversionTraverser for each specification version that has a
+ * {@code conversionTarget} configured. A ConversionTraverser walks a source tree,
+ * creating a corresponding target tree by dispatching field-level conversion to
+ * the generated per-spec ConversionVisitor's typed methods.
+ */
+public class CreateConversionTraversersStage extends AbstractJavaStage {
+
+    @Override
+    protected void doProcess() {
+        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVer -> {
+            if (specVer.getConversionTarget() != null) {
+                createConversionTraverser(specVer);
+            }
+        });
+    }
+
+    private void createConversionTraverser(SpecificationVersion specVer) {
+        String targetVersionName = specVer.getConversionTarget();
+        SpecificationVersion targetSpecVer = resolveTargetSpecVersion(targetVersionName);
+        if (targetSpecVer == null) {
+            warn("Conversion target '%s' not found for spec '%s'", targetVersionName, specVer.getName());
+            return;
+        }
+
+        String packageName = getTraverserPackageName(specVer);
+        String className = specVer.getPrefix() + "ConversionTraverser";
+
+        debug("Creating conversion traverser: " + className);
+
+        JavaClassSource classSource = Roaster.create(JavaClassSource.class)
+                .setPackage(packageName)
+                .setName(className)
+                .setPublic();
+
+        // Resolve the generated per-spec visitor
+        String visitorClassName = specVer.getPrefix() + "ConversionVisitor";
+        String visitorFQN = packageName + "." + visitorClassName;
+        JavaClassSource visitorSource = getState().getJavaIndex().lookupClass(visitorFQN);
+        classSource.addImport(visitorSource);
+
+        // Extend AbstractConversionTraverser<SpecConversionVisitor>
+        String baseFQN = getState().getConfig().getRootNamespace()
+                + ".visitors.convert.AbstractConversionTraverser";
+        JavaClassSource baseSource = getState().getJavaIndex().lookupClass(baseFQN);
+        classSource.addImport(baseSource);
+        classSource.setSuperType("AbstractConversionTraverser<" + visitorClassName + ">");
+
+        // Constructor
+        MethodSource<JavaClassSource> constructor = classSource.addMethod()
+                .setConstructor(true).setPublic();
+        constructor.addParameter(visitorClassName, "visitor");
+        constructor.setBody("super(visitor);");
+
+        java.util.Set<String> createdMethods = new java.util.HashSet<>();
+
+        createConvertDispatch(specVer, targetSpecVer, classSource, createdMethods);
+
+        specVer.getEntities().forEach(entity -> {
+            EntityModel sourceEntityModel = getState().getConceptIndex()
+                    .lookupEntity(specVer.getNamespace() + "." + entity.getName());
+            if (sourceEntityModel != null) {
+                String methodName = "convert" + sourceEntityModel.getName();
+                if (createdMethods.add(methodName)) {
+                    createEntityConvertMethod(specVer, targetSpecVer, classSource, sourceEntityModel);
+                }
+            }
+        });
+
+        // Create convert methods for union types that contain entities
+        String namespace = specVer.getNamespace();
+        NamespaceModel nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        JavaTypeFactory jtf = getJavaTypeFactory();
+        getState().getConceptIndex().findTypes(namespace).stream()
+                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
+                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .forEach(unionType -> {
+                    JavaType jt = jtf.createJavaType(unionType, nsModel);
+                    String unionMethodName = "convert" + jt.getSimpleName();
+                    if (createdMethods.add(unionMethodName)) {
+                        createUnionConvertMethod(classSource, unionType, jt,
+                                namespace, targetSpecVer);
+                    }
+                });
+
+        getState().getJavaIndex().index(classSource);
+    }
+
+    private SpecificationVersion resolveTargetSpecVersion(String targetVersionName) {
+        for (SpecificationVersion sv : getState().getSpecIndex().getAllSpecificationVersions()) {
+            if (targetVersionName.equals(sv.getVersion())) {
+                return sv;
+            }
+        }
+        return null;
+    }
+
+    private void createConvertDispatch(SpecificationVersion specVer,
+            SpecificationVersion targetSpecVer, JavaClassSource classSource,
+            java.util.Set<String> createdMethods) {
+        createdMethods.add("convert");
+
+        String anyFQN = getState().getConfig().getRootNamespace() + ".Any";
+        classSource.addImport(anyFQN);
+
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName("convert")
+                .setReturnType("Any")
+                .setPublic();
+        method.addParameter("Any", "source");
+        method.addAnnotation(Override.class);
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (source == null) return null;");
+
+        boolean first = true;
+        String namespace = specVer.getNamespace();
+        NamespaceModel nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        JavaTypeFactory jtf = getJavaTypeFactory();
+
+        // Union types first
+        for (var type : getState().getConceptIndex().findTypes(namespace)) {
+            if (!(type instanceof io.apitomy.umg.models.concept.type.UnionType)) continue;
+            io.apitomy.umg.models.concept.type.UnionType unionType =
+                    (io.apitomy.umg.models.concept.type.UnionType) type;
+            JavaType jt = jtf.createJavaType(unionType, nsModel);
+            jt.addImportsTo(classSource);
+            String unionTypeName = jt.getSimpleName();
+
+            body.addContext("unionType", unionTypeName);
+            String convertMethodName = "convert" + unionTypeName;
+            body.addContext("methodName", convertMethodName);
+
+            if (first) {
+                body.append("if (source instanceof ${unionType}) {");
+                first = false;
+            } else {
+                body.append("} else if (source instanceof ${unionType}) {");
+            }
+            body.append("    return this.${methodName}((${unionType}) source);");
+        }
+
+        // Collect entity names covered by unions
+        java.util.Set<String> unionEntityNames = new java.util.HashSet<>();
+        for (var type : getState().getConceptIndex().findTypes(namespace)) {
+            if (type instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                for (var variant : ((io.apitomy.umg.models.concept.type.UnionType) type).getTypes()) {
+                    if (variant.isEntityType()) {
+                        unionEntityNames.add(variant.getName());
+                    }
+                }
+            }
+        }
+
+        // Entity types not covered by unions
+        for (var entity : specVer.getEntities()) {
+            EntityModel entityModel = getState().getConceptIndex()
+                    .lookupEntity(namespace + "." + entity.getName());
+            if (entityModel == null) continue;
+            if (unionEntityNames.contains(entityModel.getName())) continue;
+
+            JavaInterfaceSource javaEntity = lookupJavaEntity(entityModel);
+            classSource.addImport(javaEntity);
+            String entityType = javaEntity.getName();
+
+            body.addContext("entityType", entityType);
+            String convertMethodName = "convert" + entityModel.getName();
+            body.addContext("methodName", convertMethodName);
+
+            if (first) {
+                body.append("if (source instanceof ${entityType}) {");
+                first = false;
+            } else {
+                body.append("} else if (source instanceof ${entityType}) {");
+            }
+            body.append("    return this.${methodName}((${entityType}) source);");
+        }
+
+        if (!first) {
+            body.append("}");
+        }
+        body.append("return null;");
+
+        method.setBody(body.toString());
+    }
+
+    private void createEntityConvertMethod(SpecificationVersion specVer,
+            SpecificationVersion targetSpecVer,
+            JavaClassSource classSource, EntityModel sourceEntityModel) {
+        JavaInterfaceSource sourceJavaEntity = lookupJavaEntity(sourceEntityModel);
+        classSource.addImport(sourceJavaEntity);
+
+        String sourceEntityType = sourceJavaEntity.getName();
+        String entityName = sourceEntityModel.getName();
+        String methodName = "convert" + entityName;
+
+        EntityModel targetEntityModel = getState().getConceptIndex()
+                .lookupEntity(targetSpecVer.getNamespace() + "." + entityName);
+
+        // Determine return type
+        String returnType;
+        if (targetEntityModel != null) {
+            JavaInterfaceSource targetJavaEntity = lookupJavaEntity(targetEntityModel);
+            classSource.addImport(targetJavaEntity);
+            returnType = targetJavaEntity.getName();
+        } else {
+            returnType = "Object";
+        }
+
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName(methodName)
+                .setReturnType(returnType)
+                .setPublic();
+        method.addParameter(sourceEntityType, "source");
+
+        Collection<PropertyModelWithOrigin> sourceProperties =
+                getState().getConceptIndex().getAllEntityProperties(sourceEntityModel);
+
+        // Build target property lookup
+        java.util.Map<String, PropertyModelWithOrigin> targetPropertiesByName =
+                new java.util.LinkedHashMap<>();
+        if (targetEntityModel != null) {
+            Collection<PropertyModelWithOrigin> targetProperties =
+                    getState().getConceptIndex().getAllEntityProperties(targetEntityModel);
+            for (PropertyModelWithOrigin pwo : targetProperties) {
+                targetPropertiesByName.put(pwo.getProperty().getName(), pwo);
+            }
+        }
+
+        JavaTypeFactory jtf = getJavaTypeFactory();
+        BodyBuilder body = new BodyBuilder();
+
+        body.append("if (source == null) return null;");
+        body.addContext("visitMethod", "visit" + entityName);
+        body.addContext("returnType", returnType);
+        body.append(returnType + " target = (" + returnType + ") visitor.${visitMethod}(source);");
+        body.append("if (target == null) return null;");
+
+        for (PropertyModelWithOrigin propWithOrigin : sourceProperties) {
+            PropertyModel property = propWithOrigin.getProperty();
+            if (isStarProperty(property) || isRegexProperty(property)) {
+                continue;
+            }
+
+            String getter = new GetterMethod(property).getName();
+            String fieldSuffix = fieldMethodSuffix(property);
+            String convertMethodCall = "convert" + entityName + fieldSuffix;
+
+            body.addContext("getter", getter);
+            body.addContext("convertMethod", convertMethodCall);
+            body.addContext("propertyNameLiteral", property.getName());
+
+            NamespaceModel sourceNs = propWithOrigin.getOrigin().getNamespace();
+            PropertyModelWithOrigin targetPropWithOrigin = targetPropertiesByName.get(property.getName());
+
+            body.append("{");
+            body.append("    pushProperty(\"${propertyNameLiteral}\");");
+
+            if (isEntity(property)) {
+                JavaType jt = jtf.createJavaType(property.getResolvedType(), sourceNs);
+                jt.addImportsTo(classSource);
+
+                // Find target entity type
+                String sourceEntityRefName = property.getResolvedType().getName();
+                EntityModel targetRefEntity = getState().getConceptIndex()
+                        .lookupEntity(targetSpecVer.getNamespace() + "." + sourceEntityRefName);
+                if (targetRefEntity != null) {
+                    JavaInterfaceSource targetRefJavaEntity = lookupJavaEntity(targetRefEntity);
+                    classSource.addImport(targetRefJavaEntity);
+                    body.addContext("targetRefType", targetRefJavaEntity.getName());
+                    body.addContext("convertEntity", "convert" + sourceEntityRefName);
+                    body.append("    ${targetRefType} converted = ${convertEntity}(source.${getter}());");
+                    body.append("    visitor.${convertMethod}(converted, target);");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isUnion(property)) {
+                JavaType jt = jtf.createJavaType(property.getResolvedType(), sourceNs);
+                jt.addImportsTo(classSource);
+                String unionSimpleName = jt.getSimpleName();
+
+                // Find target union type
+                NamespaceModel targetNsModel = getState().getConceptIndex()
+                        .lookupNamespace(targetSpecVer.getNamespace());
+                JavaType targetUnionJt = findTargetUnionType(jt.getSimpleName(),
+                        targetSpecVer.getNamespace(), targetNsModel, jtf);
+
+                if (targetUnionJt != null) {
+                    targetUnionJt.addImportsTo(classSource);
+                    body.addContext("targetUnionType", targetUnionJt.toJavaTypeString());
+                    body.addContext("convertUnion", "convert" + unionSimpleName);
+                    body.append("    ${targetUnionType} converted = ${convertUnion}(source.${getter}());");
+                    body.append("    visitor.${convertMethod}(converted, target);");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isEntityList(property)) {
+                ListType listType = (ListType) property.getResolvedType();
+                JavaType valueJt = jtf.createJavaType(listType.getValueType(), sourceNs);
+                valueJt.addImportsTo(classSource);
+                classSource.addImport(java.util.List.class);
+                classSource.addImport(java.util.ArrayList.class);
+
+                String sourceEntityRefName = listType.getValueType().getName();
+                EntityModel targetRefEntity = getState().getConceptIndex()
+                        .lookupEntity(targetSpecVer.getNamespace() + "." + sourceEntityRefName);
+
+                if (targetRefEntity != null) {
+                    JavaInterfaceSource targetRefJavaEntity = lookupJavaEntity(targetRefEntity);
+                    classSource.addImport(targetRefJavaEntity);
+                    body.addContext("valueType", valueJt.toJavaTypeString());
+                    body.addContext("targetValueType", targetRefJavaEntity.getName());
+                    body.addContext("convertEntity", "convert" + sourceEntityRefName);
+                    body.append("    if (source.${getter}() != null) {");
+                    body.append("        List<" + targetRefJavaEntity.getName() + "> convertedList = new ArrayList<>();");
+                    body.append("        for (" + valueJt.toJavaTypeString() + " item : source.${getter}()) {");
+                    body.append("            convertedList.add(${convertEntity}(item));");
+                    body.append("        }");
+                    body.append("        visitor.${convertMethod}(convertedList, target);");
+                    body.append("    }");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isUnionList(property)) {
+                ListType listType = (ListType) property.getResolvedType();
+                JavaType valueJt = jtf.createJavaType(listType.getValueType(), sourceNs);
+                valueJt.addImportsTo(classSource);
+                classSource.addImport(java.util.List.class);
+                classSource.addImport(java.util.ArrayList.class);
+
+                String unionSimpleName = valueJt.getSimpleName();
+                NamespaceModel targetNsModel = getState().getConceptIndex()
+                        .lookupNamespace(targetSpecVer.getNamespace());
+                JavaType targetUnionJt = findTargetUnionType(unionSimpleName,
+                        targetSpecVer.getNamespace(), targetNsModel, jtf);
+
+                if (targetUnionJt != null) {
+                    targetUnionJt.addImportsTo(classSource);
+                    body.addContext("convertUnion", "convert" + unionSimpleName);
+                    body.addContext("sourceValueType", valueJt.toJavaTypeString());
+                    body.addContext("targetValueType", targetUnionJt.toJavaTypeString());
+                    body.append("    if (source.${getter}() != null) {");
+                    body.append("        List<${targetValueType}> convertedList = new ArrayList<>();");
+                    body.append("        for (${sourceValueType} item : source.${getter}()) {");
+                    body.append("            convertedList.add(${convertUnion}(item));");
+                    body.append("        }");
+                    body.append("        visitor.${convertMethod}(convertedList, target);");
+                    body.append("    }");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isEntityMap(property)) {
+                MapType mapType = (MapType) property.getResolvedType();
+                JavaType valueJt = jtf.createJavaType(mapType.getValueType(), sourceNs);
+                valueJt.addImportsTo(classSource);
+                classSource.addImport(java.util.Map.class);
+                classSource.addImport(java.util.LinkedHashMap.class);
+
+                String sourceEntityRefName = mapType.getValueType().getName();
+                EntityModel targetRefEntity = getState().getConceptIndex()
+                        .lookupEntity(targetSpecVer.getNamespace() + "." + sourceEntityRefName);
+
+                if (targetRefEntity != null) {
+                    JavaInterfaceSource targetRefJavaEntity = lookupJavaEntity(targetRefEntity);
+                    classSource.addImport(targetRefJavaEntity);
+                    body.addContext("valueType", valueJt.toJavaTypeString());
+                    body.addContext("targetValueType", targetRefJavaEntity.getName());
+                    body.addContext("convertEntity", "convert" + sourceEntityRefName);
+                    body.append("    if (source.${getter}() != null) {");
+                    body.append("        Map<String, " + targetRefJavaEntity.getName() + "> convertedMap = new LinkedHashMap<>();");
+                    body.append("        for (Map.Entry<String, " + valueJt.toJavaTypeString() + "> entry : source.${getter}().entrySet()) {");
+                    body.append("            convertedMap.put(entry.getKey(), ${convertEntity}(entry.getValue()));");
+                    body.append("        }");
+                    body.append("        visitor.${convertMethod}(convertedMap, target);");
+                    body.append("    }");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isUnionMap(property)) {
+                MapType mapType = (MapType) property.getResolvedType();
+                JavaType valueJt = jtf.createJavaType(mapType.getValueType(), sourceNs);
+                valueJt.addImportsTo(classSource);
+                classSource.addImport(java.util.Map.class);
+                classSource.addImport(java.util.LinkedHashMap.class);
+
+                String unionSimpleName = valueJt.getSimpleName();
+                NamespaceModel targetNsModel = getState().getConceptIndex()
+                        .lookupNamespace(targetSpecVer.getNamespace());
+                JavaType targetUnionJt = findTargetUnionType(unionSimpleName,
+                        targetSpecVer.getNamespace(), targetNsModel, jtf);
+
+                if (targetUnionJt != null) {
+                    targetUnionJt.addImportsTo(classSource);
+                    body.addContext("convertUnion", "convert" + unionSimpleName);
+                    body.addContext("sourceValueType", valueJt.toJavaTypeString());
+                    body.addContext("targetValueType", targetUnionJt.toJavaTypeString());
+                    body.append("    if (source.${getter}() != null) {");
+                    body.append("        Map<String, ${targetValueType}> convertedMap = new LinkedHashMap<>();");
+                    body.append("        for (Map.Entry<String, ${sourceValueType}> entry : source.${getter}().entrySet()) {");
+                    body.append("            convertedMap.put(entry.getKey(), ${convertUnion}(entry.getValue()));");
+                    body.append("        }");
+                    body.append("        visitor.${convertMethod}(convertedMap, target);");
+                    body.append("    }");
+                } else {
+                    body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+                }
+            } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
+                JavaType jt = jtf.createJavaType(property.getResolvedType(), sourceNs);
+                jt.addImportsTo(classSource);
+                body.append("    visitor.${convertMethod}(source.${getter}(), target);");
+            }
+
+            body.append("    pop();");
+            body.append("}");
+        }
+
+        body.append("return target;");
+        method.setBody(body.toString());
+    }
+
+    private void createUnionConvertMethod(JavaClassSource classSource,
+            io.apitomy.umg.models.concept.type.UnionType unionType,
+            JavaType unionJt, String sourceNamespace,
+            SpecificationVersion targetSpecVer) {
+        String unionTypeName = unionJt.getSimpleName();
+        String methodName = "convert" + unionTypeName;
+
+        unionJt.addImportsTo(classSource);
+
+        // Find corresponding target union type
+        NamespaceModel targetNsModel = getState().getConceptIndex()
+                .lookupNamespace(targetSpecVer.getNamespace());
+        JavaTypeFactory jtf = getJavaTypeFactory();
+        JavaType targetUnionJt = findTargetUnionType(unionTypeName,
+                targetSpecVer.getNamespace(), targetNsModel, jtf);
+
+        String returnType;
+        if (targetUnionJt != null) {
+            targetUnionJt.addImportsTo(classSource);
+            returnType = targetUnionJt.toJavaTypeString();
+        } else {
+            returnType = unionJt.toJavaTypeString();
+        }
+
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName(methodName)
+                .setReturnType(returnType)
+                .setPublic();
+        method.addParameter(unionJt.toJavaTypeString(), "source");
+
+        BodyBuilder body = new BodyBuilder();
+        body.append("if (source == null) return null;");
+
+        // For entity variants: convert via the entity converter
+        for (var variantType : unionType.getTypes()) {
+            if (variantType.isEntityType()) {
+                var entity = ((io.apitomy.umg.models.concept.type.EntityType) variantType).getEntity();
+                if (entity == null) {
+                    entity = getState().getConceptIndex()
+                            .lookupEntity(sourceNamespace, variantType.getName());
+                }
+                if (entity != null) {
+                    JavaInterfaceSource entityInterface = lookupJavaEntity(entity);
+                    classSource.addImport(entityInterface);
+                    body.addContext("entityType", entityInterface.getName());
+                    body.addContext("convertEntity", "convert" + entity.getName());
+                    body.append("if (source instanceof ${entityType}) {");
+                    body.append("    return ${convertEntity}((${entityType}) source);");
+                    body.append("}");
+                }
+            }
+        }
+
+        // For primitive variants, pass through
+        body.addContext("returnType", returnType);
+        body.append("return (" + returnType + ") source;");
+
+        method.setBody(body.toString());
+    }
+
+    /**
+     * Finds a union type in the target namespace that matches the given source union name.
+     */
+    private JavaType findTargetUnionType(String sourceUnionSimpleName,
+            String targetNamespace, NamespaceModel targetNsModel, JavaTypeFactory jtf) {
+        if (targetNsModel == null) return null;
+        for (var type : getState().getConceptIndex().findTypes(targetNamespace)) {
+            if (type instanceof io.apitomy.umg.models.concept.type.UnionType) {
+                JavaType jt = jtf.createJavaType(type, targetNsModel);
+                if (jt.getSimpleName().equals(sourceUnionSimpleName)) {
+                    return jt;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String fieldMethodSuffix(PropertyModel property) {
+        String name = property.getName();
+        if (name.startsWith("$")) {
+            return name;
+        }
+        return StringUtils.capitalize(name);
+    }
+
+    private static String singularize(String name) {
+        return CodeGenContext.singularize(name);
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
@@ -226,11 +226,13 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                 method.setBody("target." + setterName + "(value);");
             } else {
                 // Different types: empty body (override needed)
-                method.setBody("// Type mismatch — custom conversion required");
+                method.setBody("");
+                method.getJavaDoc().setText("Type mismatch — custom conversion required.");
             }
         } else {
             // No matching target field: empty body (field dropped)
-            method.setBody("// Field not present in target — dropped during conversion");
+            method.setBody("");
+            method.getJavaDoc().setText("Field not present in target — dropped during conversion.");
         }
     }
 
@@ -284,13 +286,16 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                                 + " v : value) { target." + adderName + "(v); } }");
                     }
                 } else {
-                    method.setBody("// Type mismatch — custom conversion required");
+                    method.setBody("");
+                method.getJavaDoc().setText("Type mismatch — custom conversion required.");
                 }
             } else {
-                method.setBody("// Type mismatch — custom conversion required");
+                method.setBody("");
+                method.getJavaDoc().setText("Type mismatch — custom conversion required.");
             }
         } else {
-            method.setBody("// Field not present in target — dropped during conversion");
+            method.setBody("");
+            method.getJavaDoc().setText("Field not present in target — dropped during conversion.");
         }
     }
 
@@ -345,13 +350,16 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                                 + adderName + "(e.getKey(), e.getValue()); } }");
                     }
                 } else {
-                    method.setBody("// Type mismatch — custom conversion required");
+                    method.setBody("");
+                method.getJavaDoc().setText("Type mismatch — custom conversion required.");
                 }
             } else {
-                method.setBody("// Type mismatch — custom conversion required");
+                method.setBody("");
+                method.getJavaDoc().setText("Type mismatch — custom conversion required.");
             }
         } else {
-            method.setBody("// Field not present in target — dropped during conversion");
+            method.setBody("");
+            method.getJavaDoc().setText("Field not present in target — dropped during conversion.");
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
@@ -1,0 +1,348 @@
+package io.apitomy.umg.pipe.java;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+
+import io.apitomy.umg.beans.SpecificationVersion;
+import io.apitomy.umg.models.concept.EntityModel;
+import io.apitomy.umg.models.concept.NamespaceModel;
+import io.apitomy.umg.models.concept.PropertyModel;
+import io.apitomy.umg.models.concept.PropertyModelWithOrigin;
+import io.apitomy.umg.models.concept.type.ListType;
+import io.apitomy.umg.models.concept.type.MapType;
+import io.apitomy.umg.models.java.type.JavaType;
+import io.apitomy.umg.models.java.type.JavaTypeFactory;
+import io.apitomy.umg.pipe.java.method.CodeGenContext;
+
+/**
+ * Creates a ConversionVisitor abstract class per spec version that has a
+ * {@code conversionTarget} configured. Each generated visitor contains typed,
+ * field-specific methods for converting source entities/fields to target entities.
+ */
+public class CreateConversionVisitorsStage extends AbstractJavaStage {
+
+    @Override
+    protected void doProcess() {
+        getState().getSpecIndex().getAllSpecificationVersions().forEach(specVer -> {
+            if (specVer.getConversionTarget() != null) {
+                createConversionVisitor(specVer);
+            }
+        });
+    }
+
+    private void createConversionVisitor(SpecificationVersion specVer) {
+        String targetVersionName = specVer.getConversionTarget();
+        SpecificationVersion targetSpecVer = resolveTargetSpecVersion(targetVersionName);
+        if (targetSpecVer == null) {
+            warn("Conversion target '%s' not found for spec '%s'", targetVersionName, specVer.getName());
+            return;
+        }
+
+        String packageName = getTraverserPackageName(specVer);
+        String className = specVer.getPrefix() + "ConversionVisitor";
+
+        debug("Creating conversion visitor: " + className);
+
+        JavaClassSource classSource = Roaster.create(JavaClassSource.class)
+                .setPackage(packageName)
+                .setName(className)
+                .setPublic()
+                .setAbstract(true);
+
+        JavaTypeFactory jtf = getJavaTypeFactory();
+
+        specVer.getEntities().forEach(entity -> {
+            EntityModel sourceEntityModel = getState().getConceptIndex()
+                    .lookupEntity(specVer.getNamespace() + "." + entity.getName());
+            if (sourceEntityModel == null) {
+                return;
+            }
+
+            EntityModel targetEntityModel = getState().getConceptIndex()
+                    .lookupEntity(targetSpecVer.getNamespace() + "." + entity.getName());
+
+            createEntityVisitMethod(classSource, sourceEntityModel, targetEntityModel, targetSpecVer);
+            createPropertyMethods(classSource, sourceEntityModel, targetEntityModel, targetSpecVer, jtf);
+        });
+
+        getState().getJavaIndex().index(classSource);
+    }
+
+    private SpecificationVersion resolveTargetSpecVersion(String targetVersionName) {
+        for (SpecificationVersion sv : getState().getSpecIndex().getAllSpecificationVersions()) {
+            if (targetVersionName.equals(sv.getVersion())) {
+                return sv;
+            }
+        }
+        return null;
+    }
+
+    private void createEntityVisitMethod(JavaClassSource classSource,
+            EntityModel sourceEntityModel, EntityModel targetEntityModel,
+            SpecificationVersion targetSpecVer) {
+        JavaInterfaceSource sourceJavaEntity = lookupJavaEntity(sourceEntityModel);
+        classSource.addImport(sourceJavaEntity);
+
+        String methodName = "visit" + sourceEntityModel.getName();
+
+        if (targetEntityModel != null) {
+            JavaInterfaceSource targetJavaEntity = lookupJavaEntity(targetEntityModel);
+            classSource.addImport(targetJavaEntity);
+
+            String targetImplFQN = getJavaEntityClassFQN(targetEntityModel);
+            JavaClassSource targetImplSource = getState().getJavaIndex().lookupClass(targetImplFQN);
+            classSource.addImport(targetImplSource);
+
+            MethodSource<JavaClassSource> method = classSource.addMethod()
+                    .setName(methodName)
+                    .setReturnType(targetJavaEntity.getName())
+                    .setPublic();
+            method.addParameter(sourceJavaEntity.getName(), "source");
+            method.setBody("return new " + targetImplSource.getName() + "();");
+        } else {
+            // No matching target entity; return null
+            MethodSource<JavaClassSource> method = classSource.addMethod()
+                    .setName(methodName)
+                    .setReturnType("Object")
+                    .setPublic();
+            method.addParameter(sourceJavaEntity.getName(), "source");
+            method.setBody("return null;");
+        }
+    }
+
+    private void createPropertyMethods(JavaClassSource classSource,
+            EntityModel sourceEntityModel, EntityModel targetEntityModel,
+            SpecificationVersion targetSpecVer, JavaTypeFactory jtf) {
+        Collection<PropertyModelWithOrigin> sourceProperties =
+                getState().getConceptIndex().getAllEntityProperties(sourceEntityModel);
+
+        // Build a map of target properties by name for quick lookup
+        Map<String, PropertyModelWithOrigin> targetPropertiesByName = new java.util.LinkedHashMap<>();
+        if (targetEntityModel != null) {
+            Collection<PropertyModelWithOrigin> targetProperties =
+                    getState().getConceptIndex().getAllEntityProperties(targetEntityModel);
+            for (PropertyModelWithOrigin pwo : targetProperties) {
+                targetPropertiesByName.put(pwo.getProperty().getName(), pwo);
+            }
+        }
+
+        for (PropertyModelWithOrigin propWithOrigin : sourceProperties) {
+            PropertyModel property = propWithOrigin.getProperty();
+            if (isStarProperty(property) || isRegexProperty(property)) {
+                continue;
+            }
+
+            String entityName = sourceEntityModel.getName();
+            String fieldSuffix = fieldMethodSuffix(property);
+            NamespaceModel sourceNs = propWithOrigin.getOrigin().getNamespace();
+
+            PropertyModelWithOrigin targetPropWithOrigin = targetPropertiesByName.get(property.getName());
+
+            if (isEntity(property)) {
+                createSingleFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isEntityList(property) || isUnionList(property)) {
+                createListFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isEntityMap(property) || isUnionMap(property)) {
+                createMapFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isUnion(property)) {
+                createSingleFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isPrimitive(property)) {
+                createSingleFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isPrimitiveList(property)) {
+                createListFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            } else if (isPrimitiveMap(property)) {
+                createMapFieldMethod(classSource, entityName, fieldSuffix, property, sourceNs,
+                        targetEntityModel, targetPropWithOrigin, targetSpecVer, jtf);
+            }
+        }
+    }
+
+    private void createSingleFieldMethod(JavaClassSource classSource, String entityName,
+            String fieldSuffix, PropertyModel sourceProperty, NamespaceModel sourceNs,
+            EntityModel targetEntityModel, PropertyModelWithOrigin targetPropWithOrigin,
+            SpecificationVersion targetSpecVer, JavaTypeFactory jtf) {
+        JavaType sourceJt = jtf.createJavaType(sourceProperty.getResolvedType(), sourceNs);
+        sourceJt.addImportsTo(classSource);
+
+        String methodName = "convert" + entityName + fieldSuffix;
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName(methodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        method.addParameter(sourceJt.toJavaTypeString(), "value");
+
+        if (targetEntityModel != null) {
+            JavaInterfaceSource targetJavaEntity = lookupJavaEntity(targetEntityModel);
+            classSource.addImport(targetJavaEntity);
+            method.addParameter(targetJavaEntity.getName(), "target");
+        } else {
+            method.addParameter("Object", "target");
+        }
+
+        // Generate default body
+        if (targetPropWithOrigin != null && targetEntityModel != null) {
+            PropertyModel targetProperty = targetPropWithOrigin.getProperty();
+            NamespaceModel targetNs = targetPropWithOrigin.getOrigin().getNamespace();
+            JavaType targetJt = jtf.createJavaType(targetProperty.getResolvedType(), targetNs);
+            targetJt.addImportsTo(classSource);
+
+            // Check type compatibility
+            if (sourceJt.toJavaTypeString().equals(targetJt.toJavaTypeString())) {
+                // Compatible types: generate setter call
+                String setterName = "set" + StringUtils.capitalize(targetProperty.getName());
+                method.setBody("target." + setterName + "(value);");
+            } else {
+                // Different types: empty body (override needed)
+                method.setBody("");
+            }
+        } else {
+            // No matching target field: empty body (field dropped)
+            method.setBody("");
+        }
+    }
+
+    private void createListFieldMethod(JavaClassSource classSource, String entityName,
+            String fieldSuffix, PropertyModel sourceProperty, NamespaceModel sourceNs,
+            EntityModel targetEntityModel, PropertyModelWithOrigin targetPropWithOrigin,
+            SpecificationVersion targetSpecVer, JavaTypeFactory jtf) {
+        JavaType sourceJt = jtf.createJavaType(sourceProperty.getResolvedType(), sourceNs);
+        sourceJt.addImportsTo(classSource);
+        classSource.addImport(java.util.List.class);
+
+        ListType sourceListType = (ListType) sourceProperty.getResolvedType();
+        JavaType sourceValueJt = jtf.createJavaType(sourceListType.getValueType(), sourceNs);
+        sourceValueJt.addImportsTo(classSource);
+
+        String methodName = "convert" + entityName + fieldSuffix;
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName(methodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        method.addParameter("List<" + sourceValueJt.toJavaTypeString() + ">", "value");
+
+        if (targetEntityModel != null) {
+            JavaInterfaceSource targetJavaEntity = lookupJavaEntity(targetEntityModel);
+            classSource.addImport(targetJavaEntity);
+            method.addParameter(targetJavaEntity.getName(), "target");
+        } else {
+            method.addParameter("Object", "target");
+        }
+
+        // Generate default body
+        if (targetPropWithOrigin != null && targetEntityModel != null) {
+            PropertyModel targetProperty = targetPropWithOrigin.getProperty();
+            NamespaceModel targetNs = targetPropWithOrigin.getOrigin().getNamespace();
+
+            if (isEntityList(targetProperty) || isUnionList(targetProperty) || isPrimitiveList(targetProperty)) {
+                ListType targetListType = (ListType) targetProperty.getResolvedType();
+                JavaType targetValueJt = jtf.createJavaType(targetListType.getValueType(), targetNs);
+                targetValueJt.addImportsTo(classSource);
+
+                if (sourceValueJt.toJavaTypeString().equals(targetValueJt.toJavaTypeString())) {
+                    if (isPrimitiveList(targetProperty)) {
+                        // Primitive lists use setter
+                        String setterName = "set" + StringUtils.capitalize(targetProperty.getName());
+                        method.setBody("target." + setterName + "(value);");
+                    } else {
+                        // Entity/union lists use adder
+                        String adderName = "add" + StringUtils.capitalize(
+                                CodeGenContext.singularize(targetProperty.getName()));
+                        method.setBody("if (value != null) { for (" + sourceValueJt.toJavaTypeString()
+                                + " v : value) { target." + adderName + "(v); } }");
+                    }
+                } else {
+                    method.setBody("");
+                }
+            } else {
+                method.setBody("");
+            }
+        } else {
+            method.setBody("");
+        }
+    }
+
+    private void createMapFieldMethod(JavaClassSource classSource, String entityName,
+            String fieldSuffix, PropertyModel sourceProperty, NamespaceModel sourceNs,
+            EntityModel targetEntityModel, PropertyModelWithOrigin targetPropWithOrigin,
+            SpecificationVersion targetSpecVer, JavaTypeFactory jtf) {
+        JavaType sourceJt = jtf.createJavaType(sourceProperty.getResolvedType(), sourceNs);
+        sourceJt.addImportsTo(classSource);
+        classSource.addImport(java.util.Map.class);
+
+        MapType sourceMapType = (MapType) sourceProperty.getResolvedType();
+        JavaType sourceValueJt = jtf.createJavaType(sourceMapType.getValueType(), sourceNs);
+        sourceValueJt.addImportsTo(classSource);
+
+        String methodName = "convert" + entityName + fieldSuffix;
+        MethodSource<JavaClassSource> method = classSource.addMethod()
+                .setName(methodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        method.addParameter("Map<String, " + sourceValueJt.toJavaTypeString() + ">", "value");
+
+        if (targetEntityModel != null) {
+            JavaInterfaceSource targetJavaEntity = lookupJavaEntity(targetEntityModel);
+            classSource.addImport(targetJavaEntity);
+            method.addParameter(targetJavaEntity.getName(), "target");
+        } else {
+            method.addParameter("Object", "target");
+        }
+
+        // Generate default body
+        if (targetPropWithOrigin != null && targetEntityModel != null) {
+            PropertyModel targetProperty = targetPropWithOrigin.getProperty();
+            NamespaceModel targetNs = targetPropWithOrigin.getOrigin().getNamespace();
+
+            if (isEntityMap(targetProperty) || isUnionMap(targetProperty) || isPrimitiveMap(targetProperty)) {
+                MapType targetMapType = (MapType) targetProperty.getResolvedType();
+                JavaType targetValueJt = jtf.createJavaType(targetMapType.getValueType(), targetNs);
+                targetValueJt.addImportsTo(classSource);
+
+                if (sourceValueJt.toJavaTypeString().equals(targetValueJt.toJavaTypeString())) {
+                    if (isPrimitiveMap(targetProperty)) {
+                        // Primitive maps use setter
+                        String setterName = "set" + StringUtils.capitalize(targetProperty.getName());
+                        method.setBody("target." + setterName + "(value);");
+                    } else {
+                        // Entity/union maps use adder
+                        String adderName = "add" + StringUtils.capitalize(
+                                CodeGenContext.singularize(targetProperty.getName()));
+                        method.setBody("if (value != null) { for (Map.Entry<String, "
+                                + sourceValueJt.toJavaTypeString() + "> e : value.entrySet()) { target."
+                                + adderName + "(e.getKey(), e.getValue()); } }");
+                    }
+                } else {
+                    method.setBody("");
+                }
+            } else {
+                method.setBody("");
+            }
+        } else {
+            method.setBody("");
+        }
+    }
+
+    private String fieldMethodSuffix(PropertyModel property) {
+        String name = property.getName();
+        if (name.startsWith("$")) {
+            return name;
+        }
+        return StringUtils.capitalize(name);
+    }
+
+    private boolean hasMethod(JavaClassSource classSource, String methodName) {
+        return classSource.getMethods().stream().anyMatch(m -> m.getName().equals(methodName));
+    }
+}

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateConversionVisitorsStage.java
@@ -45,7 +45,7 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
         }
 
         String packageName = getTraverserPackageName(specVer);
-        String className = specVer.getPrefix() + "ConversionVisitor";
+        String className = specVer.getPrefix() + "To" + targetSpecVer.getPrefix() + "ConversionVisitor";
 
         debug("Creating conversion visitor: " + className);
 
@@ -70,6 +70,27 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
             createEntityVisitMethod(classSource, sourceEntityModel, targetEntityModel, targetSpecVer);
             createPropertyMethods(classSource, sourceEntityModel, targetEntityModel, targetSpecVer, jtf);
         });
+
+        // Union convert methods
+        String namespace = specVer.getNamespace();
+        var nsModel = getState().getConceptIndex().lookupNamespace(namespace);
+        getState().getConceptIndex().findTypes(namespace).stream()
+                .filter(t -> t instanceof io.apitomy.umg.models.concept.type.UnionType)
+                .map(t -> (io.apitomy.umg.models.concept.type.UnionType) t)
+                .forEach(unionType -> {
+                    var jt = jtf.createJavaType(unionType, nsModel);
+                    jt.addImportsTo(classSource);
+                    String unionTypeName = jt.getSimpleName();
+                    String methodName = "convert" + unionTypeName;
+                    if (!hasMethod(classSource, methodName)) {
+                        MethodSource<JavaClassSource> method = classSource.addMethod()
+                                .setName(methodName)
+                                .setReturnType(jt.toJavaTypeString())
+                                .setPublic();
+                        method.addParameter(jt.toJavaTypeString(), "source");
+                        method.setBody("return source;");
+                    }
+                });
 
         getState().getJavaIndex().index(classSource);
     }
@@ -205,11 +226,11 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                 method.setBody("target." + setterName + "(value);");
             } else {
                 // Different types: empty body (override needed)
-                method.setBody("");
+                method.setBody("// Type mismatch — custom conversion required");
             }
         } else {
             // No matching target field: empty body (field dropped)
-            method.setBody("");
+            method.setBody("// Field not present in target — dropped during conversion");
         }
     }
 
@@ -263,13 +284,13 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                                 + " v : value) { target." + adderName + "(v); } }");
                     }
                 } else {
-                    method.setBody("");
+                    method.setBody("// Type mismatch — custom conversion required");
                 }
             } else {
-                method.setBody("");
+                method.setBody("// Type mismatch — custom conversion required");
             }
         } else {
-            method.setBody("");
+            method.setBody("// Field not present in target — dropped during conversion");
         }
     }
 
@@ -324,13 +345,13 @@ public class CreateConversionVisitorsStage extends AbstractJavaStage {
                                 + adderName + "(e.getKey(), e.getValue()); } }");
                     }
                 } else {
-                    method.setBody("");
+                    method.setBody("// Type mismatch — custom conversion required");
                 }
             } else {
-                method.setBody("");
+                method.setBody("// Type mismatch — custom conversion required");
             }
         } else {
-            method.setBody("");
+            method.setBody("// Field not present in target — dropped during conversion");
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -54,16 +54,14 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
         String baseFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.AbstractDiffTraverser";
         JavaClassSource baseSource = getState().getJavaIndex().lookupClass(baseFQN);
         classSource.addImport(baseSource);
+        String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
+        classSource.addImport(pairingKeyFQN);
         classSource.addTypeVariable("P");
         classSource.setSuperType("AbstractDiffTraverser<P, " + visitorClassName + "<P>>");
 
         // Import CollectionDiff for collection field handling
         String collectionDiffFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.CollectionDiff";
         classSource.addImport(collectionDiffFQN);
-
-        String nodeFQN = getNodeEntityInterfaceFQN();
-        JavaInterfaceSource nodeSource = getState().getJavaIndex().lookupInterface(nodeFQN);
-        classSource.addImport(nodeSource);
 
         // Import PairingStrategyProvider
         String providerFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingStrategyProvider";
@@ -239,16 +237,20 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
 
             body.addContext("getter", getter);
             body.addContext("diffMethod", diffMethod);
+            body.addContext("propertyNameLiteral", property.getName());
 
             NamespaceModel ns = propWithOrigin.getOrigin().getNamespace();
+
+            body.append("{");
+            body.append("    pushProperty(\"${propertyNameLiteral}\");");
 
             if (isEntity(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("if (original.${getter}() != null && updated.${getter}() != null) {");
-                body.append("    traverse(original.${getter}(), updated.${getter}());");
-                body.append("}");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    if (original.${getter}() != null && updated.${getter}() != null) {");
+                body.append("        traverse(original.${getter}(), updated.${getter}());");
+                body.append("    }");
             } else if (isEntityList(property) || isUnionList(property)) {
                 ListType listType = (ListType) property.getResolvedType();
                 JavaType valueJt = jtf.createJavaType(listType.getValueType(), ns);
@@ -260,10 +262,10 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.addContext("visitMethod2", visitMethod);
                 body.addContext("propertyName", property.getName());
 
-                body.append("{");
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairList(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
+                body.append("        pushElement((PairingKey) pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityList(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -276,8 +278,8 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                     body.addContext("traverseUnion", traverseUnion);
                     body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        pop();");
                 body.append("    }");
-                body.append("}");
             } else if (isEntityMap(property) || isUnionMap(property)) {
                 MapType mapType = (MapType) property.getResolvedType();
                 JavaType valueJt = jtf.createJavaType(mapType.getValueType(), ns);
@@ -289,10 +291,10 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.addContext("visitMethod2", visitMethod);
                 body.addContext("propertyName", property.getName());
 
-                body.append("{");
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
+                body.append("        pushElement((PairingKey) pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -305,20 +307,23 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                     body.addContext("traverseUnion", traverseUnion);
                     body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        pop();");
                 body.append("    }");
-                body.append("}");
             } else if (isUnion(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
                 String traverseUnion = "traverse" + jt.getSimpleName();
                 body.addContext("traverseUnion", traverseUnion);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("this.${traverseUnion}(original.${getter}(), updated.${getter}());");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    this.${traverseUnion}(original.${getter}(), updated.${getter}());");
             } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
-                body.append("visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
             }
+
+            body.append("    pop();");
+            body.append("}");
         }
 
         method.setBody(body.toString());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -56,7 +56,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
         classSource.addImport(baseSource);
         String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
         classSource.addImport(pairingKeyFQN);
-        classSource.addTypeVariable("P");
+        classSource.addTypeVariable("P").setBounds("PairingKey");
         classSource.setSuperType("AbstractDiffTraverser<P, " + visitorClassName + "<P>>");
 
         // Import CollectionDiff for collection field handling
@@ -265,7 +265,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairList(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushElement((PairingKey) pair.getKey());");
+                body.append("        pushListIndex(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityList(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
@@ -294,7 +294,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushElement((PairingKey) pair.getKey());");
+                body.append("        pushMapIndex(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -294,7 +294,7 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
-                body.append("        pushMapIndex(pair.getKey());");
+                body.append("        pushMapKey(pair.getKey());");
                 body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 if (isEntityMap(property)) {
                     body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -43,7 +43,7 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
 
         String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
         classSource.addImport(pairingKeyFQN);
-        classSource.addTypeVariable("P");
+        classSource.addTypeVariable("P").setBounds("PairingKey");
 
         JavaTypeFactory jtf = getJavaTypeFactory();
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -41,6 +41,8 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
                 .setPublic()
                 .setAbstract(true);
 
+        String pairingKeyFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingKey";
+        classSource.addImport(pairingKeyFQN);
         classSource.addTypeVariable("P");
 
         JavaTypeFactory jtf = getJavaTypeFactory();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
@@ -38,6 +38,7 @@ public class LoadBaseClassesStage extends AbstractStage {
                     "io.apitomy.umg.base.visitors.TraversalStep",
                     "io.apitomy.umg.base.visitors.TraversalContextImpl",
                     "io.apitomy.umg.base.visitors.ReverseTraverser",
+                    "io.apitomy.umg.base.visitors.convert.AbstractConversionTraverser",
                     "io.apitomy.umg.base.visitors.diff.AbstractDiffTraverser",
                     "io.apitomy.umg.base.visitors.diff.CollectionDiff",
                     "io.apitomy.umg.base.visitors.diff.DefaultPairingKey",

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
@@ -72,6 +72,7 @@ public class LoadBaseClassesStage extends AbstractStage {
                     "io.apitomy.umg.base.union.StringListUnionValue",
                     "io.apitomy.umg.base.visitors.diff.ListPairingStrategy",
                     "io.apitomy.umg.base.visitors.diff.MapPairingStrategy",
+                    "io.apitomy.umg.base.visitors.diff.PairingKey",
                     "io.apitomy.umg.base.visitors.diff.PairingStrategyProvider",
 
                     "io.apitomy.umg.base.union.Union",

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/convert/AbstractConversionTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/convert/AbstractConversionTraverser.java
@@ -1,0 +1,50 @@
+package io.apitomy.umg.base.visitors.convert;
+
+import io.apitomy.umg.base.Any;
+import io.apitomy.umg.base.visitors.TraversalContext;
+import io.apitomy.umg.base.visitors.TraversalContextImpl;
+
+/**
+ * Base class for generated conversion traversers. Converts a source tree
+ * into a target tree by iterating source fields and delegating value
+ * mapping to a ConversionVisitor.
+ *
+ * @param <V> the spec-version-specific ConversionVisitor subclass
+ */
+public class AbstractConversionTraverser<V> {
+
+    protected final V visitor;
+    protected final TraversalContextImpl context;
+
+    protected AbstractConversionTraverser(V visitor) {
+        this.visitor = visitor;
+        this.context = new TraversalContextImpl();
+    }
+
+    public TraversalContext getContext() {
+        return context;
+    }
+
+    protected void pushProperty(String propertyName) {
+        context.pushProperty(propertyName);
+    }
+
+    protected void pushListIndex(int index) {
+        context.pushListIndex(index);
+    }
+
+    protected void pushMapKey(String key) {
+        context.pushMapIndex(key);
+    }
+
+    protected void pop() {
+        context.pop();
+    }
+
+    /**
+     * Public entry point. Generated subclasses override with type-based dispatch.
+     */
+    public Any convert(Any source) {
+        return null;
+    }
+}

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -53,7 +53,7 @@ public class AbstractDiffTraverser<P extends PairingKey, V> {
         updatedContext.pushProperty(propertyName);
     }
 
-    protected void pushMapIndex(PairingKey key) {
+    protected void pushMapKey(PairingKey key) {
         if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
             throw new IllegalStateException("Map pairing key must have both original and updated keys");
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -14,7 +14,7 @@ import io.apitomy.umg.base.visitors.TraversalContextImpl;
  * @param <P> the pairing key type
  * @param <V> the spec-version-specific DiffVisitor subclass
  */
-public class AbstractDiffTraverser<P, V> {
+public class AbstractDiffTraverser<P extends PairingKey, V> {
 
     protected final V visitor;
     protected final PairingStrategyProvider<P> pairingProvider;
@@ -53,20 +53,20 @@ public class AbstractDiffTraverser<P, V> {
         updatedContext.pushProperty(propertyName);
     }
 
-    /**
-     * Push collection element positions onto the respective contexts.
-     */
-    protected void pushElement(PairingKey key) {
-        if (key.getOriginalKey() != null) {
-            originalContext.pushMapIndex(key.getOriginalKey());
-        } else if (key.getOriginalIndex() != null) {
-            originalContext.pushListIndex(key.getOriginalIndex());
+    protected void pushMapIndex(PairingKey key) {
+        if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
+            throw new IllegalStateException("Map pairing key must have both original and updated keys");
         }
-        if (key.getUpdatedKey() != null) {
-            updatedContext.pushMapIndex(key.getUpdatedKey());
-        } else if (key.getUpdatedIndex() != null) {
-            updatedContext.pushListIndex(key.getUpdatedIndex());
+        originalContext.pushMapIndex(key.getOriginalKey());
+        updatedContext.pushMapIndex(key.getUpdatedKey());
+    }
+
+    protected void pushListIndex(PairingKey key) {
+        if (key.getOriginalIndex() == null || key.getUpdatedIndex() == null) {
+            throw new IllegalStateException("List pairing key must have both original and updated indices");
         }
+        originalContext.pushListIndex(key.getOriginalIndex());
+        updatedContext.pushListIndex(key.getUpdatedIndex());
     }
 
     /**

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/AbstractDiffTraverser.java
@@ -4,11 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import io.apitomy.umg.base.Any;
+import io.apitomy.umg.base.visitors.TraversalContext;
+import io.apitomy.umg.base.visitors.TraversalContextImpl;
 
 /**
- * Base class for generated diff traversers. Provides shared collection pairing logic.
- * Subclasses (generated per spec version) provide entity-specific field iteration
- * and call typed visitor methods.
+ * Base class for generated diff traversers. Provides shared collection pairing logic
+ * and path tracking via two TraversalContext instances (one per side).
  *
  * @param <P> the pairing key type
  * @param <V> the spec-version-specific DiffVisitor subclass
@@ -17,23 +18,65 @@ public class AbstractDiffTraverser<P, V> {
 
     protected final V visitor;
     protected final PairingStrategyProvider<P> pairingProvider;
+    protected final TraversalContextImpl originalContext;
+    protected final TraversalContextImpl updatedContext;
 
     @SuppressWarnings("unchecked")
     protected AbstractDiffTraverser(V visitor) {
         this.visitor = visitor;
         this.pairingProvider = (PairingStrategyProvider<P>) new DefaultPairingStrategyProvider();
+        this.originalContext = new TraversalContextImpl();
+        this.updatedContext = new TraversalContextImpl();
     }
 
+    @SuppressWarnings("unchecked")
     protected AbstractDiffTraverser(V visitor, PairingStrategyProvider<P> pairingProvider) {
         this.visitor = visitor;
         this.pairingProvider = pairingProvider;
+        this.originalContext = new TraversalContextImpl();
+        this.updatedContext = new TraversalContextImpl();
+    }
+
+    public TraversalContext getOriginalContext() {
+        return originalContext;
+    }
+
+    public TraversalContext getUpdatedContext() {
+        return updatedContext;
     }
 
     /**
-     * Public entry point — accepts Any (Node or Union).
-     * Generated subclasses override this with type-based dispatch
-     * to union traverse methods and entity traverse methods.
+     * Push a property name onto both contexts (shared by both sides).
      */
+    protected void pushProperty(String propertyName) {
+        originalContext.pushProperty(propertyName);
+        updatedContext.pushProperty(propertyName);
+    }
+
+    /**
+     * Push collection element positions onto the respective contexts.
+     */
+    protected void pushElement(PairingKey key) {
+        if (key.getOriginalKey() != null) {
+            originalContext.pushMapIndex(key.getOriginalKey());
+        } else if (key.getOriginalIndex() != null) {
+            originalContext.pushListIndex(key.getOriginalIndex());
+        }
+        if (key.getUpdatedKey() != null) {
+            updatedContext.pushMapIndex(key.getUpdatedKey());
+        } else if (key.getUpdatedIndex() != null) {
+            updatedContext.pushListIndex(key.getUpdatedIndex());
+        }
+    }
+
+    /**
+     * Pop from both contexts.
+     */
+    protected void pop() {
+        originalContext.pop();
+        updatedContext.pop();
+    }
+
     public void traverse(Any original, Any updated) {
     }
 
@@ -46,5 +89,4 @@ public class AbstractDiffTraverser<P, V> {
         ListPairingStrategy<P, T> strategy = pairingProvider.getListStrategy(propertyName);
         return strategy.pair(original, updated);
     }
-
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/CollectionDiff.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/CollectionDiff.java
@@ -11,31 +11,31 @@ import java.util.Set;
  * Result of pairing two collections. Contains entries that were added, removed,
  * or matched between the original and updated collections.
  *
- * @param <K> the key type (String for maps, Integer for lists)
- * @param <V> the value type
+ * @param <P> the pairing key type (String for maps, Integer for lists)
+ * @param <T> the value type
  */
-public class CollectionDiff<K, V> {
+public class CollectionDiff<P, T> {
 
-    private final List<Entry<K, V>> added;
-    private final List<Entry<K, V>> removed;
-    private final List<MatchedPair<K, V>> matched;
+    private final List<Entry<P, T>> added;
+    private final List<Entry<P, T>> removed;
+    private final List<MatchedPair<P, T>> matched;
 
-    public CollectionDiff(List<Entry<K, V>> added, List<Entry<K, V>> removed,
-            List<MatchedPair<K, V>> matched) {
+    public CollectionDiff(List<Entry<P, T>> added, List<Entry<P, T>> removed,
+            List<MatchedPair<P, T>> matched) {
         this.added = added;
         this.removed = removed;
         this.matched = matched;
     }
 
-    public List<Entry<K, V>> getAdded() {
+    public List<Entry<P, T>> getAdded() {
         return added;
     }
 
-    public List<Entry<K, V>> getRemoved() {
+    public List<Entry<P, T>> getRemoved() {
         return removed;
     }
 
-    public List<MatchedPair<K, V>> getMatched() {
+    public List<MatchedPair<P, T>> getMatched() {
         return matched;
     }
 
@@ -47,19 +47,19 @@ public class CollectionDiff<K, V> {
      * Pairs two maps by key. Entries with matching keys are paired;
      * keys in only one map are classified as added or removed.
      */
-    public static <K, V> CollectionDiff<K, V> pairByKey(Map<K, V> original, Map<K, V> updated) {
-        Map<K, V> orig = original != null ? original : new LinkedHashMap<>();
-        Map<K, V> upd = updated != null ? updated : new LinkedHashMap<>();
+    public static <P, T> CollectionDiff<P, T> pairByKey(Map<P, T> original, Map<P, T> updated) {
+        Map<P, T> orig = original != null ? original : new LinkedHashMap<>();
+        Map<P, T> upd = updated != null ? updated : new LinkedHashMap<>();
 
-        Set<K> allKeys = new LinkedHashSet<>();
+        Set<P> allKeys = new LinkedHashSet<>();
         allKeys.addAll(orig.keySet());
         allKeys.addAll(upd.keySet());
 
-        List<Entry<K, V>> added = new ArrayList<>();
-        List<Entry<K, V>> removed = new ArrayList<>();
-        List<MatchedPair<K, V>> matched = new ArrayList<>();
+        List<Entry<P, T>> added = new ArrayList<>();
+        List<Entry<P, T>> removed = new ArrayList<>();
+        List<MatchedPair<P, T>> matched = new ArrayList<>();
 
-        for (K key : allKeys) {
+        for (P key : allKeys) {
             boolean inOrig = orig.containsKey(key);
             boolean inUpd = upd.containsKey(key);
             if (inOrig && inUpd) {
@@ -74,32 +74,32 @@ public class CollectionDiff<K, V> {
         return new CollectionDiff<>(added, removed, matched);
     }
 
-    public static class Entry<K, V> {
-        private final K key;
-        private final V value;
+    public static class Entry<P, T> {
+        private final P key;
+        private final T value;
 
-        public Entry(K key, V value) {
+        public Entry(P key, T value) {
             this.key = key;
             this.value = value;
         }
 
-        public K getKey() { return key; }
-        public V getValue() { return value; }
+        public P getKey() { return key; }
+        public T getValue() { return value; }
     }
 
-    public static class MatchedPair<K, V> {
-        private final K key;
-        private final V original;
-        private final V updated;
+    public static class MatchedPair<P, T> {
+        private final P key;
+        private final T original;
+        private final T updated;
 
-        public MatchedPair(K key, V original, V updated) {
+        public MatchedPair(P key, T original, T updated) {
             this.key = key;
             this.original = original;
             this.updated = updated;
         }
 
-        public K getKey() { return key; }
-        public V getOriginal() { return original; }
-        public V getUpdated() { return updated; }
+        public P getKey() { return key; }
+        public T getOriginal() { return original; }
+        public T getUpdated() { return updated; }
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultListPairingStrategy.java
@@ -7,16 +7,16 @@ import java.util.Map;
 /**
  * Default list pairing strategy — pairs entries by index.
  */
-public class DefaultListPairingStrategy<V> implements ListPairingStrategy<DefaultPairingKey, V> {
+public class DefaultListPairingStrategy<T> implements ListPairingStrategy<DefaultPairingKey, T> {
 
     @Override
-    public CollectionDiff<DefaultPairingKey, V> pair(List<V> original, List<V> updated) {
+    public CollectionDiff<DefaultPairingKey, T> pair(List<T> original, List<T> updated) {
         return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
     }
 
-    private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(List<V> list) {
+    private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(List<T> list) {
         if (list == null) return new LinkedHashMap<>();
-        Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
+        Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
         for (int i = 0; i < list.size(); i++) {
             res.put(new DefaultPairingKey(i), list.get(i));
         }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultMapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultMapPairingStrategy.java
@@ -7,17 +7,17 @@ import java.util.Map;
 /**
  * Default map pairing strategy — pairs entries by key.
  */
-public class DefaultMapPairingStrategy<V> implements MapPairingStrategy<DefaultPairingKey, V> {
+public class DefaultMapPairingStrategy<T> implements MapPairingStrategy<DefaultPairingKey, T> {
 
     @Override
-    public CollectionDiff<DefaultPairingKey, V> pair(Map<String, V> original, Map<String, V> updated) {
+    public CollectionDiff<DefaultPairingKey, T> pair(Map<String, T> original, Map<String, T> updated) {
         return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
     }
 
-    private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(Map<String, V>  map) {
+    private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(Map<String, T>  map) {
         if (map == null) return new LinkedHashMap<>();
-        Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
-        for (Map.Entry<String, V> entry : map.entrySet()) {
+        Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
+        for (Map.Entry<String, T> entry : map.entrySet()) {
             res.put(new DefaultPairingKey(entry.getKey()), entry.getValue());
         }
         return res;

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingKey.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingKey.java
@@ -3,33 +3,42 @@ package io.apitomy.umg.base.visitors.diff;
 import java.util.Objects;
 
 /**
- * Default provider: key-based pairing for maps, index-based for lists.
+ * Default pairing key for index-based (lists) and key-based (maps) pairing.
+ * For the default strategies, original and updated positions are the same
+ * (same index or same key).
  */
-public class DefaultPairingKey {
+public class DefaultPairingKey implements PairingKey {
 
-    private Type type;
-    private Integer index;
-    private String key;
+    private final Integer index;
+    private final String key;
 
     public DefaultPairingKey(int index) {
-        type = Type.INDEX;
         this.index = index;
+        this.key = null;
     }
 
     public DefaultPairingKey(String key) {
-        type = Type.KEY;
+        this.index = null;
         this.key = key;
     }
 
-    public Type getType() {
-        return type;
-    }
-
-    public Integer getIndex() {
+    @Override
+    public Integer getOriginalIndex() {
         return index;
     }
 
-    public String getKey() {
+    @Override
+    public Integer getUpdatedIndex() {
+        return index;
+    }
+
+    @Override
+    public String getOriginalKey() {
+        return key;
+    }
+
+    @Override
+    public String getUpdatedKey() {
         return key;
     }
 
@@ -37,16 +46,16 @@ public class DefaultPairingKey {
     public boolean equals(Object o) {
         if (!(o instanceof DefaultPairingKey)) return false;
         DefaultPairingKey that = (DefaultPairingKey) o;
-        return type == that.type && Objects.equals(index, that.index) && Objects.equals(key, that.key);
+        return Objects.equals(index, that.index) && Objects.equals(key, that.key);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, index, key);
+        return Objects.hash(index, key);
     }
 
-    public enum Type {
-        INDEX,
-        KEY
+    @Override
+    public String toString() {
+        return key != null ? key : String.valueOf(index);
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/DefaultPairingStrategyProvider.java
@@ -6,12 +6,12 @@ package io.apitomy.umg.base.visitors.diff;
 public class DefaultPairingStrategyProvider implements PairingStrategyProvider<DefaultPairingKey> {
 
     @Override
-    public <V> MapPairingStrategy<DefaultPairingKey, V> getMapStrategy(String propertyName) {
+    public <T> MapPairingStrategy<DefaultPairingKey, T> getMapStrategy(String propertyName) {
         return new DefaultMapPairingStrategy<>();
     }
 
     @Override
-    public <V> ListPairingStrategy<DefaultPairingKey, V> getListStrategy(String propertyName) {
+    public <T> ListPairingStrategy<DefaultPairingKey, T> getListStrategy(String propertyName) {
         return new DefaultListPairingStrategy<>();
     }
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
@@ -8,7 +8,7 @@ import java.util.List;
  * @param <P> the pairing key type (e.g., Integer for index-based pairing)
  * @param <V> the value type
  */
-public interface ListPairingStrategy<P, V> {
+public interface ListPairingStrategy<P extends PairingKey, V> {
 
     CollectionDiff<P, V> pair(List<V> original, List<V> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/ListPairingStrategy.java
@@ -6,9 +6,9 @@ import java.util.List;
  * Strategy for pairing entries from two lists.
  *
  * @param <P> the pairing key type (e.g., Integer for index-based pairing)
- * @param <V> the value type
+ * @param <T> the value type
  */
-public interface ListPairingStrategy<P extends PairingKey, V> {
+public interface ListPairingStrategy<P extends PairingKey, T> {
 
-    CollectionDiff<P, V> pair(List<V> original, List<V> updated);
+    CollectionDiff<P, T> pair(List<T> original, List<T> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * @param <P> the pairing key type (e.g., String for key-based pairing)
  * @param <V> the value type
  */
-public interface MapPairingStrategy<P, V> {
+public interface MapPairingStrategy<P extends PairingKey, V> {
 
     CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/MapPairingStrategy.java
@@ -6,9 +6,9 @@ import java.util.Map;
  * Strategy for pairing entries from two maps.
  *
  * @param <P> the pairing key type (e.g., String for key-based pairing)
- * @param <V> the value type
+ * @param <T> the value type
  */
-public interface MapPairingStrategy<P extends PairingKey, V> {
+public interface MapPairingStrategy<P extends PairingKey, T> {
 
-    CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
+    CollectionDiff<P, T> pair(Map<String, T> original, Map<String, T> updated);
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingKey.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingKey.java
@@ -1,0 +1,42 @@
+package io.apitomy.umg.base.visitors.diff;
+
+/**
+ * Represents a pairing between elements from original and updated collections.
+ * Provides access to the original and updated positions as both indices and map keys.
+ */
+public interface PairingKey {
+
+    /**
+     * The index in the original list, or null if not applicable.
+     */
+    Integer getOriginalIndex();
+
+    /**
+     * The index in the updated list, or null if not applicable.
+     */
+    Integer getUpdatedIndex();
+
+    /**
+     * The key in the original map, or null if not applicable.
+     */
+    String getOriginalKey();
+
+    /**
+     * The key in the updated map, or null if not applicable.
+     */
+    String getUpdatedKey();
+
+    /**
+     * Returns the original position as a string (map key or index).
+     */
+    default String getOriginalPosition() {
+        return getOriginalKey() != null ? getOriginalKey() : String.valueOf(getOriginalIndex());
+    }
+
+    /**
+     * Returns the updated position as a string (map key or index).
+     */
+    default String getUpdatedPosition() {
+        return getUpdatedKey() != null ? getUpdatedKey() : String.valueOf(getUpdatedIndex());
+    }
+}

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
@@ -5,7 +5,7 @@ package io.apitomy.umg.base.visitors.diff;
  * Pass a custom provider to the DiffTraverser constructor to control how
  * map and list fields are paired.
  */
-public interface PairingStrategyProvider<P> {
+public interface PairingStrategyProvider<P extends PairingKey> {
 
     <V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
 

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/diff/PairingStrategyProvider.java
@@ -7,7 +7,7 @@ package io.apitomy.umg.base.visitors.diff;
  */
 public interface PairingStrategyProvider<P extends PairingKey> {
 
-    <V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
+    <T> MapPairingStrategy<P, T> getMapStrategy(String propertyName);
 
-    <V> ListPairingStrategy<P, V> getListStrategy(String propertyName);
+    <T> ListPairingStrategy<P, T> getListStrategy(String propertyName);
 }

--- a/generator/src/main/resources/openapi.json
+++ b/generator/src/main/resources/openapi.json
@@ -201,6 +201,10 @@
                     },
                     "root": {
                         "$ref": "#/components/schemas/Root"
+                    },
+                    "conversionTarget": {
+                        "description": "Version name of the target spec to convert to",
+                        "type": "string"
                     }
                 },
                 "example": {

--- a/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
+++ b/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
@@ -1428,6 +1428,7 @@ io/apitomy/datamodels/models/visitors/TraversalStepType.java
 io/apitomy/datamodels/models/visitors/Traverser.java
 io/apitomy/datamodels/models/visitors/TraversingVisitor.java
 io/apitomy/datamodels/models/visitors/Visitor.java
+io/apitomy/datamodels/models/visitors/convert/AbstractConversionTraverser.java
 io/apitomy/datamodels/models/visitors/diff/AbstractDiffTraverser.java
 io/apitomy/datamodels/models/visitors/diff/CollectionDiff.java
 io/apitomy/datamodels/models/visitors/diff/DefaultListPairingStrategy.java

--- a/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
+++ b/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
@@ -1436,4 +1436,5 @@ io/apitomy/datamodels/models/visitors/diff/DefaultPairingKey.java
 io/apitomy/datamodels/models/visitors/diff/DefaultPairingStrategyProvider.java
 io/apitomy/datamodels/models/visitors/diff/ListPairingStrategy.java
 io/apitomy/datamodels/models/visitors/diff/MapPairingStrategy.java
+io/apitomy/datamodels/models/visitors/diff/PairingKey.java
 io/apitomy/datamodels/models/visitors/diff/PairingStrategyProvider.java

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -265,7 +265,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -291,7 +291,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -304,7 +304,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
-import io.test.synthetic.Node;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynContact;
 import io.test.synthetic.SynInfo;
@@ -22,6 +21,7 @@ import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
@@ -72,25 +72,49 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
-		visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-		if (original.getInfo() != null && updated.getInfo() != null) {
-			traverse(original.getInfo(), updated.getInfo());
+		{
+			pushProperty("version");
+			visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
+			pop();
 		}
 		{
+			pushProperty("info");
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (original.getInfo() != null && updated.getInfo() != null) {
+				traverse(original.getInfo(), updated.getInfo());
+			}
+			pop();
+		}
+		{
+			pushProperty("items");
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentTags(original.getTags(), updated.getTags());
-		visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
-		visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-		this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+		{
+			pushProperty("tags");
+			visitor.diffDocumentTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("metadata");
+			visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
+			pop();
+		}
+		{
+			pushProperty("additionalSchema");
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			pop();
+		}
 	}
 
 	public void traverseInfo(Syn1Info original, Syn1Info updated) {
@@ -100,12 +124,24 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffInfoName(original.getName(), updated.getName());
-		visitor.diffInfoContact(original.getContact(), updated.getContact());
-		if (original.getContact() != null && updated.getContact() != null) {
-			traverse(original.getContact(), updated.getContact());
+		{
+			pushProperty("name");
+			visitor.diffInfoName(original.getName(), updated.getName());
+			pop();
 		}
-		visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+		{
+			pushProperty("contact");
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (original.getContact() != null && updated.getContact() != null) {
+				traverse(original.getContact(), updated.getContact());
+			}
+			pop();
+		}
+		{
+			pushProperty("version");
+			visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+			pop();
+		}
 	}
 
 	public void traverseContact(Syn1Contact original, Syn1Contact updated) {
@@ -115,9 +151,21 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffContactName(original.getName(), updated.getName());
-		visitor.diffContactEmail(original.getEmail(), updated.getEmail());
-		visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+		{
+			pushProperty("name");
+			visitor.diffContactName(original.getName(), updated.getName());
+			pop();
+		}
+		{
+			pushProperty("email");
+			visitor.diffContactEmail(original.getEmail(), updated.getEmail());
+			pop();
+		}
+		{
+			pushProperty("url");
+			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+			pop();
+		}
 	}
 
 	public void traverseItem(Syn1Item original, Syn1Item updated) {
@@ -127,21 +175,65 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffItemDescription(original.getDescription(), updated.getDescription());
-		visitor.diffItemRequired(original.isRequired(), updated.isRequired());
-		visitor.diffItemOrder(original.getOrder(), updated.getOrder());
-		visitor.diffItemWeight(original.getWeight(), updated.getWeight());
-		visitor.diffItemExtra(original.getExtra(), updated.getExtra());
-		visitor.diffItemRaw(original.getRaw(), updated.getRaw());
-		visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-		if (original.getSchema() != null && updated.getSchema() != null) {
-			traverse(original.getSchema(), updated.getSchema());
+		{
+			pushProperty("$ref");
+			visitor.diffItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffItemExamples(original.getExamples(), updated.getExamples());
-		visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-		this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
-		visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+		{
+			pushProperty("description");
+			visitor.diffItemDescription(original.getDescription(), updated.getDescription());
+			pop();
+		}
+		{
+			pushProperty("required");
+			visitor.diffItemRequired(original.isRequired(), updated.isRequired());
+			pop();
+		}
+		{
+			pushProperty("order");
+			visitor.diffItemOrder(original.getOrder(), updated.getOrder());
+			pop();
+		}
+		{
+			pushProperty("weight");
+			visitor.diffItemWeight(original.getWeight(), updated.getWeight());
+			pop();
+		}
+		{
+			pushProperty("extra");
+			visitor.diffItemExtra(original.getExtra(), updated.getExtra());
+			pop();
+		}
+		{
+			pushProperty("raw");
+			visitor.diffItemRaw(original.getRaw(), updated.getRaw());
+			pop();
+		}
+		{
+			pushProperty("schema");
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (original.getSchema() != null && updated.getSchema() != null) {
+				traverse(original.getSchema(), updated.getSchema());
+			}
+			pop();
+		}
+		{
+			pushProperty("examples");
+			visitor.diffItemExamples(original.getExamples(), updated.getExamples());
+			pop();
+		}
+		{
+			pushProperty("defaultValue");
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			pop();
+		}
+		{
+			pushProperty("title");
+			visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+			pop();
+		}
 	}
 
 	public void traverseSchema(Syn1Schema original, Syn1Schema updated) {
@@ -151,58 +243,102 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
-		visitor.diffSchemaType(original.getType(), updated.getType());
-		visitor.diffSchemaItems(original.getItems(), updated.getItems());
-		this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 		{
+			pushProperty("$ref");
+			visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
+			pop();
+		}
+		{
+			pushProperty("type");
+			visitor.diffSchemaType(original.getType(), updated.getType());
+			pop();
+		}
+		{
+			pushProperty("items");
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			pop();
+		}
+		{
+			pushProperty("properties");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("properties", original.getProperties(),
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("allOf");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairList("allOf", original.getAllOf(),
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("definitions");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("definitions", original.getDefinitions(),
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("nestedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairMap("nestedSchemas", original.getNestedSchemas(),
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("composedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairList("composedSchemas", original.getComposedSchemas(),
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
-		visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
-		visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
-		visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+		{
+			pushProperty("minLength");
+			visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
+			pop();
+		}
+		{
+			pushProperty("maxLength");
+			visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
+			pop();
+		}
+		{
+			pushProperty("enum");
+			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+			pop();
+		}
 	}
 
 	public void traversePaths(Syn1Paths original, Syn1Paths updated) {
@@ -221,19 +357,39 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
-		visitor.diffPathItemGet(original.getGet(), updated.getGet());
-		if (original.getGet() != null && updated.getGet() != null) {
-			traverse(original.getGet(), updated.getGet());
+		{
+			pushProperty("$ref");
+			visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffPathItemPut(original.getPut(), updated.getPut());
-		if (original.getPut() != null && updated.getPut() != null) {
-			traverse(original.getPut(), updated.getPut());
+		{
+			pushProperty("summary");
+			visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
+			pop();
 		}
-		visitor.diffPathItemPost(original.getPost(), updated.getPost());
-		if (original.getPost() != null && updated.getPost() != null) {
-			traverse(original.getPost(), updated.getPost());
+		{
+			pushProperty("get");
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (original.getGet() != null && updated.getGet() != null) {
+				traverse(original.getGet(), updated.getGet());
+			}
+			pop();
+		}
+		{
+			pushProperty("put");
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (original.getPut() != null && updated.getPut() != null) {
+				traverse(original.getPut(), updated.getPut());
+			}
+			pop();
+		}
+		{
+			pushProperty("post");
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (original.getPost() != null && updated.getPost() != null) {
+				traverse(original.getPost(), updated.getPost());
+			}
+			pop();
 		}
 	}
 
@@ -244,19 +400,35 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
-		visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
-		visitor.diffOperationTags(original.getTags(), updated.getTags());
 		{
+			pushProperty("operationId");
+			visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
+			pop();
+		}
+		{
+			pushProperty("summary");
+			visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
+			pop();
+		}
+		{
+			pushProperty("tags");
+			visitor.diffOperationTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("parameters");
 			CollectionDiff<P, SynItem> diff = this.pairList("parameters", original.getParameters(),
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -26,7 +26,7 @@ import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
 
-public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisitor<P>> {
+public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTraverser<P, Syn1DiffVisitor<P>> {
 
 	public Syn1DiffTraverser(Syn1DiffVisitor<P> visitor) {
 		super(visitor);
@@ -90,7 +90,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -265,7 +265,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -278,7 +278,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -291,7 +291,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -304,7 +304,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -317,7 +317,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -421,7 +421,7 @@ public class Syn1DiffTraverser<P> extends AbstractDiffTraverser<P, Syn1DiffVisit
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -23,7 +23,7 @@ import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Syn1DiffVisitor<P> {
+public abstract class Syn1DiffVisitor<P extends PairingKey> {
 
 	public boolean visitDocument(Syn1Document original, Syn1Document updated) {
 		return true;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.test.synthetic.Any;
 import io.test.synthetic.BooleanSchemaSchemaListUnion;
 import io.test.synthetic.BooleanSchemaUnion;
-import io.test.synthetic.Node;
 import io.test.synthetic.SchemaOrBoolean;
 import io.test.synthetic.SynContact;
 import io.test.synthetic.SynInfo;
@@ -22,6 +21,7 @@ import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
@@ -72,36 +72,64 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
-		visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-		if (original.getInfo() != null && updated.getInfo() != null) {
-			traverse(original.getInfo(), updated.getInfo());
+		{
+			pushProperty("version");
+			visitor.diffDocumentVersion(original.getVersion(), updated.getVersion());
+			pop();
 		}
 		{
+			pushProperty("info");
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (original.getInfo() != null && updated.getInfo() != null) {
+				traverse(original.getInfo(), updated.getInfo());
+			}
+			pop();
+		}
+		{
+			pushProperty("items");
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentTags(original.getTags(), updated.getTags());
-		visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
 		{
+			pushProperty("tags");
+			visitor.diffDocumentTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("metadata");
+			visitor.diffDocumentMetadata(original.getMetadata(), updated.getMetadata());
+			pop();
+		}
+		{
+			pushProperty("webhooks");
 			CollectionDiff<P, Syn2PathItem> diff = this.pairMap("webhooks", original.getWebhooks(),
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
-		visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-		this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+		{
+			pushProperty("additionalSchema");
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			pop();
+		}
 	}
 
 	public void traverseInfo(Syn2Info original, Syn2Info updated) {
@@ -111,13 +139,29 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffInfoName(original.getName(), updated.getName());
-		visitor.diffInfoContact(original.getContact(), updated.getContact());
-		if (original.getContact() != null && updated.getContact() != null) {
-			traverse(original.getContact(), updated.getContact());
+		{
+			pushProperty("name");
+			visitor.diffInfoName(original.getName(), updated.getName());
+			pop();
 		}
-		visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
-		visitor.diffInfoLicense(original.getLicense(), updated.getLicense());
+		{
+			pushProperty("contact");
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (original.getContact() != null && updated.getContact() != null) {
+				traverse(original.getContact(), updated.getContact());
+			}
+			pop();
+		}
+		{
+			pushProperty("version");
+			visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
+			pop();
+		}
+		{
+			pushProperty("license");
+			visitor.diffInfoLicense(original.getLicense(), updated.getLicense());
+			pop();
+		}
 	}
 
 	public void traverseContact(Syn2Contact original, Syn2Contact updated) {
@@ -127,9 +171,21 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffContactName(original.getName(), updated.getName());
-		visitor.diffContactEmail(original.getEmail(), updated.getEmail());
-		visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+		{
+			pushProperty("name");
+			visitor.diffContactName(original.getName(), updated.getName());
+			pop();
+		}
+		{
+			pushProperty("email");
+			visitor.diffContactEmail(original.getEmail(), updated.getEmail());
+			pop();
+		}
+		{
+			pushProperty("url");
+			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
+			pop();
+		}
 	}
 
 	public void traverseItem(Syn2Item original, Syn2Item updated) {
@@ -139,22 +195,70 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffItemDescription(original.getDescription(), updated.getDescription());
-		visitor.diffItemRequired(original.isRequired(), updated.isRequired());
-		visitor.diffItemOrder(original.getOrder(), updated.getOrder());
-		visitor.diffItemWeight(original.getWeight(), updated.getWeight());
-		visitor.diffItemExtra(original.getExtra(), updated.getExtra());
-		visitor.diffItemRaw(original.getRaw(), updated.getRaw());
-		visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-		if (original.getSchema() != null && updated.getSchema() != null) {
-			traverse(original.getSchema(), updated.getSchema());
+		{
+			pushProperty("$ref");
+			visitor.diffItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffItemExamples(original.getExamples(), updated.getExamples());
-		visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-		this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
-		visitor.diffItemTitle(original.getTitle(), updated.getTitle());
-		visitor.diffItemDeprecated(original.isDeprecated(), updated.isDeprecated());
+		{
+			pushProperty("description");
+			visitor.diffItemDescription(original.getDescription(), updated.getDescription());
+			pop();
+		}
+		{
+			pushProperty("required");
+			visitor.diffItemRequired(original.isRequired(), updated.isRequired());
+			pop();
+		}
+		{
+			pushProperty("order");
+			visitor.diffItemOrder(original.getOrder(), updated.getOrder());
+			pop();
+		}
+		{
+			pushProperty("weight");
+			visitor.diffItemWeight(original.getWeight(), updated.getWeight());
+			pop();
+		}
+		{
+			pushProperty("extra");
+			visitor.diffItemExtra(original.getExtra(), updated.getExtra());
+			pop();
+		}
+		{
+			pushProperty("raw");
+			visitor.diffItemRaw(original.getRaw(), updated.getRaw());
+			pop();
+		}
+		{
+			pushProperty("schema");
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (original.getSchema() != null && updated.getSchema() != null) {
+				traverse(original.getSchema(), updated.getSchema());
+			}
+			pop();
+		}
+		{
+			pushProperty("examples");
+			visitor.diffItemExamples(original.getExamples(), updated.getExamples());
+			pop();
+		}
+		{
+			pushProperty("defaultValue");
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			pop();
+		}
+		{
+			pushProperty("title");
+			visitor.diffItemTitle(original.getTitle(), updated.getTitle());
+			pop();
+		}
+		{
+			pushProperty("deprecated");
+			visitor.diffItemDeprecated(original.isDeprecated(), updated.isDeprecated());
+			pop();
+		}
 	}
 
 	public void traverseSchema(Syn2Schema original, Syn2Schema updated) {
@@ -164,58 +268,102 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
-		visitor.diffSchemaType(original.getType(), updated.getType());
-		visitor.diffSchemaItems(original.getItems(), updated.getItems());
-		this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 		{
+			pushProperty("$ref");
+			visitor.diffSchema$ref(original.get$ref(), updated.get$ref());
+			pop();
+		}
+		{
+			pushProperty("type");
+			visitor.diffSchemaType(original.getType(), updated.getType());
+			pop();
+		}
+		{
+			pushProperty("items");
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			pop();
+		}
+		{
+			pushProperty("properties");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("properties", original.getProperties(),
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("allOf");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairList("allOf", original.getAllOf(),
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("definitions");
 			CollectionDiff<P, BooleanSchemaUnion> diff = this.pairMap("definitions", original.getDefinitions(),
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("nestedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairMap("nestedSchemas", original.getNestedSchemas(),
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
 		{
+			pushProperty("composedSchemas");
 			CollectionDiff<P, SchemaOrBoolean> diff = this.pairList("composedSchemas", original.getComposedSchemas(),
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				pop();
 			}
+			pop();
 		}
-		visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
-		visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
-		visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+		{
+			pushProperty("minLength");
+			visitor.diffSchemaMinLength(original.getMinLength(), updated.getMinLength());
+			pop();
+		}
+		{
+			pushProperty("maxLength");
+			visitor.diffSchemaMaxLength(original.getMaxLength(), updated.getMaxLength());
+			pop();
+		}
+		{
+			pushProperty("enum");
+			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
+			pop();
+		}
 	}
 
 	public void traversePaths(Syn2Paths original, Syn2Paths updated) {
@@ -234,23 +382,47 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
-		visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
-		visitor.diffPathItemGet(original.getGet(), updated.getGet());
-		if (original.getGet() != null && updated.getGet() != null) {
-			traverse(original.getGet(), updated.getGet());
+		{
+			pushProperty("$ref");
+			visitor.diffPathItem$ref(original.get$ref(), updated.get$ref());
+			pop();
 		}
-		visitor.diffPathItemPut(original.getPut(), updated.getPut());
-		if (original.getPut() != null && updated.getPut() != null) {
-			traverse(original.getPut(), updated.getPut());
+		{
+			pushProperty("summary");
+			visitor.diffPathItemSummary(original.getSummary(), updated.getSummary());
+			pop();
 		}
-		visitor.diffPathItemPost(original.getPost(), updated.getPost());
-		if (original.getPost() != null && updated.getPost() != null) {
-			traverse(original.getPost(), updated.getPost());
+		{
+			pushProperty("get");
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (original.getGet() != null && updated.getGet() != null) {
+				traverse(original.getGet(), updated.getGet());
+			}
+			pop();
 		}
-		visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
-		if (original.getDelete() != null && updated.getDelete() != null) {
-			traverse(original.getDelete(), updated.getDelete());
+		{
+			pushProperty("put");
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (original.getPut() != null && updated.getPut() != null) {
+				traverse(original.getPut(), updated.getPut());
+			}
+			pop();
+		}
+		{
+			pushProperty("post");
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (original.getPost() != null && updated.getPost() != null) {
+				traverse(original.getPost(), updated.getPost());
+			}
+			pop();
+		}
+		{
+			pushProperty("delete");
+			visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
+			if (original.getDelete() != null && updated.getDelete() != null) {
+				traverse(original.getDelete(), updated.getDelete());
+			}
+			pop();
 		}
 	}
 
@@ -261,19 +433,35 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			return;
 		if (original == null || updated == null)
 			return;
-		visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
-		visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
-		visitor.diffOperationTags(original.getTags(), updated.getTags());
 		{
+			pushProperty("operationId");
+			visitor.diffOperationOperationId(original.getOperationId(), updated.getOperationId());
+			pop();
+		}
+		{
+			pushProperty("summary");
+			visitor.diffOperationSummary(original.getSummary(), updated.getSummary());
+			pop();
+		}
+		{
+			pushProperty("tags");
+			visitor.diffOperationTags(original.getTags(), updated.getTags());
+			pop();
+		}
+		{
+			pushProperty("parameters");
 			CollectionDiff<P, SynItem> diff = this.pairList("parameters", original.getParameters(),
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
+				pushElement((PairingKey) pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
 				}
+				pop();
 			}
+			pop();
 		}
 	}
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -26,7 +26,7 @@ import io.test.synthetic.visitors.diff.PairingStrategyProvider;
 import java.util.List;
 import java.util.Map;
 
-public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisitor<P>> {
+public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTraverser<P, Syn2DiffVisitor<P>> {
 
 	public Syn2DiffTraverser(Syn2DiffVisitor<P> visitor) {
 		super(visitor);
@@ -90,7 +90,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 			CollectionDiff<P, SynItem> diff = this.pairList("items", original.getItems(), updated.getItems());
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -115,7 +115,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -290,7 +290,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -303,7 +303,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getAllOf());
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -316,7 +316,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -329,7 +329,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushMapIndex(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -342,7 +342,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getComposedSchemas());
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -454,7 +454,7 @@ public class Syn2DiffTraverser<P> extends AbstractDiffTraverser<P, Syn2DiffVisit
 					updated.getParameters());
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
-				pushElement((PairingKey) pair.getKey());
+				pushListIndex(pair.getKey());
 				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -115,7 +115,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getWebhooks());
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				if (pair.getOriginal() != null && pair.getUpdated() != null) {
 					traverse(pair.getOriginal(), pair.getUpdated());
@@ -290,7 +290,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getProperties());
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -316,7 +316,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getDefinitions());
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				pop();
@@ -329,7 +329,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 					updated.getNestedSchemas());
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
-				pushMapIndex(pair.getKey());
+				pushMapKey(pair.getKey());
 				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				pop();

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -23,7 +23,7 @@ import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Syn2DiffVisitor<P> {
+public abstract class Syn2DiffVisitor<P extends PairingKey> {
 
 	public boolean visitDocument(Syn2Document original, Syn2Document updated) {
 		return true;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.visitors.diff.CollectionDiff;
+import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
 import java.util.Map;
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/convert/AbstractConversionTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/convert/AbstractConversionTraverser.java
@@ -1,0 +1,51 @@
+package io.test.synthetic.visitors.convert;
+
+import io.test.synthetic.Any;
+import io.test.synthetic.visitors.TraversalContext;
+import io.test.synthetic.visitors.TraversalContextImpl;
+
+/**
+ * Base class for generated conversion traversers. Converts a source tree into a
+ * target tree by iterating source fields and delegating value mapping to a
+ * ConversionVisitor.
+ *
+ * @param <V>
+ *            the spec-version-specific ConversionVisitor subclass
+ */
+public class AbstractConversionTraverser<V> {
+
+	protected final V visitor;
+	protected final TraversalContextImpl context;
+
+	protected AbstractConversionTraverser(V visitor) {
+		this.visitor = visitor;
+		this.context = new TraversalContextImpl();
+	}
+
+	public TraversalContext getContext() {
+		return context;
+	}
+
+	protected void pushProperty(String propertyName) {
+		context.pushProperty(propertyName);
+	}
+
+	protected void pushListIndex(int index) {
+		context.pushListIndex(index);
+	}
+
+	protected void pushMapKey(String key) {
+		context.pushMapIndex(key);
+	}
+
+	protected void pop() {
+		context.pop();
+	}
+
+	/**
+	 * Public entry point. Generated subclasses override with type-based dispatch.
+	 */
+	public Any convert(Any source) {
+		return null;
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * @param <V>
  *            the spec-version-specific DiffVisitor subclass
  */
-public class AbstractDiffTraverser<P, V> {
+public class AbstractDiffTraverser<P extends PairingKey, V> {
 
 	protected final V visitor;
 	protected final PairingStrategyProvider<P> pairingProvider;
@@ -54,20 +54,20 @@ public class AbstractDiffTraverser<P, V> {
 		updatedContext.pushProperty(propertyName);
 	}
 
-	/**
-	 * Push collection element positions onto the respective contexts.
-	 */
-	protected void pushElement(PairingKey key) {
-		if (key.getOriginalKey() != null) {
-			originalContext.pushMapIndex(key.getOriginalKey());
-		} else if (key.getOriginalIndex() != null) {
-			originalContext.pushListIndex(key.getOriginalIndex());
+	protected void pushMapIndex(PairingKey key) {
+		if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
+			throw new IllegalStateException("Map pairing key must have both original and updated keys");
 		}
-		if (key.getUpdatedKey() != null) {
-			updatedContext.pushMapIndex(key.getUpdatedKey());
-		} else if (key.getUpdatedIndex() != null) {
-			updatedContext.pushListIndex(key.getUpdatedIndex());
+		originalContext.pushMapIndex(key.getOriginalKey());
+		updatedContext.pushMapIndex(key.getUpdatedKey());
+	}
+
+	protected void pushListIndex(PairingKey key) {
+		if (key.getOriginalIndex() == null || key.getUpdatedIndex() == null) {
+			throw new IllegalStateException("List pairing key must have both original and updated indices");
 		}
+		originalContext.pushListIndex(key.getOriginalIndex());
+		updatedContext.pushListIndex(key.getUpdatedIndex());
 	}
 
 	/**

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -1,13 +1,14 @@
 package io.test.synthetic.visitors.diff;
 
 import io.test.synthetic.Any;
+import io.test.synthetic.visitors.TraversalContext;
+import io.test.synthetic.visitors.TraversalContextImpl;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Base class for generated diff traversers. Provides shared collection pairing
- * logic. Subclasses (generated per spec version) provide entity-specific field
- * iteration and call typed visitor methods.
+ * logic and path tracking via two TraversalContext instances (one per side).
  *
  * @param <P>
  *            the pairing key type
@@ -18,23 +19,65 @@ public class AbstractDiffTraverser<P, V> {
 
 	protected final V visitor;
 	protected final PairingStrategyProvider<P> pairingProvider;
+	protected final TraversalContextImpl originalContext;
+	protected final TraversalContextImpl updatedContext;
 
 	@SuppressWarnings("unchecked")
 	protected AbstractDiffTraverser(V visitor) {
 		this.visitor = visitor;
 		this.pairingProvider = (PairingStrategyProvider<P>) new DefaultPairingStrategyProvider();
+		this.originalContext = new TraversalContextImpl();
+		this.updatedContext = new TraversalContextImpl();
 	}
 
+	@SuppressWarnings("unchecked")
 	protected AbstractDiffTraverser(V visitor, PairingStrategyProvider<P> pairingProvider) {
 		this.visitor = visitor;
 		this.pairingProvider = pairingProvider;
+		this.originalContext = new TraversalContextImpl();
+		this.updatedContext = new TraversalContextImpl();
+	}
+
+	public TraversalContext getOriginalContext() {
+		return originalContext;
+	}
+
+	public TraversalContext getUpdatedContext() {
+		return updatedContext;
 	}
 
 	/**
-	 * Public entry point — accepts Any (Node or Union). Generated subclasses
-	 * override this with type-based dispatch to union traverse methods and entity
-	 * traverse methods.
+	 * Push a property name onto both contexts (shared by both sides).
 	 */
+	protected void pushProperty(String propertyName) {
+		originalContext.pushProperty(propertyName);
+		updatedContext.pushProperty(propertyName);
+	}
+
+	/**
+	 * Push collection element positions onto the respective contexts.
+	 */
+	protected void pushElement(PairingKey key) {
+		if (key.getOriginalKey() != null) {
+			originalContext.pushMapIndex(key.getOriginalKey());
+		} else if (key.getOriginalIndex() != null) {
+			originalContext.pushListIndex(key.getOriginalIndex());
+		}
+		if (key.getUpdatedKey() != null) {
+			updatedContext.pushMapIndex(key.getUpdatedKey());
+		} else if (key.getUpdatedIndex() != null) {
+			updatedContext.pushListIndex(key.getUpdatedIndex());
+		}
+	}
+
+	/**
+	 * Pop from both contexts.
+	 */
+	protected void pop() {
+		originalContext.pop();
+		updatedContext.pop();
+	}
+
 	public void traverse(Any original, Any updated) {
 	}
 
@@ -47,5 +90,4 @@ public class AbstractDiffTraverser<P, V> {
 		ListPairingStrategy<P, T> strategy = pairingProvider.getListStrategy(propertyName);
 		return strategy.pair(original, updated);
 	}
-
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/AbstractDiffTraverser.java
@@ -54,7 +54,7 @@ public class AbstractDiffTraverser<P extends PairingKey, V> {
 		updatedContext.pushProperty(propertyName);
 	}
 
-	protected void pushMapIndex(PairingKey key) {
+	protected void pushMapKey(PairingKey key) {
 		if (key.getOriginalKey() == null || key.getUpdatedKey() == null) {
 			throw new IllegalStateException("Map pairing key must have both original and updated keys");
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/CollectionDiff.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/CollectionDiff.java
@@ -11,32 +11,32 @@ import java.util.Set;
  * Result of pairing two collections. Contains entries that were added, removed,
  * or matched between the original and updated collections.
  *
- * @param <K>
- *            the key type (String for maps, Integer for lists)
- * @param <V>
+ * @param <P>
+ *            the pairing key type (String for maps, Integer for lists)
+ * @param <T>
  *            the value type
  */
-public class CollectionDiff<K, V> {
+public class CollectionDiff<P, T> {
 
-	private final List<Entry<K, V>> added;
-	private final List<Entry<K, V>> removed;
-	private final List<MatchedPair<K, V>> matched;
+	private final List<Entry<P, T>> added;
+	private final List<Entry<P, T>> removed;
+	private final List<MatchedPair<P, T>> matched;
 
-	public CollectionDiff(List<Entry<K, V>> added, List<Entry<K, V>> removed, List<MatchedPair<K, V>> matched) {
+	public CollectionDiff(List<Entry<P, T>> added, List<Entry<P, T>> removed, List<MatchedPair<P, T>> matched) {
 		this.added = added;
 		this.removed = removed;
 		this.matched = matched;
 	}
 
-	public List<Entry<K, V>> getAdded() {
+	public List<Entry<P, T>> getAdded() {
 		return added;
 	}
 
-	public List<Entry<K, V>> getRemoved() {
+	public List<Entry<P, T>> getRemoved() {
 		return removed;
 	}
 
-	public List<MatchedPair<K, V>> getMatched() {
+	public List<MatchedPair<P, T>> getMatched() {
 		return matched;
 	}
 
@@ -48,19 +48,19 @@ public class CollectionDiff<K, V> {
 	 * Pairs two maps by key. Entries with matching keys are paired; keys in only
 	 * one map are classified as added or removed.
 	 */
-	public static <K, V> CollectionDiff<K, V> pairByKey(Map<K, V> original, Map<K, V> updated) {
-		Map<K, V> orig = original != null ? original : new LinkedHashMap<>();
-		Map<K, V> upd = updated != null ? updated : new LinkedHashMap<>();
+	public static <P, T> CollectionDiff<P, T> pairByKey(Map<P, T> original, Map<P, T> updated) {
+		Map<P, T> orig = original != null ? original : new LinkedHashMap<>();
+		Map<P, T> upd = updated != null ? updated : new LinkedHashMap<>();
 
-		Set<K> allKeys = new LinkedHashSet<>();
+		Set<P> allKeys = new LinkedHashSet<>();
 		allKeys.addAll(orig.keySet());
 		allKeys.addAll(upd.keySet());
 
-		List<Entry<K, V>> added = new ArrayList<>();
-		List<Entry<K, V>> removed = new ArrayList<>();
-		List<MatchedPair<K, V>> matched = new ArrayList<>();
+		List<Entry<P, T>> added = new ArrayList<>();
+		List<Entry<P, T>> removed = new ArrayList<>();
+		List<MatchedPair<P, T>> matched = new ArrayList<>();
 
-		for (K key : allKeys) {
+		for (P key : allKeys) {
 			boolean inOrig = orig.containsKey(key);
 			boolean inUpd = upd.containsKey(key);
 			if (inOrig && inUpd) {
@@ -75,41 +75,41 @@ public class CollectionDiff<K, V> {
 		return new CollectionDiff<>(added, removed, matched);
 	}
 
-	public static class Entry<K, V> {
-		private final K key;
-		private final V value;
+	public static class Entry<P, T> {
+		private final P key;
+		private final T value;
 
-		public Entry(K key, V value) {
+		public Entry(P key, T value) {
 			this.key = key;
 			this.value = value;
 		}
 
-		public K getKey() {
+		public P getKey() {
 			return key;
 		}
-		public V getValue() {
+		public T getValue() {
 			return value;
 		}
 	}
 
-	public static class MatchedPair<K, V> {
-		private final K key;
-		private final V original;
-		private final V updated;
+	public static class MatchedPair<P, T> {
+		private final P key;
+		private final T original;
+		private final T updated;
 
-		public MatchedPair(K key, V original, V updated) {
+		public MatchedPair(P key, T original, T updated) {
 			this.key = key;
 			this.original = original;
 			this.updated = updated;
 		}
 
-		public K getKey() {
+		public P getKey() {
 			return key;
 		}
-		public V getOriginal() {
+		public T getOriginal() {
 			return original;
 		}
-		public V getUpdated() {
+		public T getUpdated() {
 			return updated;
 		}
 	}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultListPairingStrategy.java
@@ -7,17 +7,17 @@ import java.util.Map;
 /**
  * Default list pairing strategy — pairs entries by index.
  */
-public class DefaultListPairingStrategy<V> implements ListPairingStrategy<DefaultPairingKey, V> {
+public class DefaultListPairingStrategy<T> implements ListPairingStrategy<DefaultPairingKey, T> {
 
 	@Override
-	public CollectionDiff<DefaultPairingKey, V> pair(List<V> original, List<V> updated) {
+	public CollectionDiff<DefaultPairingKey, T> pair(List<T> original, List<T> updated) {
 		return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
 	}
 
-	private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(List<V> list) {
+	private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(List<T> list) {
 		if (list == null)
 			return new LinkedHashMap<>();
-		Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
+		Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
 		for (int i = 0; i < list.size(); i++) {
 			res.put(new DefaultPairingKey(i), list.get(i));
 		}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultMapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultMapPairingStrategy.java
@@ -7,18 +7,18 @@ import java.util.Map;
 /**
  * Default map pairing strategy — pairs entries by key.
  */
-public class DefaultMapPairingStrategy<V> implements MapPairingStrategy<DefaultPairingKey, V> {
+public class DefaultMapPairingStrategy<T> implements MapPairingStrategy<DefaultPairingKey, T> {
 
 	@Override
-	public CollectionDiff<DefaultPairingKey, V> pair(Map<String, V> original, Map<String, V> updated) {
+	public CollectionDiff<DefaultPairingKey, T> pair(Map<String, T> original, Map<String, T> updated) {
 		return CollectionDiff.pairByKey(toPairingKeyMap(original), toPairingKeyMap(updated));
 	}
 
-	private static <V> Map<DefaultPairingKey, V> toPairingKeyMap(Map<String, V> map) {
+	private static <T> Map<DefaultPairingKey, T> toPairingKeyMap(Map<String, T> map) {
 		if (map == null)
 			return new LinkedHashMap<>();
-		Map<DefaultPairingKey, V> res = new LinkedHashMap<>();
-		for (Map.Entry<String, V> entry : map.entrySet()) {
+		Map<DefaultPairingKey, T> res = new LinkedHashMap<>();
+		for (Map.Entry<String, T> entry : map.entrySet()) {
 			res.put(new DefaultPairingKey(entry.getKey()), entry.getValue());
 		}
 		return res;

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingKey.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingKey.java
@@ -3,33 +3,42 @@ package io.test.synthetic.visitors.diff;
 import java.util.Objects;
 
 /**
- * Default provider: key-based pairing for maps, index-based for lists.
+ * Default pairing key for index-based (lists) and key-based (maps) pairing. For
+ * the default strategies, original and updated positions are the same (same
+ * index or same key).
  */
-public class DefaultPairingKey {
+public class DefaultPairingKey implements PairingKey {
 
-	private Type type;
-	private Integer index;
-	private String key;
+	private final Integer index;
+	private final String key;
 
 	public DefaultPairingKey(int index) {
-		type = Type.INDEX;
 		this.index = index;
+		this.key = null;
 	}
 
 	public DefaultPairingKey(String key) {
-		type = Type.KEY;
+		this.index = null;
 		this.key = key;
 	}
 
-	public Type getType() {
-		return type;
-	}
-
-	public Integer getIndex() {
+	@Override
+	public Integer getOriginalIndex() {
 		return index;
 	}
 
-	public String getKey() {
+	@Override
+	public Integer getUpdatedIndex() {
+		return index;
+	}
+
+	@Override
+	public String getOriginalKey() {
+		return key;
+	}
+
+	@Override
+	public String getUpdatedKey() {
 		return key;
 	}
 
@@ -38,15 +47,16 @@ public class DefaultPairingKey {
 		if (!(o instanceof DefaultPairingKey))
 			return false;
 		DefaultPairingKey that = (DefaultPairingKey) o;
-		return type == that.type && Objects.equals(index, that.index) && Objects.equals(key, that.key);
+		return Objects.equals(index, that.index) && Objects.equals(key, that.key);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(type, index, key);
+		return Objects.hash(index, key);
 	}
 
-	public enum Type {
-		INDEX, KEY
+	@Override
+	public String toString() {
+		return key != null ? key : String.valueOf(index);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/DefaultPairingStrategyProvider.java
@@ -6,12 +6,12 @@ package io.test.synthetic.visitors.diff;
 public class DefaultPairingStrategyProvider implements PairingStrategyProvider<DefaultPairingKey> {
 
 	@Override
-	public <V> MapPairingStrategy<DefaultPairingKey, V> getMapStrategy(String propertyName) {
+	public <T> MapPairingStrategy<DefaultPairingKey, T> getMapStrategy(String propertyName) {
 		return new DefaultMapPairingStrategy<>();
 	}
 
 	@Override
-	public <V> ListPairingStrategy<DefaultPairingKey, V> getListStrategy(String propertyName) {
+	public <T> ListPairingStrategy<DefaultPairingKey, T> getListStrategy(String propertyName) {
 		return new DefaultListPairingStrategy<>();
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
@@ -7,10 +7,10 @@ import java.util.List;
  *
  * @param <P>
  *            the pairing key type (e.g., Integer for index-based pairing)
- * @param <V>
+ * @param <T>
  *            the value type
  */
-public interface ListPairingStrategy<P extends PairingKey, V> {
+public interface ListPairingStrategy<P extends PairingKey, T> {
 
-	CollectionDiff<P, V> pair(List<V> original, List<V> updated);
+	CollectionDiff<P, T> pair(List<T> original, List<T> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/ListPairingStrategy.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @param <V>
  *            the value type
  */
-public interface ListPairingStrategy<P, V> {
+public interface ListPairingStrategy<P extends PairingKey, V> {
 
 	CollectionDiff<P, V> pair(List<V> original, List<V> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
@@ -7,10 +7,10 @@ import java.util.Map;
  *
  * @param <P>
  *            the pairing key type (e.g., String for key-based pairing)
- * @param <V>
+ * @param <T>
  *            the value type
  */
-public interface MapPairingStrategy<P extends PairingKey, V> {
+public interface MapPairingStrategy<P extends PairingKey, T> {
 
-	CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
+	CollectionDiff<P, T> pair(Map<String, T> original, Map<String, T> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/MapPairingStrategy.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * @param <V>
  *            the value type
  */
-public interface MapPairingStrategy<P, V> {
+public interface MapPairingStrategy<P extends PairingKey, V> {
 
 	CollectionDiff<P, V> pair(Map<String, V> original, Map<String, V> updated);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingKey.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingKey.java
@@ -1,0 +1,43 @@
+package io.test.synthetic.visitors.diff;
+
+/**
+ * Represents a pairing between elements from original and updated collections.
+ * Provides access to the original and updated positions as both indices and map
+ * keys.
+ */
+public interface PairingKey {
+
+	/**
+	 * The index in the original list, or null if not applicable.
+	 */
+	Integer getOriginalIndex();
+
+	/**
+	 * The index in the updated list, or null if not applicable.
+	 */
+	Integer getUpdatedIndex();
+
+	/**
+	 * The key in the original map, or null if not applicable.
+	 */
+	String getOriginalKey();
+
+	/**
+	 * The key in the updated map, or null if not applicable.
+	 */
+	String getUpdatedKey();
+
+	/**
+	 * Returns the original position as a string (map key or index).
+	 */
+	default String getOriginalPosition() {
+		return getOriginalKey() != null ? getOriginalKey() : String.valueOf(getOriginalIndex());
+	}
+
+	/**
+	 * Returns the updated position as a string (map key or index).
+	 */
+	default String getUpdatedPosition() {
+		return getUpdatedKey() != null ? getUpdatedKey() : String.valueOf(getUpdatedIndex());
+	}
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
@@ -7,7 +7,7 @@ package io.test.synthetic.visitors.diff;
  */
 public interface PairingStrategyProvider<P extends PairingKey> {
 
-	<V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
+	<T> MapPairingStrategy<P, T> getMapStrategy(String propertyName);
 
-	<V> ListPairingStrategy<P, V> getListStrategy(String propertyName);
+	<T> ListPairingStrategy<P, T> getListStrategy(String propertyName);
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/diff/PairingStrategyProvider.java
@@ -5,7 +5,7 @@ package io.test.synthetic.visitors.diff;
  * a custom provider to the DiffTraverser constructor to control how map and
  * list fields are paired.
  */
-public interface PairingStrategyProvider<P> {
+public interface PairingStrategyProvider<P extends PairingKey> {
 
 	<V> MapPairingStrategy<P, V> getMapStrategy(String propertyName);
 


### PR DESCRIPTION
## Summary

### Compound JSON Schema spec
Synthetic compound spec merging all properties from drafts 4/6/7/2019-09/2020-12 into one `JCFullSchema` entity. Both old and new field names included (`id`+`$id`, `definitions`+`$defs`). Type-changed fields use the widest union (`exclusiveMinimum: boolean|number`).

### ConversionTraverser/Visitor infrastructure
Generated per source spec version (when `conversionTarget` is configured in YAML):

- **ConversionVisitor** — abstract class with `void convertXxxField(value, target)` methods. Default body calls the same-name setter on the target entity. Override for renames and type conversions.
- **ConversionTraverser** — iterates source entity fields, recursively converts entity/union children, delegates field mapping to the visitor. Pattern matches DiffTraverser.
- **AbstractConversionTraverser** — base class with single TraversalContext for path tracking.

All 5 JSON Schema drafts configured with `conversionTarget: compound`.

### Example generated code
```java
// Default visitor: copies title to same-name setter
void convertFullSchemaTitle(String value, JCFullSchema target) {
    target.setTitle(value);
}

// Override for rename (d4 id → compound $id):
void convertFullSchemaId(String value, JCFullSchema target) {
    target.set$id(value); // redirect to $id
}
```

## Context

C41c + G26 in #1042. Next: hand-written converter implementations per draft version (Phase 3).

## Test plan

- [x] All 1129 data-models tests pass
- [x] Generated code compiles (FullGeneratorTest)
- [x] 5 conversion traverser/visitor pairs generated for JSON Schema drafts