### PR TITLE
feat(generator): boolean recursion control + post-visit callbacks (C41d/C41e)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -422,7 +422,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public void diffFullSchemaExclusiveMinimum(BooleanNumberUnion original, BooleanNumberUnion updated) {
+    public boolean diffFullSchemaExclusiveMinimum(BooleanNumberUnion original, BooleanNumberUnion updated) {
         var origIsD4 = original != null && original.isBoolean();
         var updIsD4 = updated != null && updated.isBoolean();
 
@@ -454,10 +454,11 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                     NUMBER_TYPE_EXCLUSIVE_MINIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_REMOVED,
                     NUMBER_TYPE_EXCLUSIVE_MINIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_DECREASED);
         }
+        return true;
     }
 
     @Override
-    public void diffFullSchemaExclusiveMaximum(BooleanNumberUnion original, BooleanNumberUnion updated) {
+    public boolean diffFullSchemaExclusiveMaximum(BooleanNumberUnion original, BooleanNumberUnion updated) {
         var origIsD4 = original != null && original.isBoolean();
         var updIsD4 = updated != null && updated.isBoolean();
 
@@ -489,6 +490,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                     NUMBER_TYPE_EXCLUSIVE_MAXIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_REMOVED,
                     NUMBER_TYPE_EXCLUSIVE_MAXIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_DECREASED);
         }
+        return true;
     }
 
     @Override
