### PR TITLE
Update node to 24.18.0

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22.23.1
+          node-version: 24.18.0
           registry-url: 'https://registry.npmjs.org'
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22.23.1
+          node-version: 24.18.0
 
 
       - name: Set up settings.xml


### PR DESCRIPTION
## Summary
- Update node from 22.23.1 to 24.18.0 (npm-publish.yaml and release.yaml)

## Context
This dependency upgrade was split from Renovate PR #1140 for easier review and testing.

Note: This only affects the publish/release pipelines, not the verify build workflow.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected