### PR TITLE
Update junit-jupiter to 6.1.1

### DIFF
--- a/generator/src/test/resources/pom.xml
+++ b/generator/src/test/resources/pom.xml
@@ -63,7 +63,7 @@
         <!-- Dependency Versions -->
         <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
         <version.commons-io>2.22.0</version.commons-io>
-        <version.junit-jupiter>5.14.4</version.junit-jupiter>
+        <version.junit-jupiter>6.1.1</version.junit-jupiter>
         <version.org.jsweet>3.1.0</version.org.jsweet>
         <version.org.skyscreamer>1.5.3</version.org.skyscreamer>
         

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
         <version.commons-lang3>3.20.0</version.commons-lang3>
         <version.commons-io>2.22.0</version.commons-io>
-        <version.junit-jupiter>5.14.4</version.junit-jupiter>
+        <version.junit-jupiter>6.1.1</version.junit-jupiter>
 
         <!-- Dependency Versions (generator-specific) -->
         <version.commons-collections4>4.5.0</version.commons-collections4>


### PR DESCRIPTION
## Summary
- Update junit-jupiter from 5.14.4 to 6.1.1 (both root pom.xml and generator/src/test/resources/pom.xml)

## Context
This dependency upgrade was split from Renovate PR #1140 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected