### PR TITLE
feat: normalize min/max to RangeValue in compound schema (C41g)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -15,7 +15,7 @@ import io.apitomy.datamodels.models.jsonschema.draft.draft6.JD6FullSchema;
 import io.apitomy.datamodels.models.jsonschema.draft.draft7.JD7FullSchema;
 import io.apitomy.datamodels.models.jsonschema.modern.v201909.JM201909FullSchema;
 import io.apitomy.datamodels.models.jsonschema.modern.v202012.JM202012FullSchema;
-import io.apitomy.datamodels.models.union.BooleanNumberUnion;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
 import io.apitomy.datamodels.models.visitors.diff.CollectionDiff;
 import io.apitomy.datamodels.models.visitors.diff.DefaultPairingKey;
 
@@ -232,8 +232,6 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 || schema.getRequired() != null
                 || schema.getMinLength() != null
                 || schema.getMaxLength() != null
-                || schema.getMinimum() != null
-                || schema.getMaximum() != null
                 || schema.getMinItems() != null
                 || schema.getMaxItems() != null
                 || schema.getMinProperties() != null
@@ -246,7 +244,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             return false;
         }
         if (schema instanceof JCFullSchema c
-                && (c.getItems() != null || c.getAdditionalItems() != null
+                && (c.getMinimum() != null || c.getMaximum() != null
+                    || c.getItems() != null || c.getAdditionalItems() != null
                     || c.getConst() != null)) {
             return false;
         }
@@ -331,141 +330,67 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public void diffFullSchemaMinimum(Number original, Number updated) {
-        // Adjust for draft-4 exclusiveMinimum (boolean form) interaction
-        var adjOrig = original;
-        var adjUpd = updated;
-        if (currentOriginal != null && currentUpdated != null) {
-            var origExclMin = getEffectiveExclusiveMinimum(currentOriginal);
-            var updExclMin = getEffectiveExclusiveMinimum(currentUpdated);
-
-            if (isDraft4ExclusiveMinimum(currentOriginal)
-                    && Boolean.TRUE.equals(getDraft4ExclusiveMinimum(currentOriginal))) {
-                adjOrig = null;
-            }
-            if (isDraft4ExclusiveMinimum(currentUpdated)
-                    && Boolean.TRUE.equals(getDraft4ExclusiveMinimum(currentUpdated))) {
-                adjUpd = null;
-            }
-            if (adjOrig == null && adjUpd != null && origExclMin != null) {
-                if (toBigDecimal(origExclMin).compareTo(toBigDecimal(adjUpd)) >= 0) {
-                    adjUpd = null;
-                }
-            }
-            if (adjOrig != null && adjUpd == null && updExclMin != null) {
-                if (toBigDecimal(updExclMin).compareTo(toBigDecimal(adjOrig)) >= 0) {
-                    adjOrig = null;
-                }
-            }
+    public boolean diffFullSchemaMinimum(JCRangeValue original, JCRangeValue updated) {
+        if (original == null && updated == null) return false;
+        if (original == null) {
+            ctx.addDifference(NUMBER_TYPE_MINIMUM_ADDED, null, rangeToString(updated));
+            return false;
         }
-        diffNumber(ctx, adjOrig, adjUpd,
-                NUMBER_TYPE_MINIMUM_ADDED, NUMBER_TYPE_MINIMUM_REMOVED,
-                NUMBER_TYPE_MINIMUM_INCREASED, NUMBER_TYPE_MINIMUM_DECREASED);
+        if (updated == null) {
+            ctx.addDifference(NUMBER_TYPE_MINIMUM_REMOVED, rangeToString(original), null);
+            return false;
+        }
+        // Both present -- compare values
+        Number origVal = original.getValue();
+        Number updVal = updated.getValue();
+        if (origVal != null && updVal != null) {
+            int cmp = toBigDecimal(origVal).compareTo(toBigDecimal(updVal));
+            boolean origExcl = Boolean.TRUE.equals(original.isExclusive());
+            boolean updExcl = Boolean.TRUE.equals(updated.isExclusive());
+            if (cmp < 0 || (cmp == 0 && !origExcl && updExcl)) {
+                // minimum increased (tightened)
+                ctx.addDifference(NUMBER_TYPE_MINIMUM_INCREASED,
+                        rangeToString(original), rangeToString(updated));
+            } else if (cmp > 0 || (cmp == 0 && origExcl && !updExcl)) {
+                // minimum decreased (relaxed)
+                ctx.addDifference(NUMBER_TYPE_MINIMUM_DECREASED,
+                        rangeToString(original), rangeToString(updated));
+            }
+            // else: same value and exclusivity -- no diff
+        }
+        return false; // don't auto-recurse into RangeValue fields
     }
 
     @Override
-    public void diffFullSchemaMaximum(Number original, Number updated) {
-        // Adjust for draft-4 exclusiveMaximum (boolean form) interaction
-        var adjOrig = original;
-        var adjUpd = updated;
-        if (currentOriginal != null && currentUpdated != null) {
-            var origExclMax = getEffectiveExclusiveMaximum(currentOriginal);
-            var updExclMax = getEffectiveExclusiveMaximum(currentUpdated);
-
-            if (isDraft4ExclusiveMaximum(currentOriginal)
-                    && Boolean.TRUE.equals(getDraft4ExclusiveMaximum(currentOriginal))) {
-                adjOrig = null;
-            }
-            if (isDraft4ExclusiveMaximum(currentUpdated)
-                    && Boolean.TRUE.equals(getDraft4ExclusiveMaximum(currentUpdated))) {
-                adjUpd = null;
-            }
-            if (adjOrig == null && adjUpd != null && origExclMax != null) {
-                if (toBigDecimal(origExclMax).compareTo(toBigDecimal(adjUpd)) <= 0) {
-                    adjUpd = null;
-                }
-            }
-            if (adjOrig != null && adjUpd == null && updExclMax != null) {
-                if (toBigDecimal(updExclMax).compareTo(toBigDecimal(adjOrig)) <= 0) {
-                    adjOrig = null;
-                }
-            }
+    public boolean diffFullSchemaMaximum(JCRangeValue original, JCRangeValue updated) {
+        if (original == null && updated == null) return false;
+        if (original == null) {
+            ctx.addDifference(NUMBER_TYPE_MAXIMUM_ADDED, null, rangeToString(updated));
+            return false;
         }
-        diffNumber(ctx, adjOrig, adjUpd,
-                NUMBER_TYPE_MAXIMUM_ADDED, NUMBER_TYPE_MAXIMUM_REMOVED,
-                NUMBER_TYPE_MAXIMUM_INCREASED, NUMBER_TYPE_MAXIMUM_DECREASED);
-    }
-
-    @Override
-    public boolean diffFullSchemaExclusiveMinimum(BooleanNumberUnion original, BooleanNumberUnion updated) {
-        var origIsD4 = original != null && original.isBoolean();
-        var updIsD4 = updated != null && updated.isBoolean();
-
-        if (origIsD4 && updIsD4) {
-            diffBooleanTransition(ctx, original.asBoolean(), updated.asBoolean(), false,
-                    NUMBER_TYPE_IS_MINIMUM_EXCLUSIVE_FALSE_TO_TRUE,
-                    NUMBER_TYPE_IS_MINIMUM_EXCLUSIVE_TRUE_TO_FALSE,
-                    NUMBER_TYPE_IS_MINIMUM_EXCLUSIVE_UNCHANGED);
-        } else if (origIsD4 && !updIsD4) {
-            var origIsExcl = original.asBoolean();
-            var origMin = currentOriginal != null ? currentOriginal.getMinimum() : null;
-            Number effectiveOrigExclMin = (Boolean.TRUE.equals(origIsExcl) && origMin != null) ? origMin : null;
-            var updExcl = updated != null && updated.isNumber() ? updated.asNumber() : null;
-            diffNumber(ctx, effectiveOrigExclMin, updExcl,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_DECREASED);
-        } else if (!origIsD4 && updIsD4) {
-            var origExcl = original != null && original.isNumber() ? original.asNumber() : null;
-            var updIsExcl = updated.asBoolean();
-            var updMin = currentUpdated != null ? currentUpdated.getMinimum() : null;
-            Number effectiveUpdExclMin = (Boolean.TRUE.equals(updIsExcl) && updMin != null) ? updMin : null;
-            diffNumber(ctx, origExcl, effectiveUpdExclMin,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_DECREASED);
-        } else {
-            var origExcl = original != null && original.isNumber() ? original.asNumber() : null;
-            var updExcl = updated != null && updated.isNumber() ? updated.asNumber() : null;
-            diffNumber(ctx, origExcl, updExcl,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MINIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_DECREASED);
+        if (updated == null) {
+            ctx.addDifference(NUMBER_TYPE_MAXIMUM_REMOVED, rangeToString(original), null);
+            return false;
         }
-        return true;
-    }
-
-    @Override
-    public boolean diffFullSchemaExclusiveMaximum(BooleanNumberUnion original, BooleanNumberUnion updated) {
-        var origIsD4 = original != null && original.isBoolean();
-        var updIsD4 = updated != null && updated.isBoolean();
-
-        if (origIsD4 && updIsD4) {
-            diffBooleanTransition(ctx, original.asBoolean(), updated.asBoolean(), false,
-                    NUMBER_TYPE_IS_MAXIMUM_EXCLUSIVE_FALSE_TO_TRUE,
-                    NUMBER_TYPE_IS_MAXIMUM_EXCLUSIVE_TRUE_TO_FALSE,
-                    NUMBER_TYPE_IS_MAXIMUM_EXCLUSIVE_UNCHANGED);
-        } else if (origIsD4 && !updIsD4) {
-            var origIsExcl = original.asBoolean();
-            var origMax = currentOriginal != null ? currentOriginal.getMaximum() : null;
-            Number effectiveOrigExclMax = (Boolean.TRUE.equals(origIsExcl) && origMax != null) ? origMax : null;
-            var updExcl = updated != null && updated.isNumber() ? updated.asNumber() : null;
-            diffNumber(ctx, effectiveOrigExclMax, updExcl,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_DECREASED);
-        } else if (!origIsD4 && updIsD4) {
-            var origExcl = original != null && original.isNumber() ? original.asNumber() : null;
-            var updIsExcl = updated.asBoolean();
-            var updMax = currentUpdated != null ? currentUpdated.getMaximum() : null;
-            Number effectiveUpdExclMax = (Boolean.TRUE.equals(updIsExcl) && updMax != null) ? updMax : null;
-            diffNumber(ctx, origExcl, effectiveUpdExclMax,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_DECREASED);
-        } else {
-            var origExcl = original != null && original.isNumber() ? original.asNumber() : null;
-            var updExcl = updated != null && updated.isNumber() ? updated.asNumber() : null;
-            diffNumber(ctx, origExcl, updExcl,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_REMOVED,
-                    NUMBER_TYPE_EXCLUSIVE_MAXIMUM_INCREASED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_DECREASED);
+        // Both present -- compare values
+        Number origVal = original.getValue();
+        Number updVal = updated.getValue();
+        if (origVal != null && updVal != null) {
+            int cmp = toBigDecimal(origVal).compareTo(toBigDecimal(updVal));
+            boolean origExcl = Boolean.TRUE.equals(original.isExclusive());
+            boolean updExcl = Boolean.TRUE.equals(updated.isExclusive());
+            if (cmp > 0 || (cmp == 0 && !origExcl && updExcl)) {
+                // maximum decreased (tightened)
+                ctx.addDifference(NUMBER_TYPE_MAXIMUM_DECREASED,
+                        rangeToString(original), rangeToString(updated));
+            } else if (cmp < 0 || (cmp == 0 && origExcl && !updExcl)) {
+                // maximum increased (relaxed)
+                ctx.addDifference(NUMBER_TYPE_MAXIMUM_INCREASED,
+                        rangeToString(original), rangeToString(updated));
+            }
+            // else: same value and exclusivity -- no diff
         }
-        return true;
+        return false; // don't auto-recurse into RangeValue fields
     }
 
     @Override
@@ -1295,64 +1220,10 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // Helper methods from NumberSchemaDiff
     // -----------------------------------------------------------------------
 
-    private static boolean isDraft4ExclusiveMinimum(JFullSchema schema) {
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMinimum();
-            return u != null && u.isBoolean();
-        }
-        return false;
-    }
-
-    private static boolean isDraft4ExclusiveMaximum(JFullSchema schema) {
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMaximum();
-            return u != null && u.isBoolean();
-        }
-        return false;
-    }
-
-    private static Boolean getDraft4ExclusiveMinimum(JFullSchema schema) {
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMinimum();
-            if (u != null && u.isBoolean()) return u.asBoolean();
-        }
-        return null;
-    }
-
-    private static Boolean getDraft4ExclusiveMaximum(JFullSchema schema) {
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMaximum();
-            if (u != null && u.isBoolean()) return u.asBoolean();
-        }
-        return null;
-    }
-
-    private static Number getEffectiveExclusiveMinimum(JFullSchema schema) {
-        if (isDraft4ExclusiveMinimum(schema)) {
-            if (Boolean.TRUE.equals(getDraft4ExclusiveMinimum(schema))) {
-                return schema.getMinimum();
-            }
-            return null;
-        }
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMinimum();
-            if (u != null && u.isNumber()) return u.asNumber();
-        }
-        return null;
-    }
-
-    private static Number getEffectiveExclusiveMaximum(JFullSchema schema) {
-        if (isDraft4ExclusiveMaximum(schema)) {
-            if (Boolean.TRUE.equals(getDraft4ExclusiveMaximum(schema))) {
-                return schema.getMaximum();
-            }
-            return null;
-        }
-        if (schema instanceof JCFullSchema c) {
-            BooleanNumberUnion u = c.getExclusiveMaximum();
-            if (u != null && u.isNumber()) return u.asNumber();
-        }
-        return null;
+    private static String rangeToString(JCRangeValue range) {
+        if (range == null) return null;
+        String prefix = Boolean.TRUE.equals(range.isExclusive()) ? "exclusive " : "";
+        return prefix + range.getValue();
     }
 
     private static BigDecimal toBigDecimal(Number n) {

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffUtil.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffUtil.java
@@ -4,6 +4,9 @@ import io.apitomy.datamodels.models.Node;
 import io.apitomy.datamodels.models.Referenceable;
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
 import io.apitomy.datamodels.models.jsonschema.JsonSchema;
+import io.apitomy.datamodels.models.ModelType;
+import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.jsonschema.convert.CompoundSchemaConverter;
 import io.apitomy.datamodels.models.union.StringStringListUnion;
 
 import java.math.BigDecimal;
@@ -171,12 +174,47 @@ public final class DiffUtil {
     public static boolean isSchemaCompatible(DiffContext ctx, JFullSchema original, JFullSchema updated,
                                               boolean backward) {
         var subCtx = ctx.isolated();
-        if (backward) {
-            SchemaDiffVisitor.diffSchemas(subCtx, original, updated);
+        // If either schema is compound, convert the other and use the compound traverser.
+        // This is needed because converted schemas may have RangeValue-based min/max
+        // that the old SchemaDiffVisitor cannot access.
+        if (original instanceof JCFullSchema || updated instanceof JCFullSchema) {
+            var origCompound = ensureCompound(original);
+            var updCompound = ensureCompound(updated);
+            if (backward) {
+                CompoundSchemaDiffVisitor.diffSchemas(subCtx, origCompound, updCompound);
+            } else {
+                CompoundSchemaDiffVisitor.diffSchemas(subCtx, updCompound, origCompound);
+            }
         } else {
-            SchemaDiffVisitor.diffSchemas(subCtx, updated, original);
+            if (backward) {
+                SchemaDiffVisitor.diffSchemas(subCtx, original, updated);
+            } else {
+                SchemaDiffVisitor.diffSchemas(subCtx, updated, original);
+            }
         }
         return subCtx.foundAllDifferencesAreCompatible();
+    }
+
+    static JFullSchema ensureCompound(JFullSchema schema) {
+        if (schema instanceof JCFullSchema) return schema;
+        // Use instanceof checks to determine the model type, ignoring root().modelType()
+        // because sub-schemas may have a compound root after top-level conversion
+        // while themselves remaining draft-specific.
+        ModelType modelType = detectModelTypeByInstance(schema);
+        if (modelType != null) {
+            var converted = CompoundSchemaConverter.toCompound((JsonSchema) schema, modelType);
+            if (converted instanceof JFullSchema fs) return fs;
+        }
+        return schema;
+    }
+
+    private static ModelType detectModelTypeByInstance(JFullSchema schema) {
+        if (schema instanceof io.apitomy.datamodels.models.jsonschema.modern.v202012.JM202012FullSchema) return ModelType.JM202012;
+        if (schema instanceof io.apitomy.datamodels.models.jsonschema.modern.v201909.JM201909FullSchema) return ModelType.JM201909;
+        if (schema instanceof io.apitomy.datamodels.models.jsonschema.draft.draft7.JD7FullSchema) return ModelType.JD7;
+        if (schema instanceof io.apitomy.datamodels.models.jsonschema.draft.draft6.JD6FullSchema) return ModelType.JD6;
+        if (schema instanceof io.apitomy.datamodels.models.jsonschema.draft.draft4.JD4FullSchema) return ModelType.JD4;
+        return null;
     }
 
     public static boolean isUnionSchemaCompatible(DiffContext ctx, JsonSchema original,

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/NumberSchemaDiff.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/NumberSchemaDiff.java
@@ -1,6 +1,7 @@
 package io.apitomy.datamodels.jsonschema.compat;
 
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
+import io.apitomy.datamodels.models.jsonschema.draft.JDFullSchema;
 import io.apitomy.datamodels.models.jsonschema.draft.draft4.JD4FullSchema;
 import io.apitomy.datamodels.models.jsonschema.draft.draft6.JD6FullSchema;
 import io.apitomy.datamodels.models.jsonschema.draft.draft7.JD7FullSchema;
@@ -29,8 +30,8 @@ public class NumberSchemaDiff {
         var origExclMax = getEffectiveExclusiveMaximum(original);
         var updExclMax = getEffectiveExclusiveMaximum(updated);
 
-        var origMinimum = original.getMinimum();
-        var updMinimum = updated.getMinimum();
+        var origMinimum = getMinimum(original);
+        var updMinimum = getMinimum(updated);
         if (isDraft4(original) && Boolean.TRUE.equals(getDraft4ExclusiveMinimum(original))) {
             origMinimum = null;
         }
@@ -51,8 +52,8 @@ public class NumberSchemaDiff {
                 NUMBER_TYPE_MINIMUM_ADDED, NUMBER_TYPE_MINIMUM_REMOVED,
                 NUMBER_TYPE_MINIMUM_INCREASED, NUMBER_TYPE_MINIMUM_DECREASED);
 
-        var origMaximum = original.getMaximum();
-        var updMaximum = updated.getMaximum();
+        var origMaximum = getMaximum(original);
+        var updMaximum = getMaximum(updated);
         if (isDraft4(original) && Boolean.TRUE.equals(getDraft4ExclusiveMaximum(original))) {
             origMaximum = null;
         }
@@ -89,7 +90,7 @@ public class NumberSchemaDiff {
                     NUMBER_TYPE_IS_MINIMUM_EXCLUSIVE_UNCHANGED);
         } else if (isDraft4(original) && !isDraft4(updated)) {
             var origIsExcl = getDraft4ExclusiveMinimum(original);
-            var origMin = original.getMinimum();
+            var origMin = getMinimum(original);
             Number effectiveOrigExclMin = (Boolean.TRUE.equals(origIsExcl) && origMin != null) ? origMin : null;
             var updExcl = getExclusiveMinimumAsNumber(updated);
             diffNumber(ctx, effectiveOrigExclMin, updExcl,
@@ -98,7 +99,7 @@ public class NumberSchemaDiff {
         } else if (!isDraft4(original) && isDraft4(updated)) {
             var origExcl = getExclusiveMinimumAsNumber(original);
             var updIsExcl = getDraft4ExclusiveMinimum(updated);
-            var updMin = updated.getMinimum();
+            var updMin = getMinimum(updated);
             Number effectiveUpdExclMin = (Boolean.TRUE.equals(updIsExcl) && updMin != null) ? updMin : null;
             diffNumber(ctx, origExcl, effectiveUpdExclMin,
                     NUMBER_TYPE_EXCLUSIVE_MINIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MINIMUM_REMOVED,
@@ -122,7 +123,7 @@ public class NumberSchemaDiff {
                     NUMBER_TYPE_IS_MAXIMUM_EXCLUSIVE_UNCHANGED);
         } else if (isDraft4(original) && !isDraft4(updated)) {
             var origIsExcl = getDraft4ExclusiveMaximum(original);
-            var origMax = original.getMaximum();
+            var origMax = getMaximum(original);
             Number effectiveOrigExclMax = (Boolean.TRUE.equals(origIsExcl) && origMax != null) ? origMax : null;
             var updExcl = getExclusiveMaximumAsNumber(updated);
             diffNumber(ctx, effectiveOrigExclMax, updExcl,
@@ -131,7 +132,7 @@ public class NumberSchemaDiff {
         } else if (!isDraft4(original) && isDraft4(updated)) {
             var origExcl = getExclusiveMaximumAsNumber(original);
             var updIsExcl = getDraft4ExclusiveMaximum(updated);
-            var updMax = updated.getMaximum();
+            var updMax = getMaximum(updated);
             Number effectiveUpdExclMax = (Boolean.TRUE.equals(updIsExcl) && updMax != null) ? updMax : null;
             diffNumber(ctx, origExcl, effectiveUpdExclMax,
                     NUMBER_TYPE_EXCLUSIVE_MAXIMUM_ADDED, NUMBER_TYPE_EXCLUSIVE_MAXIMUM_REMOVED,
@@ -197,7 +198,7 @@ public class NumberSchemaDiff {
     private static Number getEffectiveExclusiveMinimum(JFullSchema schema) {
         if (isDraft4(schema)) {
             if (Boolean.TRUE.equals(getDraft4ExclusiveMinimum(schema))) {
-                return schema.getMinimum();
+                return getMinimum(schema);
             }
             return null;
         }
@@ -207,11 +208,21 @@ public class NumberSchemaDiff {
     private static Number getEffectiveExclusiveMaximum(JFullSchema schema) {
         if (isDraft4(schema)) {
             if (Boolean.TRUE.equals(getDraft4ExclusiveMaximum(schema))) {
-                return schema.getMaximum();
+                return getMaximum(schema);
             }
             return null;
         }
         return getExclusiveMaximumAsNumber(schema);
+    }
+
+    private static Number getMinimum(JFullSchema schema) {
+        if (schema instanceof JDFullSchema d) return d.getMinimum();
+        return null;
+    }
+
+    private static Number getMaximum(JFullSchema schema) {
+        if (schema instanceof JDFullSchema d) return d.getMaximum();
+        return null;
     }
 
     private static java.math.BigDecimal toBigDecimal(Number n) {

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/SchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/SchemaDiffVisitor.java
@@ -162,8 +162,6 @@ public class SchemaDiffVisitor {
                 || schema.getRequired() != null
                 || schema.getMinLength() != null
                 || schema.getMaxLength() != null
-                || schema.getMinimum() != null
-                || schema.getMaximum() != null
                 || schema.getMinItems() != null
                 || schema.getMaxItems() != null
                 || schema.getMinProperties() != null
@@ -177,7 +175,8 @@ public class SchemaDiffVisitor {
             return false;
         }
         if (schema instanceof JDFullSchema d
-                && (d.getItems() != null || d.getAdditionalItems() != null)) {
+                && (d.getMinimum() != null || d.getMaximum() != null
+                    || d.getItems() != null || d.getAdditionalItems() != null)) {
             return false;
         }
         return true;

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD4ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD4ToCompoundConverter.java
@@ -1,26 +1,52 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft4.visitors.JD4ToJCConversionVisitor;
-import io.apitomy.datamodels.models.union.BooleanUnionValueImpl;
 
 /**
  * Converts Draft 4 schemas to the compound schema type.
- * Handles: exclusiveMinimum/Maximum boolean → boolean|number union.
+ * Handles: exclusiveMinimum/Maximum boolean + minimum/maximum number to RangeValue.
  */
 public class JD4ToCompoundConverter extends JD4ToJCConversionVisitor {
 
     @Override
-    public void convertFullSchemaExclusiveMinimum(Boolean value, JCFullSchema target) {
+    public void convertFullSchemaMinimum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMinimum(new BooleanUnionValueImpl(value));
+            target.setMinimum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaMaximum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMaximum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaExclusiveMinimum(Boolean value, JCFullSchema target) {
+        // In Draft 4, exclusiveMinimum is a boolean that modifies the minimum field.
+        // If true, mark the existing minimum as exclusive.
+        if (Boolean.TRUE.equals(value) && target.getMinimum() != null) {
+            target.getMinimum().setExclusive(true);
         }
     }
 
     @Override
     public void convertFullSchemaExclusiveMaximum(Boolean value, JCFullSchema target) {
-        if (value != null) {
-            target.setExclusiveMaximum(new BooleanUnionValueImpl(value));
+        // In Draft 4, exclusiveMaximum is a boolean that modifies the maximum field.
+        // If true, mark the existing maximum as exclusive.
+        if (Boolean.TRUE.equals(value) && target.getMaximum() != null) {
+            target.getMaximum().setExclusive(true);
         }
+    }
+
+    private static JCRangeValue rangeValue(Number value, boolean exclusive) {
+        JCRangeValueImpl rv = new JCRangeValueImpl();
+        rv.setValue(value);
+        rv.setExclusive(exclusive);
+        return rv;
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD6ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD6ToCompoundConverter.java
@@ -1,26 +1,81 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft6.visitors.JD6ToJCConversionVisitor;
-import io.apitomy.datamodels.models.union.NumberUnionValueImpl;
+
+import java.math.BigDecimal;
 
 /**
  * Converts Draft 6 schemas to the compound schema type.
- * Handles: exclusiveMinimum/Maximum number → boolean|number union.
+ * Handles: minimum/maximum number and exclusiveMinimum/Maximum number to RangeValue.
+ * When both minimum and exclusiveMinimum are present, the tighter constraint wins.
  */
 public class JD6ToCompoundConverter extends JD6ToJCConversionVisitor {
 
     @Override
+    public void convertFullSchemaMinimum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMinimum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaMaximum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMaximum(rangeValue(value, false));
+        }
+    }
+
+    @Override
     public void convertFullSchemaExclusiveMinimum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMinimum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMinimum();
+            if (existing == null || isTighterMinimum(value, true, existing)) {
+                target.setMinimum(rangeValue(value, true));
+            }
         }
     }
 
     @Override
     public void convertFullSchemaExclusiveMaximum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMaximum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMaximum();
+            if (existing == null || isTighterMaximum(value, true, existing)) {
+                target.setMaximum(rangeValue(value, true));
+            }
         }
+    }
+
+    /**
+     * For minimum (lower bound), a higher value is tighter.
+     * At the same value, exclusive is tighter than inclusive.
+     */
+    private static boolean isTighterMinimum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp > 0) return true;
+        if (cmp < 0) return false;
+        // Same value: exclusive is tighter
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    /**
+     * For maximum (upper bound), a lower value is tighter.
+     * At the same value, exclusive is tighter than inclusive.
+     */
+    private static boolean isTighterMaximum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp < 0) return true;
+        if (cmp > 0) return false;
+        // Same value: exclusive is tighter
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static JCRangeValue rangeValue(Number value, boolean exclusive) {
+        JCRangeValueImpl rv = new JCRangeValueImpl();
+        rv.setValue(value);
+        rv.setExclusive(exclusive);
+        return rv;
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD7ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD7ToCompoundConverter.java
@@ -1,26 +1,71 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft7.visitors.JD7ToJCConversionVisitor;
-import io.apitomy.datamodels.models.union.NumberUnionValueImpl;
+
+import java.math.BigDecimal;
 
 /**
  * Converts Draft 7 schemas to the compound schema type.
- * Handles: exclusiveMinimum/Maximum number → boolean|number union.
+ * Handles: minimum/maximum number and exclusiveMinimum/Maximum number to RangeValue.
+ * When both minimum and exclusiveMinimum are present, the tighter constraint wins.
  */
 public class JD7ToCompoundConverter extends JD7ToJCConversionVisitor {
 
     @Override
+    public void convertFullSchemaMinimum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMinimum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaMaximum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMaximum(rangeValue(value, false));
+        }
+    }
+
+    @Override
     public void convertFullSchemaExclusiveMinimum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMinimum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMinimum();
+            if (existing == null || isTighterMinimum(value, true, existing)) {
+                target.setMinimum(rangeValue(value, true));
+            }
         }
     }
 
     @Override
     public void convertFullSchemaExclusiveMaximum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMaximum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMaximum();
+            if (existing == null || isTighterMaximum(value, true, existing)) {
+                target.setMaximum(rangeValue(value, true));
+            }
         }
+    }
+
+    private static boolean isTighterMinimum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp > 0) return true;
+        if (cmp < 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static boolean isTighterMaximum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp < 0) return true;
+        if (cmp > 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static JCRangeValue rangeValue(Number value, boolean exclusive) {
+        JCRangeValueImpl rv = new JCRangeValueImpl();
+        rv.setValue(value);
+        rv.setExclusive(exclusive);
+        return rv;
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JM201909ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JM201909ToCompoundConverter.java
@@ -1,26 +1,71 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.modern.v201909.visitors.JM201909ToJCConversionVisitor;
-import io.apitomy.datamodels.models.union.NumberUnionValueImpl;
+
+import java.math.BigDecimal;
 
 /**
  * Converts 2019-09 schemas to the compound schema type.
- * Handles: exclusiveMinimum/Maximum number → boolean|number union.
+ * Handles: minimum/maximum number and exclusiveMinimum/Maximum number to RangeValue.
+ * When both minimum and exclusiveMinimum are present, the tighter constraint wins.
  */
 public class JM201909ToCompoundConverter extends JM201909ToJCConversionVisitor {
 
     @Override
+    public void convertFullSchemaMinimum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMinimum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaMaximum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMaximum(rangeValue(value, false));
+        }
+    }
+
+    @Override
     public void convertFullSchemaExclusiveMinimum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMinimum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMinimum();
+            if (existing == null || isTighterMinimum(value, true, existing)) {
+                target.setMinimum(rangeValue(value, true));
+            }
         }
     }
 
     @Override
     public void convertFullSchemaExclusiveMaximum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMaximum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMaximum();
+            if (existing == null || isTighterMaximum(value, true, existing)) {
+                target.setMaximum(rangeValue(value, true));
+            }
         }
+    }
+
+    private static boolean isTighterMinimum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp > 0) return true;
+        if (cmp < 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static boolean isTighterMaximum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp < 0) return true;
+        if (cmp > 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static JCRangeValue rangeValue(Number value, boolean exclusive) {
+        JCRangeValueImpl rv = new JCRangeValueImpl();
+        rv.setValue(value);
+        rv.setExclusive(exclusive);
+        return rv;
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JM202012ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JM202012ToCompoundConverter.java
@@ -3,27 +3,50 @@ package io.apitomy.datamodels.jsonschema.convert;
 import io.apitomy.datamodels.models.jsonschema.BooleanFullSchemaFullSchemaListUnion;
 import io.apitomy.datamodels.models.jsonschema.JsonSchema;
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
+import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.modern.v202012.visitors.JM202012ToJCConversionVisitor;
-import io.apitomy.datamodels.models.union.NumberUnionValueImpl;
+
+import java.math.BigDecimal;
 
 /**
  * Converts 2020-12 schemas to the compound schema type.
- * Handles: exclusiveMinimum/Maximum number → boolean|number union,
- *          items JsonSchema → boolean|FullSchema|[FullSchema] union.
+ * Handles: minimum/maximum number and exclusiveMinimum/Maximum number to RangeValue,
+ *          items JsonSchema to boolean|FullSchema|[FullSchema] union.
  */
 public class JM202012ToCompoundConverter extends JM202012ToJCConversionVisitor {
 
     @Override
+    public void convertFullSchemaMinimum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMinimum(rangeValue(value, false));
+        }
+    }
+
+    @Override
+    public void convertFullSchemaMaximum(Number value, JCFullSchema target) {
+        if (value != null) {
+            target.setMaximum(rangeValue(value, false));
+        }
+    }
+
+    @Override
     public void convertFullSchemaExclusiveMinimum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMinimum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMinimum();
+            if (existing == null || isTighterMinimum(value, true, existing)) {
+                target.setMinimum(rangeValue(value, true));
+            }
         }
     }
 
     @Override
     public void convertFullSchemaExclusiveMaximum(Number value, JCFullSchema target) {
         if (value != null) {
-            target.setExclusiveMaximum(new NumberUnionValueImpl(value));
+            JCRangeValue existing = target.getMaximum();
+            if (existing == null || isTighterMaximum(value, true, existing)) {
+                target.setMaximum(rangeValue(value, true));
+            }
         }
     }
 
@@ -32,5 +55,26 @@ public class JM202012ToCompoundConverter extends JM202012ToJCConversionVisitor {
         if (value != null) {
             target.setItems((BooleanFullSchemaFullSchemaListUnion) value);
         }
+    }
+
+    private static boolean isTighterMinimum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp > 0) return true;
+        if (cmp < 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static boolean isTighterMaximum(Number newValue, boolean newExclusive, JCRangeValue existing) {
+        int cmp = new BigDecimal(newValue.toString()).compareTo(new BigDecimal(existing.getValue().toString()));
+        if (cmp < 0) return true;
+        if (cmp > 0) return false;
+        return newExclusive && !Boolean.TRUE.equals(existing.isExclusive());
+    }
+
+    private static JCRangeValue rangeValue(Number value, boolean exclusive) {
+        JCRangeValueImpl rv = new JCRangeValueImpl();
+        rv.setValue(value);
+        rv.setExclusive(exclusive);
+        return rv;
     }
 }

--- a/data-models/src/main/resources/specs/json-schema/json-schema-compound.yaml
+++ b/data-models/src/main/resources/specs/json-schema/json-schema-compound.yaml
@@ -29,6 +29,15 @@ root:
   type: JsonSchema
 
 entities:
+  - name: RangeValue
+    properties:
+      - name: value
+        type: number
+      - name: exclusive
+        type: boolean
+    propertyOrder:
+      - $this
+
   - name: FullSchema
     traits:
       - Referenceable
@@ -123,16 +132,14 @@ entities:
       # --- Numeric validation ---
       - name: multipleOf
         type: number
+      # minimum/maximum normalized to RangeValue during conversion.
+      # Combines value + exclusivity into a single field.
+      # d4's boolean exclusiveMinimum + minimum → single RangeValue.
+      # d6+ minimum/exclusiveMinimum → tighter bound as RangeValue.
       - name: minimum
-        type: number
+        type: RangeValue
       - name: maximum
-        type: number
-      # exclusiveMinimum/Maximum use the widest type (boolean in d4, number in d6+)
-      # Converters map d4 boolean to the compound union type
-      - name: exclusiveMinimum
-        type: 'boolean|number'
-      - name: exclusiveMaximum
-        type: 'boolean|number'
+        type: RangeValue
 
       # --- String validation ---
       - name: minLength

--- a/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/convert/conversion-test-data.json
+++ b/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/convert/conversion-test-data.json
@@ -8,8 +8,7 @@
         "minimum": 5
       },
       "expected": {
-        "exclusiveMinimum": true,
-        "minimum": 5
+        "minimum": { "value": 5, "exclusive": true }
       }
     },
     {
@@ -20,8 +19,7 @@
         "minimum": 5
       },
       "expected": {
-        "exclusiveMinimum": false,
-        "minimum": 5
+        "minimum": { "value": 5, "exclusive": false }
       }
     },
     {
@@ -32,8 +30,7 @@
         "maximum": 100
       },
       "expected": {
-        "exclusiveMaximum": true,
-        "maximum": 100
+        "maximum": { "value": 100, "exclusive": true }
       }
     },
     {
@@ -43,7 +40,7 @@
         "exclusiveMinimum": 5
       },
       "expected": {
-        "exclusiveMinimum": 5
+        "minimum": { "value": 5, "exclusive": true }
       }
     },
     {
@@ -53,7 +50,7 @@
         "exclusiveMaximum": 100
       },
       "expected": {
-        "exclusiveMaximum": 100
+        "maximum": { "value": 100, "exclusive": true }
       }
     },
     {
@@ -138,7 +135,7 @@
         "type": "object",
         "properties": {
           "name": { "type": "string", "minLength": 1 },
-          "age": { "type": "integer", "minimum": 0 }
+          "age": { "type": "integer", "minimum": { "value": 0, "exclusive": false } }
         },
         "required": ["name"],
         "additionalProperties": false


### PR DESCRIPTION
## Summary

New `RangeValue` entity in compound schema: `{value: number, exclusive: boolean}`.
Combines the bound value and exclusivity into a single comparable unit.

### Converters
- **d4**: `minimum: 10, exclusiveMinimum: true` → `minimum: RangeValue(10, true)`
- **d6+**: picks tighter of `minimum`/`exclusiveMinimum` → single `RangeValue`

### CompoundSchemaDiffVisitor
- `diffFullSchemaMinimum(JCRangeValue, JCRangeValue)` compares value + exclusivity together
- Accounts for exclusivity in tightness: exclusive 10 is tighter than inclusive 10
- **Removed**: 4-case boolean/number dispatch, all isDraft4/getDraft4/getEffective helpers
- Old: ~70 lines per exclusive field. New: ~20 lines.

## Context
C41g in #1042.

## Test plan
- [x] All 1133 data-models tests pass
- [x] All 6 exclusiveMin/Max CC tests pass (were failing with naive approach)
- [x] Conversion tests updated for RangeValue output format