@@ -528,11 +530,9 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public void diffFullSchemaItems(BooleanFullSchemaFullSchemaListUnion original,
+    public boolean diffFullSchemaItems(BooleanFullSchemaFullSchemaListUnion original,
                                     BooleanFullSchemaFullSchemaListUnion updated) {
-        // Suppress auto-recursion for items — we handle comparison ourselves
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+        if (original == null && updated == null) return false;
 
         if (original != null && updated != null) {
             if (original.isFullSchema() && updated.isFullSchema()) {
@@ -554,6 +554,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             diffAddedRemoved(ctx, original, updated,
                     ARRAY_TYPE_ALL_ITEM_SCHEMA_ADDED, ARRAY_TYPE_ALL_ITEM_SCHEMA_REMOVED);
         }
+        return false;
     }
 
     @SuppressWarnings("unchecked")
@@ -626,10 +627,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public void diffFullSchemaAdditionalItems(JsonSchema original, JsonSchema updated) {
-        // Suppress auto-recursion — we handle the comparison ourselves
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaAdditionalItems(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
 
         var origPermits = original == null || (original.isBoolean() ? original.asBoolean() : true);
         var updPermits = updated == null || (updated.isBoolean() ? updated.asBoolean() : true);
@@ -662,25 +661,25 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
         } else if ((original == null || (origIsBoolean && origPermits)) && updIsSchema) {
             ctx.addDifference(ARRAY_TYPE_ADDITIONAL_ITEMS_NARROWED, original, updated);
         }
+        return false;
     }
 
     @Override
-    public void diffFullSchemaContains(JsonSchema original, JsonSchema updated) {
-        // Suppress auto-recursion — we handle the comparison ourselves
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaContains(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         if (original == null) {
             ctx.addDifference(ARRAY_TYPE_CONTAINED_ITEM_SCHEMA_ADDED, null, updated);
-            return;
+            return false;
         }
         if (updated == null) {
             ctx.addDifference(ARRAY_TYPE_CONTAINED_ITEM_SCHEMA_REMOVED, original, null);
-            return;
+            return false;
         }
         var subCtx = ctx.sub("contains");
         if (!isUnionSchemaCompatible(subCtx, original, updated, true)) {
             subCtx.addDifference(ARRAY_TYPE_ITEM_SCHEMAS_CHANGED, original, updated);
         }
+        return false;
     }
 
     // -----------------------------------------------------------------------
@@ -803,10 +802,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public void diffFullSchemaAdditionalProperties(JsonSchema original, JsonSchema updated) {
-        // Suppress auto-recursion — we handle the comparison ourselves
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaAdditionalProperties(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
 
         var origPermits = permitsAdditional(original);
         var updPermits = permitsAdditional(updated);
@@ -846,6 +843,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 ctx.addDifference(OBJECT_TYPE_ADDITIONAL_PROPERTIES_EXTENDED, original, updated);
             }
         }
+        return false;
     }
 
     @Override
@@ -882,10 +880,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public void diffFullSchemaPropertyNames(JsonSchema original, JsonSchema updated) {
-        // Suppress auto-recursion — compareSchema handles the comparison
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaPropertyNames(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         compareSchema(ctx, original, updated,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_ADDED,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_REMOVED,
@@ -893,6 +889,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_NONE);
+        return false;
     }
 
     @Override
@@ -1103,16 +1100,15 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public void diffFullSchemaNot(JsonSchema original, JsonSchema updated) {
-        // Suppress auto-recursion — compareSchema handles the comparison
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaNot(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         compareSchema(ctx, original, updated,
                 SUBSCHEMA_TYPE_CHANGED, SUBSCHEMA_TYPE_CHANGED,
                 NOT_TYPE_SCHEMA_COMPATIBLE_BOTH,
                 NOT_TYPE_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 NOT_TYPE_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 NOT_TYPE_SCHEMA_COMPATIBLE_NONE);
+        return false;
     }
 
     // -----------------------------------------------------------------------
@@ -1122,39 +1118,39 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public void diffFullSchemaIf(JsonSchema original, JsonSchema updated) {
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaIf(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_IF_SCHEMA_ADDED, CONDITIONAL_TYPE_IF_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_NONE);
+        return false;
     }
 
     @Override
-    public void diffFullSchemaThen(JsonSchema original, JsonSchema updated) {
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaThen(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_THEN_SCHEMA_ADDED, CONDITIONAL_TYPE_THEN_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_NONE);
+        return false;
     }
 
     @Override
-    public void diffFullSchemaElse(JsonSchema original, JsonSchema updated) {
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaElse(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_ADDED, CONDITIONAL_TYPE_ELSE_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_NONE);
+        return false;
     }
 
     // -----------------------------------------------------------------------
@@ -1232,7 +1228,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public void diffFullSchemaType(
+    public boolean diffFullSchemaType(
             io.apitomy.datamodels.models.union.StringStringListUnion original,
             io.apitomy.datamodels.models.union.StringStringListUnion updated) {
         // Type change detection is handled in visitFullSchema.
@@ -1251,6 +1247,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                         NUMBER_TYPE_INTEGER_REQUIRED_UNCHANGED);
             }
         }
+        return true;
     }
 
     // -----------------------------------------------------------------------
@@ -1306,15 +1303,15 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public void diffFullSchemaContentSchema(JsonSchema original, JsonSchema updated) {
-        if (original != null || updated != null) suppressAutoRecursionCount++;
-        if (original == null && updated == null) return;
+    public boolean diffFullSchemaContentSchema(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) return false;
         if (original != null && updated != null) {
             var subCtx = ctx.sub("contentSchema");
             if (!isUnionSchemaCompatible(subCtx, original, updated, true)) {
                 subCtx.addDifference(SUBSCHEMA_TYPE_CHANGED, original, updated);
             }
         }
+        return false;
     }
 
     // -----------------------------------------------------------------------

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -49,14 +49,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     private JFullSchema currentOriginal;
     private JFullSchema currentUpdated;
 
-    /**
-     * Counter for suppressing the traverser's auto-recursion into sub-schemas.
-     * Incremented when our diff methods handle comparison themselves (composition items,
-     * not, if/then/else, contains, etc.). Decremented in {@link #visitFullSchema}
-     * or {@link #diffJsonSchema} when the traverser auto-recurses.
-     */
-    private int suppressAutoRecursionCount;
-
     public CompoundSchemaDiffVisitor(DiffContext ctx) {
         this.ctx = ctx;
     }
@@ -157,14 +149,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
 
     @Override
     public boolean visitFullSchema(JCFullSchema original, JCFullSchema updated) {
-        // When auto-recursion is suppressed (composition items, not, if/then/else, etc.),
-        // don't produce any diffs from the traverser's auto-recursion —
-        // our field-level methods handle it.
-        if (suppressAutoRecursionCount > 0) {
-            suppressAutoRecursionCount--;
-            return false;
-        }
-
         // Store for cross-field logic
         this.currentOriginal = original;
         this.currentUpdated = updated;
@@ -273,37 +257,28 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // Union visit methods
     // -----------------------------------------------------------------------
 
-    @Override
-    public void diffJsonSchema(JsonSchema original, JsonSchema updated) {
-        // When suppressing auto-recursion for non-JCFullSchema pairs (boolean schemas),
-        // visitFullSchema won't be called to decrement the counter, so we do it here.
-        if (suppressAutoRecursionCount > 0
-                && (!(original instanceof JCFullSchema) || !(updated instanceof JCFullSchema))) {
-            suppressAutoRecursionCount--;
-        }
-    }
+    // Collection item visitors: skip auto-recursion because the collection-level
+    // diff methods (diffFullSchemaProperties, diffFullSchemaAllOf, etc.) handle
+    // comparison with custom matching logic (e.g., key-based property matching,
+    // compatibility-based composition matching).
 
     @Override
-    public void diffBooleanFullSchemaFullSchemaListUnion(
-            BooleanFullSchemaFullSchemaListUnion original,
-            BooleanFullSchemaFullSchemaListUnion updated) {
-        // Same as diffJsonSchema — handle counter decrement for non-JCFullSchema pairs
-        // (e.g., when items is a tuple list, not a single schema).
-        if (suppressAutoRecursionCount > 0
-                && (!(original instanceof JCFullSchema) || !(updated instanceof JCFullSchema))) {
-            suppressAutoRecursionCount--;
-        }
-    }
+    public boolean visitFullSchemaProperty(JsonSchema original, JsonSchema updated) { return false; }
 
     @Override
-    public void diffDependency(Dependency original, Dependency updated) {
-        // Handle counter decrement for non-JCFullSchema dependency pairs
-        // (e.g., string-list dependencies).
-        if (suppressAutoRecursionCount > 0
-                && (!(original instanceof JCFullSchema) || !(updated instanceof JCFullSchema))) {
-            suppressAutoRecursionCount--;
-        }
-    }
+    public boolean visitFullSchemaPatternProperty(JsonSchema original, JsonSchema updated) { return false; }
+
+    @Override
+    public boolean visitFullSchemaDependency(Dependency original, Dependency updated) { return false; }
+
+    @Override
+    public boolean visitFullSchemaAllOfItem(JsonSchema original, JsonSchema updated) { return false; }
+
+    @Override
+    public boolean visitFullSchemaAnyOfItem(JsonSchema original, JsonSchema updated) { return false; }
+
+    @Override
+    public boolean visitFullSchemaOneOfItem(JsonSchema original, JsonSchema updated) { return false; }
 
     // -----------------------------------------------------------------------
     // String type fields
@@ -719,7 +694,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                                          Map<String, JsonSchema> updated,
                                          CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
         // Suppress auto-recursion for matched property schemas — we handle it ourselves
-        suppressAutoRecursionCount += diff.getMatched().size();
         if (original == null && updated == null) return;
 
         var origKeys = original != null ? new HashSet<>(original.keySet()) : new HashSet<String>();
@@ -851,7 +825,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                                                 Map<String, JsonSchema> updated,
                                                 CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
         // Suppress auto-recursion for matched pattern property schemas
-        suppressAutoRecursionCount += diff.getMatched().size();
         if (original == null && updated == null) return;
 
         var origKeys = original != null ? new HashSet<>(original.keySet()) : new HashSet<String>();
@@ -897,7 +870,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                                            Map<String, Dependency> updated,
                                            CollectionDiff<DefaultPairingKey, Dependency> diff) {
         // Suppress auto-recursion for matched dependencies
-        suppressAutoRecursionCount += diff.getMatched().size();
         if (original == null && updated == null) return;
 
         var origKeys = original != null
@@ -962,7 +934,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                                     CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
         // Suppress auto-recursion: the traverser will iterate diff.getMatched() and
         // call traverseJsonSchema for each pair. We handle matching in diffCompositionList.
-        suppressAutoRecursionCount += diff.getMatched().size();
 
         // Cross-field transition detection: check if composition keyword changed
         if (currentOriginal != null && currentUpdated != null) {
@@ -991,7 +962,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     @Override
     public void diffFullSchemaAnyOf(List<JsonSchema> original, List<JsonSchema> updated,
                                     CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
-        suppressAutoRecursionCount += diff.getMatched().size();
         if (currentOriginal != null && currentUpdated != null) {
             var origAllOf = currentOriginal.getAllOf();
             var origOneOf = currentOriginal.getOneOf();
@@ -1027,7 +997,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     @Override
     public void diffFullSchemaOneOf(List<JsonSchema> original, List<JsonSchema> updated,
                                     CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
-        suppressAutoRecursionCount += diff.getMatched().size();
         if (currentOriginal != null && currentUpdated != null) {
             var origAnyOf = currentOriginal.getAnyOf();
             var updAnyOf = currentUpdated.getAnyOf();

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -247,10 +247,14 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
             if (isEntity(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
-                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("    if (original.${getter}() != null && updated.${getter}() != null) {");
-                body.append("        traverse(original.${getter}(), updated.${getter}());");
+                String afterDiffMethod = "afterDiff" + entityName + fieldSuffix;
+                body.addContext("afterDiffMethod", afterDiffMethod);
+                body.append("    if (visitor.${diffMethod}(original.${getter}(), updated.${getter}())) {");
+                body.append("        if (original.${getter}() != null && updated.${getter}() != null) {");
+                body.append("            traverse(original.${getter}(), updated.${getter}());");
+                body.append("        }");
                 body.append("    }");
+                body.append("    visitor.${afterDiffMethod}(original.${getter}(), updated.${getter}());");
             } else if (isEntityList(property) || isUnionList(property)) {
                 ListType listType = (ListType) property.getResolvedType();
                 JavaType valueJt = jtf.createJavaType(listType.getValueType(), ns);
@@ -258,26 +262,30 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
 
                 String valueTypeStr = valueJt.toJavaTypeString();
                 String visitMethod = "visit" + entityName + fieldSuffix + "Item";
+                String afterVisitMethod = "afterVisit" + entityName + fieldSuffix + "Item";
                 body.addContext("valueType", valueTypeStr);
                 body.addContext("visitMethod2", visitMethod);
+                body.addContext("afterVisitMethod2", afterVisitMethod);
                 body.addContext("propertyName", property.getName());
 
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairList(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
                 body.append("        pushListIndex(pair.getKey());");
-                body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
+                body.append("        if (visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated())) {");
                 if (isEntityList(property)) {
-                    body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
-                    body.append("            traverse(pair.getOriginal(), pair.getUpdated());");
-                    body.append("        }");
+                    body.append("            if (pair.getOriginal() != null && pair.getUpdated() != null) {");
+                    body.append("                traverse(pair.getOriginal(), pair.getUpdated());");
+                    body.append("            }");
                 } else if (isUnionList(property)) {
                     ListType lt = (ListType) property.getResolvedType();
                     JavaType unionJt = jtf.createJavaType(lt.getValueType(), ns);
                     String traverseUnion = "traverse" + unionJt.getSimpleName();
                     body.addContext("traverseUnion", traverseUnion);
-                    body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
+                    body.append("            this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        }");
+                body.append("        visitor.${afterVisitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 body.append("        pop();");
                 body.append("    }");
             } else if (isEntityMap(property) || isUnionMap(property)) {
@@ -286,36 +294,45 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 valueJt.addImportsTo(classSource);
 
                 String valueTypeStr = valueJt.toJavaTypeString();
-                String visitMethod = "visit" + entityName + singularize(fieldSuffix);
+                String singularSuffix = singularize(fieldSuffix);
+                String visitMethod = "visit" + entityName + singularSuffix;
+                String afterVisitMethod = "afterVisit" + entityName + singularSuffix;
                 body.addContext("valueType", valueTypeStr);
                 body.addContext("visitMethod2", visitMethod);
+                body.addContext("afterVisitMethod2", afterVisitMethod);
                 body.addContext("propertyName", property.getName());
 
                 body.append("    CollectionDiff<P," + valueTypeStr + "> diff = this.pairMap(\"${propertyName}\", original.${getter}(), updated.${getter}());");
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
                 body.append("        pushMapKey(pair.getKey());");
-                body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
+                body.append("        if (visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated())) {");
                 if (isEntityMap(property)) {
-                    body.append("        if (pair.getOriginal() != null && pair.getUpdated() != null) {");
-                    body.append("            traverse(pair.getOriginal(), pair.getUpdated());");
-                    body.append("        }");
+                    body.append("            if (pair.getOriginal() != null && pair.getUpdated() != null) {");
+                    body.append("                traverse(pair.getOriginal(), pair.getUpdated());");
+                    body.append("            }");
                 } else if (isUnionMap(property)) {
                     MapType mt = (MapType) property.getResolvedType();
                     JavaType unionJt = jtf.createJavaType(mt.getValueType(), ns);
                     String traverseUnion = "traverse" + unionJt.getSimpleName();
                     body.addContext("traverseUnion", traverseUnion);
-                    body.append("        this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
+                    body.append("            this.${traverseUnion}(pair.getOriginal(), pair.getUpdated());");
                 }
+                body.append("        }");
+                body.append("        visitor.${afterVisitMethod2}(pair.getOriginal(), pair.getUpdated());");
                 body.append("        pop();");
                 body.append("    }");
             } else if (isUnion(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
                 String traverseUnion = "traverse" + jt.getSimpleName();
+                String afterDiffMethod = "afterDiff" + entityName + fieldSuffix;
                 body.addContext("traverseUnion", traverseUnion);
-                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
-                body.append("    this.${traverseUnion}(original.${getter}(), updated.${getter}());");
+                body.addContext("afterDiffMethod", afterDiffMethod);
+                body.append("    if (visitor.${diffMethod}(original.${getter}(), updated.${getter}())) {");
+                body.append("        this.${traverseUnion}(original.${getter}(), updated.${getter}());");
+                body.append("    }");
+                body.append("    visitor.${afterDiffMethod}(original.${getter}(), updated.${getter}());");
             } else if (isPrimitive(property) || isPrimitiveList(property) || isPrimitiveMap(property)) {
                 JavaType jt = jtf.createJavaType(property.getResolvedType(), ns);
                 jt.addImportsTo(classSource);
@@ -325,6 +342,9 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
             body.append("    pop();");
             body.append("}");
         }
+
+        body.addContext("afterVisitEntity", "afterVisit" + entityName);
+        body.append("visitor.${afterVisitEntity}(original, updated);");
 
         method.setBody(body.toString());
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -95,6 +95,15 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         method.addParameter(javaEntity.getName(), "original");
         method.addParameter(javaEntity.getName(), "updated");
         method.setBody("return true;");
+
+        String afterMethodName = "afterVisit" + entityModel.getName();
+        MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
+                .setName(afterMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        afterMethod.addParameter(javaEntity.getName(), "original");
+        afterMethod.addParameter(javaEntity.getName(), "updated");
+        afterMethod.setBody("");
     }
 
     private void createPropertyMethods(JavaClassSource classSource, EntityModel entityModel,
@@ -153,11 +162,20 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String methodName = "diff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> method = classSource.addMethod()
                 .setName(methodName)
-                .setReturnTypeVoid()
+                .setReturnType(boolean.class)
                 .setPublic();
         method.addParameter(jt.toJavaTypeString(), "original");
         method.addParameter(jt.toJavaTypeString(), "updated");
-        method.setBody("");
+        method.setBody("return true;");
+
+        String afterMethodName = "afterDiff" + entityName + fieldSuffix;
+        MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
+                .setName(afterMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        afterMethod.addParameter(jt.toJavaTypeString(), "original");
+        afterMethod.addParameter(jt.toJavaTypeString(), "updated");
+        afterMethod.setBody("");
     }
 
     private void createUnionFieldMethod(JavaClassSource classSource, String entityName,
@@ -168,11 +186,20 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String methodName = "diff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> method = classSource.addMethod()
                 .setName(methodName)
-                .setReturnTypeVoid()
+                .setReturnType(boolean.class)
                 .setPublic();
         method.addParameter(jt.toJavaTypeString(), "original");
         method.addParameter(jt.toJavaTypeString(), "updated");
-        method.setBody("");
+        method.setBody("return true;");
+
+        String afterMethodName = "afterDiff" + entityName + fieldSuffix;
+        MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
+                .setName(afterMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        afterMethod.addParameter(jt.toJavaTypeString(), "original");
+        afterMethod.addParameter(jt.toJavaTypeString(), "updated");
+        afterMethod.setBody("");
     }
 
     private void createListFieldMethods(JavaClassSource classSource, String entityName,
@@ -200,11 +227,20 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String visitMethodName = "visit" + entityName + fieldSuffix + "Item";
         MethodSource<JavaClassSource> visitMethod = classSource.addMethod()
                 .setName(visitMethodName)
-                .setReturnTypeVoid()
+                .setReturnType(boolean.class)
                 .setPublic();
         visitMethod.addParameter(valueJt.toJavaTypeString(), "original");
         visitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
-        visitMethod.setBody("");
+        visitMethod.setBody("return true;");
+
+        String afterVisitMethodName = "afterVisit" + entityName + fieldSuffix + "Item";
+        MethodSource<JavaClassSource> afterVisitMethod = classSource.addMethod()
+                .setName(afterVisitMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        afterVisitMethod.addParameter(valueJt.toJavaTypeString(), "original");
+        afterVisitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
+        afterVisitMethod.setBody("");
     }
 
     private void createMapFieldMethods(JavaClassSource classSource, String entityName,
@@ -232,11 +268,20 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String visitMethodName = "visit" + entityName + singularSuffix;
         MethodSource<JavaClassSource> visitMethod = classSource.addMethod()
                 .setName(visitMethodName)
-                .setReturnTypeVoid()
+                .setReturnType(boolean.class)
                 .setPublic();
         visitMethod.addParameter(valueJt.toJavaTypeString(), "original");
         visitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
-        visitMethod.setBody("");
+        visitMethod.setBody("return true;");
+
+        String afterVisitMethodName = "afterVisit" + entityName + singularSuffix;
+        MethodSource<JavaClassSource> afterVisitMethod = classSource.addMethod()
+                .setName(afterVisitMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        afterVisitMethod.addParameter(valueJt.toJavaTypeString(), "original");
+        afterVisitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
+        afterVisitMethod.setBody("");
     }
 
     private static String singularize(String name) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -79,10 +79,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("info");
-			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-			if (original.getInfo() != null && updated.getInfo() != null) {
-				traverse(original.getInfo(), updated.getInfo());
+			if (visitor.diffDocumentInfo(original.getInfo(), updated.getInfo())) {
+				if (original.getInfo() != null && updated.getInfo() != null) {
+					traverse(original.getInfo(), updated.getInfo());
+				}
 			}
+			visitor.afterDiffDocumentInfo(original.getInfo(), updated.getInfo());
 			pop();
 		}
 		{
@@ -91,10 +93,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
-				if (pair.getOriginal() != null && pair.getUpdated() != null) {
-					traverse(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated())) {
+					if (pair.getOriginal() != null && pair.getUpdated() != null) {
+						traverse(pair.getOriginal(), pair.getUpdated());
+					}
 				}
+				visitor.afterVisitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -111,10 +115,13 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("additionalSchema");
-			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			if (visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema())) {
+				this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			}
+			visitor.afterDiffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
 			pop();
 		}
+		visitor.afterVisitDocument(original, updated);
 	}
 
 	public void traverseInfo(Syn1Info original, Syn1Info updated) {
@@ -131,10 +138,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("contact");
-			visitor.diffInfoContact(original.getContact(), updated.getContact());
-			if (original.getContact() != null && updated.getContact() != null) {
-				traverse(original.getContact(), updated.getContact());
+			if (visitor.diffInfoContact(original.getContact(), updated.getContact())) {
+				if (original.getContact() != null && updated.getContact() != null) {
+					traverse(original.getContact(), updated.getContact());
+				}
 			}
+			visitor.afterDiffInfoContact(original.getContact(), updated.getContact());
 			pop();
 		}
 		{
@@ -142,6 +151,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffInfoVersion(original.getVersion(), updated.getVersion());
 			pop();
 		}
+		visitor.afterVisitInfo(original, updated);
 	}
 
 	public void traverseContact(Syn1Contact original, Syn1Contact updated) {
@@ -166,6 +176,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
 			pop();
 		}
+		visitor.afterVisitContact(original, updated);
 	}
 
 	public void traverseItem(Syn1Item original, Syn1Item updated) {
@@ -212,10 +223,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("schema");
-			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-			if (original.getSchema() != null && updated.getSchema() != null) {
-				traverse(original.getSchema(), updated.getSchema());
+			if (visitor.diffItemSchema(original.getSchema(), updated.getSchema())) {
+				if (original.getSchema() != null && updated.getSchema() != null) {
+					traverse(original.getSchema(), updated.getSchema());
+				}
 			}
+			visitor.afterDiffItemSchema(original.getSchema(), updated.getSchema());
 			pop();
 		}
 		{
@@ -225,8 +238,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("defaultValue");
-			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			if (visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue())) {
+				this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			}
+			visitor.afterDiffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
 			pop();
 		}
 		{
@@ -234,6 +249,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffItemTitle(original.getTitle(), updated.getTitle());
 			pop();
 		}
+		visitor.afterVisitItem(original, updated);
 	}
 
 	public void traverseSchema(Syn1Schema original, Syn1Schema updated) {
@@ -255,8 +271,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("items");
-			visitor.diffSchemaItems(original.getItems(), updated.getItems());
-			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			if (visitor.diffSchemaItems(original.getItems(), updated.getItems())) {
+				this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			}
+			visitor.afterDiffSchemaItems(original.getItems(), updated.getItems());
 			pop();
 		}
 		{
@@ -266,8 +284,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -279,8 +299,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -292,8 +314,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -305,8 +329,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
-				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -318,8 +344,10 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
-				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -339,6 +367,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
 			pop();
 		}
+		visitor.afterVisitSchema(original, updated);
 	}
 
 	public void traversePaths(Syn1Paths original, Syn1Paths updated) {
@@ -348,6 +377,7 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			return;
 		if (original == null || updated == null)
 			return;
+		visitor.afterVisitPaths(original, updated);
 	}
 
 	public void traversePathItem(Syn1PathItem original, Syn1PathItem updated) {
@@ -369,28 +399,35 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("get");
-			visitor.diffPathItemGet(original.getGet(), updated.getGet());
-			if (original.getGet() != null && updated.getGet() != null) {
-				traverse(original.getGet(), updated.getGet());
+			if (visitor.diffPathItemGet(original.getGet(), updated.getGet())) {
+				if (original.getGet() != null && updated.getGet() != null) {
+					traverse(original.getGet(), updated.getGet());
+				}
 			}
+			visitor.afterDiffPathItemGet(original.getGet(), updated.getGet());
 			pop();
 		}
 		{
 			pushProperty("put");
-			visitor.diffPathItemPut(original.getPut(), updated.getPut());
-			if (original.getPut() != null && updated.getPut() != null) {
-				traverse(original.getPut(), updated.getPut());
+			if (visitor.diffPathItemPut(original.getPut(), updated.getPut())) {
+				if (original.getPut() != null && updated.getPut() != null) {
+					traverse(original.getPut(), updated.getPut());
+				}
 			}
+			visitor.afterDiffPathItemPut(original.getPut(), updated.getPut());
 			pop();
 		}
 		{
 			pushProperty("post");
-			visitor.diffPathItemPost(original.getPost(), updated.getPost());
-			if (original.getPost() != null && updated.getPost() != null) {
-				traverse(original.getPost(), updated.getPost());
+			if (visitor.diffPathItemPost(original.getPost(), updated.getPost())) {
+				if (original.getPost() != null && updated.getPost() != null) {
+					traverse(original.getPost(), updated.getPost());
+				}
 			}
+			visitor.afterDiffPathItemPost(original.getPost(), updated.getPost());
 			pop();
 		}
+		visitor.afterVisitPathItem(original, updated);
 	}
 
 	public void traverseOperation(Syn1Operation original, Syn1Operation updated) {
@@ -422,14 +459,17 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
-				if (pair.getOriginal() != null && pair.getUpdated() != null) {
-					traverse(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated())) {
+					if (pair.getOriginal() != null && pair.getUpdated() != null) {
+						traverse(pair.getOriginal(), pair.getUpdated());
+					}
 				}
+				visitor.afterVisitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
 		}
+		visitor.afterVisitOperation(original, updated);
 	}
 
 	public void traverseSchemaOrBoolean(SchemaOrBoolean original, SchemaOrBoolean updated) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -29,16 +29,27 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitDocument(Syn1Document original, Syn1Document updated) {
+	}
+
 	public void diffDocumentVersion(String original, String updated) {
 	}
 
-	public void diffDocumentInfo(SynInfo original, SynInfo updated) {
+	public boolean diffDocumentInfo(SynInfo original, SynInfo updated) {
+		return true;
+	}
+
+	public void afterDiffDocumentInfo(SynInfo original, SynInfo updated) {
 	}
 
 	public void diffDocumentItems(List<SynItem> original, List<SynItem> updated, CollectionDiff<P, SynItem> diff) {
 	}
 
-	public void visitDocumentItemsItem(SynItem original, SynItem updated) {
+	public boolean visitDocumentItemsItem(SynItem original, SynItem updated) {
+		return true;
+	}
+
+	public void afterVisitDocumentItemsItem(SynItem original, SynItem updated) {
 	}
 
 	public void diffDocumentTags(List<String> original, List<String> updated) {
@@ -47,17 +58,28 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffDocumentMetadata(Map<String, String> original, Map<String, String> updated) {
 	}
 
-	public void diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public boolean diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterDiffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public boolean visitInfo(Syn1Info original, Syn1Info updated) {
 		return true;
 	}
 
+	public void afterVisitInfo(Syn1Info original, Syn1Info updated) {
+	}
+
 	public void diffInfoName(String original, String updated) {
 	}
 
-	public void diffInfoContact(SynContact original, SynContact updated) {
+	public boolean diffInfoContact(SynContact original, SynContact updated) {
+		return true;
+	}
+
+	public void afterDiffInfoContact(SynContact original, SynContact updated) {
 	}
 
 	public void diffInfoVersion(String original, String updated) {
@@ -65,6 +87,9 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 
 	public boolean visitContact(Syn1Contact original, Syn1Contact updated) {
 		return true;
+	}
+
+	public void afterVisitContact(Syn1Contact original, Syn1Contact updated) {
 	}
 
 	public void diffContactName(String original, String updated) {
@@ -78,6 +103,9 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 
 	public boolean visitItem(Syn1Item original, Syn1Item updated) {
 		return true;
+	}
+
+	public void afterVisitItem(Syn1Item original, Syn1Item updated) {
 	}
 
 	public void diffItem$ref(String original, String updated) {
@@ -101,13 +129,21 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffItemRaw(ObjectNode original, ObjectNode updated) {
 	}
 
-	public void diffItemSchema(SynSchema original, SynSchema updated) {
+	public boolean diffItemSchema(SynSchema original, SynSchema updated) {
+		return true;
+	}
+
+	public void afterDiffItemSchema(SynSchema original, SynSchema updated) {
 	}
 
 	public void diffItemExamples(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public void diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterDiffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffItemTitle(String original, String updated) {
@@ -117,48 +153,75 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitSchema(Syn1Schema original, Syn1Schema updated) {
+	}
+
 	public void diffSchema$ref(String original, String updated) {
 	}
 
 	public void diffSchemaType(String original, String updated) {
 	}
 
-	public void diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
+	public boolean diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
+		return true;
+	}
+
+	public void afterDiffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
 	}
 
 	public void diffSchemaProperties(Map<String, BooleanSchemaUnion> original, Map<String, BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaAllOf(List<BooleanSchemaUnion> original, List<BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaDefinitions(Map<String, BooleanSchemaUnion> original, Map<String, BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaNestedSchemas(Map<String, SchemaOrBoolean> original, Map<String, SchemaOrBoolean> updated,
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public void visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public boolean visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void diffSchemaComposedSchemas(List<SchemaOrBoolean> original, List<SchemaOrBoolean> updated,
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public void visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public boolean visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void diffSchemaMinLength(Integer original, Integer updated) {
@@ -174,8 +237,14 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitPaths(Syn1Paths original, Syn1Paths updated) {
+	}
+
 	public boolean visitPathItem(Syn1PathItem original, Syn1PathItem updated) {
 		return true;
+	}
+
+	public void afterVisitPathItem(Syn1PathItem original, Syn1PathItem updated) {
 	}
 
 	public void diffPathItem$ref(String original, String updated) {
@@ -184,17 +253,32 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffPathItemSummary(String original, String updated) {
 	}
 
-	public void diffPathItemGet(SynOperation original, SynOperation updated) {
+	public boolean diffPathItemGet(SynOperation original, SynOperation updated) {
+		return true;
 	}
 
-	public void diffPathItemPut(SynOperation original, SynOperation updated) {
+	public void afterDiffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
-	public void diffPathItemPost(SynOperation original, SynOperation updated) {
+	public boolean diffPathItemPut(SynOperation original, SynOperation updated) {
+		return true;
+	}
+
+	public void afterDiffPathItemPut(SynOperation original, SynOperation updated) {
+	}
+
+	public boolean diffPathItemPost(SynOperation original, SynOperation updated) {
+		return true;
+	}
+
+	public void afterDiffPathItemPost(SynOperation original, SynOperation updated) {
 	}
 
 	public boolean visitOperation(Syn1Operation original, Syn1Operation updated) {
 		return true;
+	}
+
+	public void afterVisitOperation(Syn1Operation original, Syn1Operation updated) {
 	}
 
 	public void diffOperationOperationId(String original, String updated) {
@@ -210,7 +294,11 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SynItem> diff) {
 	}
 
-	public void visitOperationParametersItem(SynItem original, SynItem updated) {
+	public boolean visitOperationParametersItem(SynItem original, SynItem updated) {
+		return true;
+	}
+
+	public void afterVisitOperationParametersItem(SynItem original, SynItem updated) {
 	}
 
 	public void diffSchemaOrBoolean(SchemaOrBoolean original, SchemaOrBoolean updated) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -79,10 +79,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("info");
-			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
-			if (original.getInfo() != null && updated.getInfo() != null) {
-				traverse(original.getInfo(), updated.getInfo());
+			if (visitor.diffDocumentInfo(original.getInfo(), updated.getInfo())) {
+				if (original.getInfo() != null && updated.getInfo() != null) {
+					traverse(original.getInfo(), updated.getInfo());
+				}
 			}
+			visitor.afterDiffDocumentInfo(original.getInfo(), updated.getInfo());
 			pop();
 		}
 		{
@@ -91,10 +93,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
-				if (pair.getOriginal() != null && pair.getUpdated() != null) {
-					traverse(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated())) {
+					if (pair.getOriginal() != null && pair.getUpdated() != null) {
+						traverse(pair.getOriginal(), pair.getUpdated());
+					}
 				}
+				visitor.afterVisitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -116,20 +120,25 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
-				if (pair.getOriginal() != null && pair.getUpdated() != null) {
-					traverse(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated())) {
+					if (pair.getOriginal() != null && pair.getUpdated() != null) {
+						traverse(pair.getOriginal(), pair.getUpdated());
+					}
 				}
+				visitor.afterVisitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
 		}
 		{
 			pushProperty("additionalSchema");
-			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
-			this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			if (visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema())) {
+				this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			}
+			visitor.afterDiffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
 			pop();
 		}
+		visitor.afterVisitDocument(original, updated);
 	}
 
 	public void traverseInfo(Syn2Info original, Syn2Info updated) {
@@ -146,10 +155,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("contact");
-			visitor.diffInfoContact(original.getContact(), updated.getContact());
-			if (original.getContact() != null && updated.getContact() != null) {
-				traverse(original.getContact(), updated.getContact());
+			if (visitor.diffInfoContact(original.getContact(), updated.getContact())) {
+				if (original.getContact() != null && updated.getContact() != null) {
+					traverse(original.getContact(), updated.getContact());
+				}
 			}
+			visitor.afterDiffInfoContact(original.getContact(), updated.getContact());
 			pop();
 		}
 		{
@@ -162,6 +173,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffInfoLicense(original.getLicense(), updated.getLicense());
 			pop();
 		}
+		visitor.afterVisitInfo(original, updated);
 	}
 
 	public void traverseContact(Syn2Contact original, Syn2Contact updated) {
@@ -186,6 +198,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffContactUrl(original.getUrl(), updated.getUrl());
 			pop();
 		}
+		visitor.afterVisitContact(original, updated);
 	}
 
 	public void traverseItem(Syn2Item original, Syn2Item updated) {
@@ -232,10 +245,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("schema");
-			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
-			if (original.getSchema() != null && updated.getSchema() != null) {
-				traverse(original.getSchema(), updated.getSchema());
+			if (visitor.diffItemSchema(original.getSchema(), updated.getSchema())) {
+				if (original.getSchema() != null && updated.getSchema() != null) {
+					traverse(original.getSchema(), updated.getSchema());
+				}
 			}
+			visitor.afterDiffItemSchema(original.getSchema(), updated.getSchema());
 			pop();
 		}
 		{
@@ -245,8 +260,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("defaultValue");
-			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
-			this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			if (visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue())) {
+				this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
+			}
+			visitor.afterDiffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
 			pop();
 		}
 		{
@@ -259,6 +276,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffItemDeprecated(original.isDeprecated(), updated.isDeprecated());
 			pop();
 		}
+		visitor.afterVisitItem(original, updated);
 	}
 
 	public void traverseSchema(Syn2Schema original, Syn2Schema updated) {
@@ -280,8 +298,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("items");
-			visitor.diffSchemaItems(original.getItems(), updated.getItems());
-			this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			if (visitor.diffSchemaItems(original.getItems(), updated.getItems())) {
+				this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
+			}
+			visitor.afterDiffSchemaItems(original.getItems(), updated.getItems());
 			pop();
 		}
 		{
@@ -291,8 +311,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaProperty(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -304,8 +326,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -317,8 +341,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
-				this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -330,8 +356,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
-				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -343,8 +371,10 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
-				this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated())) {
+					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
+				}
+				visitor.afterVisitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
@@ -364,6 +394,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaEnum(original.getEnum(), updated.getEnum());
 			pop();
 		}
+		visitor.afterVisitSchema(original, updated);
 	}
 
 	public void traversePaths(Syn2Paths original, Syn2Paths updated) {
@@ -373,6 +404,7 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			return;
 		if (original == null || updated == null)
 			return;
+		visitor.afterVisitPaths(original, updated);
 	}
 
 	public void traversePathItem(Syn2PathItem original, Syn2PathItem updated) {
@@ -394,36 +426,45 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("get");
-			visitor.diffPathItemGet(original.getGet(), updated.getGet());
-			if (original.getGet() != null && updated.getGet() != null) {
-				traverse(original.getGet(), updated.getGet());
+			if (visitor.diffPathItemGet(original.getGet(), updated.getGet())) {
+				if (original.getGet() != null && updated.getGet() != null) {
+					traverse(original.getGet(), updated.getGet());
+				}
 			}
+			visitor.afterDiffPathItemGet(original.getGet(), updated.getGet());
 			pop();
 		}
 		{
 			pushProperty("put");
-			visitor.diffPathItemPut(original.getPut(), updated.getPut());
-			if (original.getPut() != null && updated.getPut() != null) {
-				traverse(original.getPut(), updated.getPut());
+			if (visitor.diffPathItemPut(original.getPut(), updated.getPut())) {
+				if (original.getPut() != null && updated.getPut() != null) {
+					traverse(original.getPut(), updated.getPut());
+				}
 			}
+			visitor.afterDiffPathItemPut(original.getPut(), updated.getPut());
 			pop();
 		}
 		{
 			pushProperty("post");
-			visitor.diffPathItemPost(original.getPost(), updated.getPost());
-			if (original.getPost() != null && updated.getPost() != null) {
-				traverse(original.getPost(), updated.getPost());
+			if (visitor.diffPathItemPost(original.getPost(), updated.getPost())) {
+				if (original.getPost() != null && updated.getPost() != null) {
+					traverse(original.getPost(), updated.getPost());
+				}
 			}
+			visitor.afterDiffPathItemPost(original.getPost(), updated.getPost());
 			pop();
 		}
 		{
 			pushProperty("delete");
-			visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
-			if (original.getDelete() != null && updated.getDelete() != null) {
-				traverse(original.getDelete(), updated.getDelete());
+			if (visitor.diffPathItemDelete(original.getDelete(), updated.getDelete())) {
+				if (original.getDelete() != null && updated.getDelete() != null) {
+					traverse(original.getDelete(), updated.getDelete());
+				}
 			}
+			visitor.afterDiffPathItemDelete(original.getDelete(), updated.getDelete());
 			pop();
 		}
+		visitor.afterVisitPathItem(original, updated);
 	}
 
 	public void traverseOperation(Syn2Operation original, Syn2Operation updated) {
@@ -455,14 +496,17 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
-				if (pair.getOriginal() != null && pair.getUpdated() != null) {
-					traverse(pair.getOriginal(), pair.getUpdated());
+				if (visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated())) {
+					if (pair.getOriginal() != null && pair.getUpdated() != null) {
+						traverse(pair.getOriginal(), pair.getUpdated());
+					}
 				}
+				visitor.afterVisitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
 				pop();
 			}
 			pop();
 		}
+		visitor.afterVisitOperation(original, updated);
 	}
 
 	public void traverseSchemaOrBoolean(SchemaOrBoolean original, SchemaOrBoolean updated) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -29,16 +29,27 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitDocument(Syn2Document original, Syn2Document updated) {
+	}
+
 	public void diffDocumentVersion(String original, String updated) {
 	}
 
-	public void diffDocumentInfo(SynInfo original, SynInfo updated) {
+	public boolean diffDocumentInfo(SynInfo original, SynInfo updated) {
+		return true;
+	}
+
+	public void afterDiffDocumentInfo(SynInfo original, SynInfo updated) {
 	}
 
 	public void diffDocumentItems(List<SynItem> original, List<SynItem> updated, CollectionDiff<P, SynItem> diff) {
 	}
 
-	public void visitDocumentItemsItem(SynItem original, SynItem updated) {
+	public boolean visitDocumentItemsItem(SynItem original, SynItem updated) {
+		return true;
+	}
+
+	public void afterVisitDocumentItemsItem(SynItem original, SynItem updated) {
 	}
 
 	public void diffDocumentTags(List<String> original, List<String> updated) {
@@ -51,20 +62,35 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, Syn2PathItem> diff) {
 	}
 
-	public void visitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
+	public boolean visitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
+		return true;
 	}
 
-	public void diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public void afterVisitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
+	}
+
+	public boolean diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterDiffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public boolean visitInfo(Syn2Info original, Syn2Info updated) {
 		return true;
 	}
 
+	public void afterVisitInfo(Syn2Info original, Syn2Info updated) {
+	}
+
 	public void diffInfoName(String original, String updated) {
 	}
 
-	public void diffInfoContact(SynContact original, SynContact updated) {
+	public boolean diffInfoContact(SynContact original, SynContact updated) {
+		return true;
+	}
+
+	public void afterDiffInfoContact(SynContact original, SynContact updated) {
 	}
 
 	public void diffInfoVersion(String original, String updated) {
@@ -75,6 +101,9 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 
 	public boolean visitContact(Syn2Contact original, Syn2Contact updated) {
 		return true;
+	}
+
+	public void afterVisitContact(Syn2Contact original, Syn2Contact updated) {
 	}
 
 	public void diffContactName(String original, String updated) {
@@ -88,6 +117,9 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 
 	public boolean visitItem(Syn2Item original, Syn2Item updated) {
 		return true;
+	}
+
+	public void afterVisitItem(Syn2Item original, Syn2Item updated) {
 	}
 
 	public void diffItem$ref(String original, String updated) {
@@ -111,13 +143,21 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffItemRaw(ObjectNode original, ObjectNode updated) {
 	}
 
-	public void diffItemSchema(SynSchema original, SynSchema updated) {
+	public boolean diffItemSchema(SynSchema original, SynSchema updated) {
+		return true;
+	}
+
+	public void afterDiffItemSchema(SynSchema original, SynSchema updated) {
 	}
 
 	public void diffItemExamples(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public void diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterDiffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffItemTitle(String original, String updated) {
@@ -130,48 +170,75 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitSchema(Syn2Schema original, Syn2Schema updated) {
+	}
+
 	public void diffSchema$ref(String original, String updated) {
 	}
 
 	public void diffSchemaType(String original, String updated) {
 	}
 
-	public void diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
+	public boolean diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
+		return true;
+	}
+
+	public void afterDiffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
 	}
 
 	public void diffSchemaProperties(Map<String, BooleanSchemaUnion> original, Map<String, BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaAllOf(List<BooleanSchemaUnion> original, List<BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaDefinitions(Map<String, BooleanSchemaUnion> original, Map<String, BooleanSchemaUnion> updated,
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public void visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+	public boolean visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void diffSchemaNestedSchemas(Map<String, SchemaOrBoolean> original, Map<String, SchemaOrBoolean> updated,
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public void visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public boolean visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void diffSchemaComposedSchemas(List<SchemaOrBoolean> original, List<SchemaOrBoolean> updated,
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public void visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
+	public boolean visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
+		return true;
+	}
+
+	public void afterVisitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void diffSchemaMinLength(Integer original, Integer updated) {
@@ -187,8 +254,14 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 		return true;
 	}
 
+	public void afterVisitPaths(Syn2Paths original, Syn2Paths updated) {
+	}
+
 	public boolean visitPathItem(Syn2PathItem original, Syn2PathItem updated) {
 		return true;
+	}
+
+	public void afterVisitPathItem(Syn2PathItem original, Syn2PathItem updated) {
 	}
 
 	public void diffPathItem$ref(String original, String updated) {
@@ -197,20 +270,39 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffPathItemSummary(String original, String updated) {
 	}
 
-	public void diffPathItemGet(SynOperation original, SynOperation updated) {
+	public boolean diffPathItemGet(SynOperation original, SynOperation updated) {
+		return true;
 	}
 
-	public void diffPathItemPut(SynOperation original, SynOperation updated) {
+	public void afterDiffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
-	public void diffPathItemPost(SynOperation original, SynOperation updated) {
+	public boolean diffPathItemPut(SynOperation original, SynOperation updated) {
+		return true;
 	}
 
-	public void diffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
+	public void afterDiffPathItemPut(SynOperation original, SynOperation updated) {
+	}
+
+	public boolean diffPathItemPost(SynOperation original, SynOperation updated) {
+		return true;
+	}
+
+	public void afterDiffPathItemPost(SynOperation original, SynOperation updated) {
+	}
+
+	public boolean diffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
+		return true;
+	}
+
+	public void afterDiffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
 	}
 
 	public boolean visitOperation(Syn2Operation original, Syn2Operation updated) {
 		return true;
+	}
+
+	public void afterVisitOperation(Syn2Operation original, Syn2Operation updated) {
 	}
 
 	public void diffOperationOperationId(String original, String updated) {
@@ -226,7 +318,11 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SynItem> diff) {
 	}
 
-	public void visitOperationParametersItem(SynItem original, SynItem updated) {
+	public boolean visitOperationParametersItem(SynItem original, SynItem updated) {
+		return true;
+	}
+
+	public void afterVisitOperationParametersItem(SynItem original, SynItem updated) {
 	}
 
 	public void diffSchemaOrBoolean(SchemaOrBoolean original, SchemaOrBoolean updated) {


### PR DESCRIPTION
## Summary

Two generator improvements for DiffTraverser/DiffVisitor:

### C41d: Boolean return for recursion control
- Entity/union field diff methods return `boolean` — `false` suppresses auto-recursion
- Collection item visitor methods (`visitFullSchemaAllOfItem`) also return `boolean`
- Primitive field methods stay `void` (no recursion)
- Default: `return true` (auto-recurse)

### C41e: Post-visit callbacks
- `afterVisitFullSchema(orig, upd)` — after all entity fields processed
- `afterDiffFullSchemaNot(orig, upd)` — after field recursion completes (or skips)
- `afterVisitFullSchemaAllOfItem(orig, upd)` — after per-item recursion
- Called regardless of whether recursion happened

### CompoundSchemaDiffVisitor updates
9 field methods now return `false` instead of using `suppressAutoRecursionCount++`.
Counter still used for collection-level suppression (follow-up cleanup).

## Context
C41d + C41e in #1042.

## Test plan
- [x] All 1133 data-models tests pass
- [x] Generated code compiles