### PR TITLE
feat: builder API for compatibility checker + result types (C41k/C42a)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompatibilityCheckResult.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompatibilityCheckResult.java
@@ -1,0 +1,80 @@
+package io.apitomy.datamodels.jsonschema.compat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Result of a single-direction compatibility check (backward or forward).
+ * <p>
+ * Wraps the internal {@link DiffContext} into a clean, immutable public API.
+ * Instances are created by {@link JsonSchemaCompatibilityChecker} and are not
+ * directly constructible by callers.
+ */
+public final class CompatibilityCheckResult {
+
+    private final Set<Difference> differences;
+    private final List<String> unsupportedFeatures;
+
+    /**
+     * Package-private constructor — created by the checker.
+     */
+    CompatibilityCheckResult(DiffContext ctx) {
+        this.differences = ctx.getDiffs();
+        this.unsupportedFeatures = ctx.getUnsupportedFeatures();
+    }
+
+    /**
+     * Returns {@code true} if all differences found are compatible in the
+     * checked direction (i.e. there are no incompatible differences).
+     *
+     * @return {@code true} when there are no incompatible differences
+     */
+    public boolean isCompatible() {
+        return differences.stream()
+                .noneMatch(d -> !d.getDiffType().isBackwardsCompatible());
+    }
+
+    /**
+     * Returns all differences found between the original and updated schemas,
+     * regardless of whether they are compatible or incompatible.
+     *
+     * @return an unmodifiable set of all differences
+     */
+    public Set<Difference> getDifferences() {
+        return Set.copyOf(differences);
+    }
+
+    /**
+     * Returns only the incompatible differences — those that would break
+     * consumers in the checked direction.
+     *
+     * @return an unmodifiable set of incompatible differences
+     */
+    public Set<Difference> getIncompatibleDifferences() {
+        return differences.stream()
+                .filter(d -> !d.getDiffType().isBackwardsCompatible())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Returns {@code true} if any schema features were flagged as unsupported
+     * during the comparison (e.g. modern JSON Schema versions whose keywords
+     * are not yet fully handled by the diff engine).
+     *
+     * @return {@code true} when unsupported features were encountered
+     */
+    public boolean hasUnsupportedFeatures() {
+        return !unsupportedFeatures.isEmpty();
+    }
+
+    /**
+     * Returns the list of unsupported-feature messages collected during
+     * the comparison.
+     *
+     * @return an unmodifiable list of unsupported-feature descriptions
+     */
+    public List<String> getUnsupportedFeatures() {
+        return List.copyOf(unsupportedFeatures);
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/FullCompatibilityCheckResult.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/FullCompatibilityCheckResult.java
@@ -1,0 +1,73 @@
+package io.apitomy.datamodels.jsonschema.compat;
+
+/**
+ * Result of a full (bidirectional) compatibility check, combining the results
+ * of both a backward and a forward compatibility check.
+ * <p>
+ * Instances are created by {@link JsonSchemaCompatibilityChecker#checkFull}
+ * and are not directly constructible by callers.
+ */
+public final class FullCompatibilityCheckResult {
+
+    private final CompatibilityCheckResult backward;
+    private final CompatibilityCheckResult forward;
+
+    /**
+     * Package-private constructor — created by the checker.
+     */
+    FullCompatibilityCheckResult(CompatibilityCheckResult backward,
+                                 CompatibilityCheckResult forward) {
+        this.backward = backward;
+        this.forward = forward;
+    }
+
+    /**
+     * Returns {@code true} if the schemas are both backward and forward
+     * compatible (i.e. fully compatible in both directions).
+     *
+     * @return {@code true} when the schemas are fully compatible
+     */
+    public boolean isFullyCompatible() {
+        return backward.isCompatible() && forward.isCompatible();
+    }
+
+    /**
+     * Returns {@code true} if the updated schema is backward compatible
+     * with the original (data written with the original can be read with
+     * the updated).
+     *
+     * @return {@code true} when backward compatible
+     */
+    public boolean isBackwardCompatible() {
+        return backward.isCompatible();
+    }
+
+    /**
+     * Returns {@code true} if the updated schema is forward compatible
+     * with the original (data written with the updated can be read with
+     * the original).
+     *
+     * @return {@code true} when forward compatible
+     */
+    public boolean isForwardCompatible() {
+        return forward.isCompatible();
+    }
+
+    /**
+     * Returns the detailed backward compatibility check result.
+     *
+     * @return the backward compatibility result
+     */
+    public CompatibilityCheckResult getBackwardResult() {
+        return backward;
+    }
+
+    /**
+     * Returns the detailed forward compatibility check result.
+     *
+     * @return the forward compatibility result
+     */
+    public CompatibilityCheckResult getForwardResult() {
+        return forward;
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityChecker.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityChecker.java
@@ -3,50 +3,110 @@ package io.apitomy.datamodels.jsonschema.compat;
 import io.apitomy.datamodels.Library;
 import io.apitomy.datamodels.jsonschema.convert.CompoundSchemaConverter;
 import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefResolver;
-import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefResolverChain;
 import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefTraversal;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
 import io.apitomy.datamodels.models.jsonschema.JsonSchema;
-import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
-import io.apitomy.datamodels.models.jsonschema.compound.visitors.JCDiffTraverser;
-
-import java.util.Set;
 
 /**
- * Entry point for JSON Schema backward compatibility checking.
+ * Entry point for JSON Schema compatibility checking.
  * <p>
  * Schemas are first converted to a compound schema type that merges all
  * draft-version properties, then compared using the diff visitor infrastructure.
+ * <p>
+ * Use the {@link #builder()} method to create and configure an instance:
+ * <pre>{@code
+ * var checker = JsonSchemaCompatibilityChecker.builder()
+ *     .allowCrossVersionChecking(true)
+ *     .build();
+ *
+ * CompatibilityCheckResult result = checker.checkBackward(original, updated);
+ * if (!result.isCompatible()) {
+ *     result.getIncompatibleDifferences().forEach(System.out::println);
+ * }
+ * }</pre>
+ * <p>
+ * Instances are immutable and safe to reuse across multiple checks.
  * <p>
  * <b>Note:</b> This API is experimental and subject to change in future versions.
  */
 public final class JsonSchemaCompatibilityChecker {
 
-    private boolean allowCrossVersionChecking = false;
+    private final boolean allowCrossVersionChecking;
+    private final JsonSchemaRefResolver refResolver;
 
-    public JsonSchemaCompatibilityChecker() {
-    }
-
-    public JsonSchemaCompatibilityChecker allowCrossVersionChecking(boolean allow) {
-        this.allowCrossVersionChecking = allow;
-        return this;
+    /**
+     * Package-private constructor — use {@link #builder()} to create instances.
+     */
+    JsonSchemaCompatibilityChecker(boolean allowCrossVersionChecking,
+                                   JsonSchemaRefResolver refResolver) {
+        this.allowCrossVersionChecking = allowCrossVersionChecking;
+        this.refResolver = refResolver;
     }
 
     /**
-     * Check if the updated schema is backward compatible with the original.
+     * Returns a new builder for configuring a {@link JsonSchemaCompatibilityChecker}.
+     *
+     * @return a new builder instance
      */
-    public DiffContext check(String originalSchemaJson, String updatedSchemaJson) {
-        return check(originalSchemaJson, updatedSchemaJson,
-                JsonSchemaRefResolverChain.withDefaults());
+    public static JsonSchemaCompatibilityCheckerBuilder builder() {
+        return new JsonSchemaCompatibilityCheckerBuilder();
     }
 
     /**
-     * Check backward compatibility using a custom reference resolver.
+     * Check backward compatibility: data written with the original schema can
+     * be read by a consumer using the updated schema.
+     *
+     * @param originalJson the original JSON Schema document as a JSON string
+     * @param updatedJson  the updated JSON Schema document as a JSON string
+     * @return the result of the backward compatibility check
+     * @throws IllegalArgumentException if the input is not a valid JSON Schema,
+     *         or if cross-version checking is disabled and the schemas use different draft versions
      */
-    public DiffContext check(String originalSchemaJson, String updatedSchemaJson,
-                              JsonSchemaRefResolver resolver) {
-        java.util.Objects.requireNonNull(resolver, "resolver must not be null");
+    public CompatibilityCheckResult checkBackward(String originalJson, String updatedJson) {
+        return new CompatibilityCheckResult(doCheck(originalJson, updatedJson));
+    }
+
+    /**
+     * Check forward compatibility: data written with the updated schema can
+     * be read by a consumer using the original schema.
+     * <p>
+     * This is equivalent to checking backward compatibility with the arguments swapped.
+     *
+     * @param originalJson the original JSON Schema document as a JSON string
+     * @param updatedJson  the updated JSON Schema document as a JSON string
+     * @return the result of the forward compatibility check
+     * @throws IllegalArgumentException if the input is not a valid JSON Schema,
+     *         or if cross-version checking is disabled and the schemas use different draft versions
+     */
+    public CompatibilityCheckResult checkForward(String originalJson, String updatedJson) {
+        return new CompatibilityCheckResult(doCheck(updatedJson, originalJson));
+    }
+
+    /**
+     * Check full compatibility (both backward and forward).
+     * <p>
+     * This performs both a backward and a forward compatibility check and
+     * combines the results into a {@link FullCompatibilityCheckResult}.
+     *
+     * @param originalJson the original JSON Schema document as a JSON string
+     * @param updatedJson  the updated JSON Schema document as a JSON string
+     * @return the combined result of both compatibility checks
+     * @throws IllegalArgumentException if the input is not a valid JSON Schema,
+     *         or if cross-version checking is disabled and the schemas use different draft versions
+     */
+    public FullCompatibilityCheckResult checkFull(String originalJson, String updatedJson) {
+        var backward = checkBackward(originalJson, updatedJson);
+        var forward = checkForward(originalJson, updatedJson);
+        return new FullCompatibilityCheckResult(backward, forward);
+    }
+
+    // --- Internal ---
+
+    /**
+     * Core check logic: parse, validate versions, convert to compound, diff.
+     */
+    private DiffContext doCheck(String originalSchemaJson, String updatedSchemaJson) {
         var originalParsed = parseSchema(originalSchemaJson);
         var updatedParsed = parseSchema(updatedSchemaJson);
 
@@ -64,7 +124,7 @@ public final class JsonSchemaCompatibilityChecker {
         var originalCompound = toCompoundFullSchema(originalParsed, originalModelType);
         var updatedCompound = toCompoundFullSchema(updatedParsed, updatedModelType);
 
-        var refTraversal = new JsonSchemaRefTraversal(resolver);
+        var refTraversal = new JsonSchemaRefTraversal(refResolver);
         var ctx = DiffContext.createRootContext("", null, refTraversal);
 
         // TODO: Modern version support — flag for now, remove when diff classes handle all keywords
@@ -74,91 +134,6 @@ public final class JsonSchemaCompatibilityChecker {
         CompoundSchemaDiffVisitor.diffSchemas(ctx, originalCompound, updatedCompound);
         return ctx;
     }
-
-    /**
-     * Check backward compatibility using the compound traverser (visitor-driven approach).
-     * <p>
-     * This uses {@link CompoundSchemaDiffVisitor} with {@link JCDiffTraverser} instead of
-     * the old type-dispatching approach (SchemaDiffVisitor + ObjectSchemaDiff/ArraySchemaDiff/etc.).
-     */
-    public DiffContext checkWithCompoundTraverser(String originalSchemaJson, String updatedSchemaJson) {
-        return checkWithCompoundTraverser(originalSchemaJson, updatedSchemaJson,
-                JsonSchemaRefResolverChain.withDefaults());
-    }
-
-    /**
-     * Check backward compatibility using a custom reference resolver and the compound traverser.
-     */
-    public DiffContext checkWithCompoundTraverser(String originalSchemaJson, String updatedSchemaJson,
-                                                  JsonSchemaRefResolver resolver) {
-        java.util.Objects.requireNonNull(resolver, "resolver must not be null");
-        var originalParsed = parseSchema(originalSchemaJson);
-        var updatedParsed = parseSchema(updatedSchemaJson);
-
-        var originalModelType = originalParsed.root().modelType();
-        var updatedModelType = updatedParsed.root().modelType();
-
-        if (!allowCrossVersionChecking && originalModelType != updatedModelType) {
-            throw new IllegalArgumentException(
-                    "Cross-version checking is not enabled. Original: " + originalModelType
-                    + ", Updated: " + updatedModelType
-                    + ". Use allowCrossVersionChecking(true) to enable.");
-        }
-
-        // Convert both schemas to compound type
-        var originalCompound = toCompoundFullSchema(originalParsed, originalModelType);
-        var updatedCompound = toCompoundFullSchema(updatedParsed, updatedModelType);
-
-        var refTraversal = new JsonSchemaRefTraversal(resolver);
-        var ctx = DiffContext.createRootContext("", null, refTraversal);
-
-        flagModernVersions(ctx, originalModelType);
-        flagModernVersions(ctx, updatedModelType);
-
-        var visitor = new CompoundSchemaDiffVisitor(ctx);
-        var traverser = new JCDiffTraverser<>(visitor);
-        traverser.traverseFullSchema((JCFullSchema) originalCompound, (JCFullSchema) updatedCompound);
-        return ctx;
-    }
-
-    // --- Static convenience methods (backward-compatible API) ---
-
-    // --- Static convenience methods (delegate to instance) ---
-
-    public static DiffContext checkBackwardCompatibility(String originalSchemaJson, String updatedSchemaJson) {
-        return new JsonSchemaCompatibilityChecker()
-                .allowCrossVersionChecking(true)
-                .check(originalSchemaJson, updatedSchemaJson);
-    }
-
-    public static DiffContext checkBackwardCompatibility(String originalSchemaJson, String updatedSchemaJson,
-                                                          JsonSchemaRefResolver resolver) {
-        return new JsonSchemaCompatibilityChecker()
-                .allowCrossVersionChecking(true)
-                .check(originalSchemaJson, updatedSchemaJson, resolver);
-    }
-
-    public static boolean isBackwardCompatible(String originalSchemaJson, String updatedSchemaJson) {
-        return checkBackwardCompatibility(originalSchemaJson, updatedSchemaJson)
-                .foundAllDifferencesAreCompatible();
-    }
-
-    public static Set<Difference> getIncompatibleDifferences(String originalSchemaJson,
-                                                              String updatedSchemaJson) {
-        return checkBackwardCompatibility(originalSchemaJson, updatedSchemaJson)
-                .getIncompatibleDifferences();
-    }
-
-    public static boolean isForwardCompatible(String originalSchemaJson, String updatedSchemaJson) {
-        return isBackwardCompatible(updatedSchemaJson, originalSchemaJson);
-    }
-
-    public static boolean isFullyCompatible(String originalSchemaJson, String updatedSchemaJson) {
-        return isBackwardCompatible(originalSchemaJson, updatedSchemaJson)
-                && isForwardCompatible(originalSchemaJson, updatedSchemaJson);
-    }
-
-    // --- Internal ---
 
     private static JFullSchema toCompoundFullSchema(JFullSchema doc, ModelType modelType) {
         // Convert to compound schema
@@ -183,4 +158,5 @@ public final class JsonSchemaCompatibilityChecker {
         }
         return jsonSchemaDoc;
     }
+
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityCheckerBuilder.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityCheckerBuilder.java
@@ -1,0 +1,69 @@
+package io.apitomy.datamodels.jsonschema.compat;
+
+import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefResolver;
+import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefResolverChain;
+
+/**
+ * Builder for {@link JsonSchemaCompatibilityChecker}.
+ * <p>
+ * Configure the checker and call {@link #build()} to create an immutable instance.
+ *
+ * <pre>{@code
+ * var checker = JsonSchemaCompatibilityChecker.builder()
+ *     .allowCrossVersionChecking(true)
+ *     .refResolver(myResolver)
+ *     .build();
+ * }</pre>
+ */
+public final class JsonSchemaCompatibilityCheckerBuilder {
+
+    private boolean allowCrossVersionChecking = false;
+    private JsonSchemaRefResolver refResolver = null;
+
+    JsonSchemaCompatibilityCheckerBuilder() {
+    }
+
+    /**
+     * Allow comparing schemas from different JSON Schema draft versions.
+     * <p>
+     * When disabled (the default), comparing a draft-4 schema with a draft-7
+     * schema throws {@link IllegalArgumentException}. Enable this to permit
+     * cross-version comparisons.
+     *
+     * @param allow {@code true} to allow cross-version checking
+     * @return this builder
+     */
+    public JsonSchemaCompatibilityCheckerBuilder allowCrossVersionChecking(boolean allow) {
+        this.allowCrossVersionChecking = allow;
+        return this;
+    }
+
+    /**
+     * Set a custom reference resolver for resolving {@code $ref} values
+     * during comparison.
+     * <p>
+     * Defaults to {@link JsonSchemaRefResolverChain#withDefaults()} which handles
+     * JSON Pointer and anchor-based internal references.
+     *
+     * @param resolver the reference resolver to use; must not be {@code null}
+     * @return this builder
+     * @throws NullPointerException if {@code resolver} is {@code null}
+     */
+    public JsonSchemaCompatibilityCheckerBuilder refResolver(JsonSchemaRefResolver resolver) {
+        java.util.Objects.requireNonNull(resolver, "resolver must not be null");
+        this.refResolver = resolver;
+        return this;
+    }
+
+    /**
+     * Builds an immutable {@link JsonSchemaCompatibilityChecker} with the
+     * configured settings.
+     *
+     * @return a new checker instance
+     */
+    public JsonSchemaCompatibilityChecker build() {
+        return new JsonSchemaCompatibilityChecker(
+                allowCrossVersionChecking,
+                refResolver != null ? refResolver : JsonSchemaRefResolverChain.withDefaults());
+    }
+}

--- a/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityTest.java
@@ -14,6 +14,11 @@ public class JsonSchemaCompatibilityTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private static final JsonSchemaCompatibilityChecker CHECKER =
+            JsonSchemaCompatibilityChecker.builder()
+                    .allowCrossVersionChecking(true)
+                    .build();
+
     @Test
     public void testCompatibilityTestData() throws Exception {
         var testData = readResource("compatibility-test-data.json");
@@ -45,13 +50,11 @@ public class JsonSchemaCompatibilityTest {
             }
 
             try {
-                var backwardResult = JsonSchemaCompatibilityChecker
-                        .checkBackwardCompatibility(original, updated);
-                var forwardResult = JsonSchemaCompatibilityChecker
-                        .checkBackwardCompatibility(updated, original);
+                var backwardResult = CHECKER.checkBackward(original, updated);
+                var forwardResult = CHECKER.checkForward(original, updated);
 
-                var backwardOk = backwardResult.foundAllDifferencesAreCompatible();
-                var forwardOk = forwardResult.foundAllDifferencesAreCompatible();
+                var backwardOk = backwardResult.isCompatible();
+                var forwardOk = forwardResult.isCompatible();
 
                 var success = switch (expectedCompat) {
                     case "backward" -> backwardOk && !forwardOk;
@@ -94,7 +97,7 @@ public class JsonSchemaCompatibilityTest {
     public void testSimpleBackwardCompatible() {
         var original = "{%s, \"type\": \"string\", \"minLength\": 10}".formatted(D7);
         var updated = "{%s, \"type\": \"string\", \"minLength\": 5}".formatted(D7);
-        Assertions.assertTrue(JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated));
+        Assertions.assertTrue(CHECKER.checkBackward(original, updated).isCompatible());
     }
 
     @Test
@@ -122,14 +125,14 @@ public class JsonSchemaCompatibilityTest {
     public void testSimpleBackwardIncompatible() {
         var original = "{%s, \"type\": \"string\", \"minLength\": 5}".formatted(D7);
         var updated = "{%s, \"type\": \"string\", \"minLength\": 10}".formatted(D7);
-        Assertions.assertFalse(JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated));
+        Assertions.assertFalse(CHECKER.checkBackward(original, updated).isCompatible());
     }
 
     @Test
     public void testTypeChange() {
         var original = "{%s, \"type\": \"string\"}".formatted(D7);
         var updated = "{%s, \"type\": \"number\"}".formatted(D7);
-        Assertions.assertFalse(JsonSchemaCompatibilityChecker.isBackwardCompatible(original, updated));
+        Assertions.assertFalse(CHECKER.checkBackward(original, updated).isCompatible());
     }
 
     @Test
@@ -140,7 +143,7 @@ public class JsonSchemaCompatibilityTest {
         var updated = """
                 {%s, "type": "object", "properties": {"name": {"type": "string"}}}
                 """.formatted(D7);
-        Assertions.assertTrue(JsonSchemaCompatibilityChecker.isFullyCompatible(original, updated));
+        Assertions.assertTrue(CHECKER.checkFull(original, updated).isFullyCompatible());
     }
 
     // ======================== Compound traverser tests ========================
@@ -176,13 +179,11 @@ public class JsonSchemaCompatibilityTest {
             }
 
             try {
-                var checker = new JsonSchemaCompatibilityChecker()
-                        .allowCrossVersionChecking(true);
-                var backwardResult = checker.checkWithCompoundTraverser(original, updated);
-                var forwardResult = checker.checkWithCompoundTraverser(updated, original);
+                var backwardResult = CHECKER.checkBackward(original, updated);
+                var forwardResult = CHECKER.checkForward(original, updated);
 
-                var backwardOk = backwardResult.foundAllDifferencesAreCompatible();
-                var forwardOk = forwardResult.foundAllDifferencesAreCompatible();
+                var backwardOk = backwardResult.isCompatible();
+                var forwardOk = forwardResult.isCompatible();
 
                 var success = switch (expectedCompat) {
                     case "backward" -> backwardOk && !forwardOk;
@@ -223,20 +224,18 @@ public class JsonSchemaCompatibilityTest {
     public void testCompoundTraverserSimpleBackwardCompatible() {
         var original = "{%s, \"type\": \"string\", \"minLength\": 10}".formatted(D7);
         var updated = "{%s, \"type\": \"string\", \"minLength\": 5}".formatted(D7);
-        var checker = new JsonSchemaCompatibilityChecker().allowCrossVersionChecking(true);
-        var result = checker.checkWithCompoundTraverser(original, updated);
-        Assertions.assertTrue(result.foundAllDifferencesAreCompatible(),
-                "minLength decrease should be backward compatible. Diffs: " + result.getDiffs());
+        var result = CHECKER.checkBackward(original, updated);
+        Assertions.assertTrue(result.isCompatible(),
+                "minLength decrease should be backward compatible. Diffs: " + result.getDifferences());
     }
 
     @Test
     public void testCompoundTraverserSimpleBackwardIncompatible() {
         var original = "{%s, \"type\": \"string\", \"minLength\": 5}".formatted(D7);
         var updated = "{%s, \"type\": \"string\", \"minLength\": 10}".formatted(D7);
-        var checker = new JsonSchemaCompatibilityChecker().allowCrossVersionChecking(true);
-        var result = checker.checkWithCompoundTraverser(original, updated);
-        Assertions.assertFalse(result.foundAllDifferencesAreCompatible(),
-                "minLength increase should be backward incompatible. Diffs: " + result.getDiffs());
+        var result = CHECKER.checkBackward(original, updated);
+        Assertions.assertFalse(result.isCompatible(),
+                "minLength increase should be backward incompatible. Diffs: " + result.getDifferences());
     }
 
     private static String nodeToSchemaString(JsonNode node) {


### PR DESCRIPTION
## Summary

Redesigned `JsonSchemaCompatibilityChecker` with builder pattern:

```java
var checker = JsonSchemaCompatibilityChecker.builder()
    .allowCrossVersionChecking(true)
    .refResolver(myResolver)
    .build();

var result = checker.checkBackward(original, updated);
result.isCompatible();
result.getIncompatibleDifferences();

var full = checker.checkFull(original, updated);
full.isFullyCompatible();
```

### New classes
- `CompatibilityCheckResult` — wraps DiffContext into clean public API
- `FullCompatibilityCheckResult` — combines backward + forward results

### API changes
- Private constructor, `builder()` required
- Three check methods: `checkBackward()`, `checkForward()`, `checkFull()`
- Instances are immutable and reusable
- Removed: all static convenience methods, public constructor, transitional APIs

## Context
C41k + C42a (partial) in #1042.

## Test plan
- [x] All 1133 data-models tests pass
- [x] Tests updated to use builder + new result types