### PR TITLE
Fix validation rules silently skipping OpenAPI 3.2 documents (#1161)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/reference/OasInvalidSecurityRequirementNameRule.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/reference/OasInvalidSecurityRequirementNameRule.java
@@ -22,6 +22,7 @@ import io.apitomy.datamodels.models.SecurityRequirement;
 import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20Document;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
 import io.apitomy.datamodels.models.openapi.v3x.v31.OpenApi31Document;
+import io.apitomy.datamodels.models.openapi.v3x.v32.OpenApi32Document;
 import io.apitomy.datamodels.validation.ValidationRule;
 import io.apitomy.datamodels.validation.ValidationRuleMetaData;
 
@@ -63,6 +64,12 @@ public class OasInvalidSecurityRequirementNameRule extends ValidationRule {
                     isDefined(doc31.getComponents()) &&
                     hasValue(doc31.getComponents().getSecuritySchemes()) &&
                     isDefined(doc31.getComponents().getSecuritySchemes().get(securityReqName));
+        } else if (dt == ModelType.OPENAPI32) {
+            OpenApi32Document doc32 = (OpenApi32Document) doc;
+            return hasValue(doc32.getComponents()) &&
+                    isDefined(doc32.getComponents()) &&
+                    hasValue(doc32.getComponents().getSecuritySchemes()) &&
+                    isDefined(doc32.getComponents().getSecuritySchemes().get(securityReqName));
         } else if (dt == ModelType.ASYNCAPI20 || dt == ModelType.ASYNCAPI21 || dt == ModelType.ASYNCAPI22 || dt == ModelType.ASYNCAPI23 || dt == ModelType.ASYNCAPI24 || dt == ModelType.ASYNCAPI25 || dt == ModelType.ASYNCAPI26) {
             // TODO implement this
         }

--- a/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasInvalidHeaderStyleRule.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasInvalidHeaderStyleRule.java
@@ -19,6 +19,7 @@ package io.apitomy.datamodels.validation.rules.invalid.value;
 import io.apitomy.datamodels.models.openapi.OpenApiHeader;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Header;
 import io.apitomy.datamodels.models.openapi.v3x.v31.OpenApi31Header;
+import io.apitomy.datamodels.models.openapi.v3x.v32.OpenApi32Header;
 import io.apitomy.datamodels.util.ModelTypeUtil;
 import io.apitomy.datamodels.validation.ValidationRuleMetaData;
 
@@ -45,6 +46,8 @@ public class OasInvalidHeaderStyleRule extends AbstractInvalidPropertyValueRule 
             style = ((OpenApi30Header) node).getStyle();
         } else if (ModelTypeUtil.isOpenApi31Model(node)) {
             style = ((OpenApi31Header) node).getStyle();
+        } else if (ModelTypeUtil.isOpenApi32Model(node)) {
+            style = ((OpenApi32Header) node).getStyle();
         }
 
         if (hasValue(style)) {

--- a/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasSecurityRequirementScopesMustBeEmptyRule.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasSecurityRequirementScopesMustBeEmptyRule.java
@@ -19,13 +19,14 @@ package io.apitomy.datamodels.validation.rules.invalid.value;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.SecurityRequirement;
 import io.apitomy.datamodels.models.SecurityScheme;
 import io.apitomy.datamodels.models.openapi.OpenApiDocument;
 import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20Document;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Document;
 import io.apitomy.datamodels.models.openapi.v3x.v31.OpenApi31Document;
+import io.apitomy.datamodels.models.openapi.v3x.v32.OpenApi32Document;
+import io.apitomy.datamodels.util.ModelTypeUtil;
 import io.apitomy.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -43,20 +44,25 @@ public class OasSecurityRequirementScopesMustBeEmptyRule extends AbstractInvalid
     }
 
     private SecurityScheme findSecurityScheme(OpenApiDocument document, String schemeName) {
-        if (document.root().modelType() == ModelType.OPENAPI20) {
+        if (ModelTypeUtil.isOpenApi2Model(document)) {
             OpenApi20Document doc20 = (OpenApi20Document) document;
             if (hasValue(doc20.getSecurityDefinitions())) {
                 return doc20.getSecurityDefinitions().getItem(schemeName);
             }
-        } else if (document.root().modelType() == ModelType.OPENAPI30) {
+        } else if (ModelTypeUtil.isOpenApi30Model(document)) {
             OpenApi30Document doc30 = (OpenApi30Document) document;
             if (hasValue(doc30.getComponents()) && hasValue(doc30.getComponents().getSecuritySchemes())) {
                 return doc30.getComponents().getSecuritySchemes().get(schemeName);
             }
-        } else if (document.root().modelType() == ModelType.OPENAPI31) {
+        } else if (ModelTypeUtil.isOpenApi31Model(document)) {
             OpenApi31Document doc31 = (OpenApi31Document) document;
             if (hasValue(doc31.getComponents()) && hasValue(doc31.getComponents().getSecuritySchemes())) {
                 return doc31.getComponents().getSecuritySchemes().get(schemeName);
+            }
+        } else if (ModelTypeUtil.isOpenApi32Model(document)) {
+            OpenApi32Document doc32 = (OpenApi32Document) document;
+            if (hasValue(doc32.getComponents()) && hasValue(doc32.getComponents().getSecuritySchemes())) {
+                return doc32.getComponents().getSecuritySchemes().get(schemeName);
             }
         }
 
@@ -68,7 +74,7 @@ public class OasSecurityRequirementScopesMustBeEmptyRule extends AbstractInvalid
         List<String> allowedTypes = new ArrayList<>();
         allowedTypes.add("oauth2");
         String options = "\"oauth2\"";
-        if (node.root().modelType() == ModelType.OPENAPI30 || node.root().modelType() == ModelType.OPENAPI31) {
+        if (ModelTypeUtil.isOpenApi3Model(node)) {
             allowedTypes.add("openIdConnect");
             options = "\"oauth2\" or \"openIdConnect\"";
         }

--- a/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasUnexpectedUsageOfBearerTokenRule.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasUnexpectedUsageOfBearerTokenRule.java
@@ -16,10 +16,11 @@
 
 package io.apitomy.datamodels.validation.rules.invalid.value;
 
-import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.SecurityScheme;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30SecurityScheme;
 import io.apitomy.datamodels.models.openapi.v3x.v31.OpenApi31SecurityScheme;
+import io.apitomy.datamodels.models.openapi.v3x.v32.OpenApi32SecurityScheme;
+import io.apitomy.datamodels.util.ModelTypeUtil;
 import io.apitomy.datamodels.validation.ValidationRuleMetaData;
 
 /**
@@ -40,14 +41,20 @@ public class OasUnexpectedUsageOfBearerTokenRule extends AbstractInvalidProperty
      */
     @Override
     public void visitSecurityScheme(SecurityScheme node) {
-        if (node.root().modelType() == ModelType.OPENAPI30) {
+        if (ModelTypeUtil.isOpenApi30Model(node)) {
             OpenApi30SecurityScheme scheme = (OpenApi30SecurityScheme) node;
             if (hasValue(scheme.getBearerFormat())) {
                 this.reportIfInvalid(equals(scheme.getType(), "http") && equals(scheme.getScheme(), "bearer"), node,
                         "bearerFormat", map());
             }
-        } else if (node.root().modelType() == ModelType.OPENAPI31) {
+        } else if (ModelTypeUtil.isOpenApi31Model(node)) {
             OpenApi31SecurityScheme scheme = (OpenApi31SecurityScheme) node;
+            if (hasValue(scheme.getBearerFormat())) {
+                this.reportIfInvalid(equals(scheme.getType(), "http") && equals(scheme.getScheme(), "bearer"), node,
+                        "bearerFormat", map());
+            }
+        } else if (ModelTypeUtil.isOpenApi32Model(node)) {
+            OpenApi32SecurityScheme scheme = (OpenApi32SecurityScheme) node;
             if (hasValue(scheme.getBearerFormat())) {
                 this.reportIfInvalid(equals(scheme.getType(), "http") && equals(scheme.getScheme(), "bearer"), node,
                         "bearerFormat", map());

--- a/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasUnknownHeaderParamStyleRule.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/validation/rules/invalid/value/OasUnknownHeaderParamStyleRule.java
@@ -19,6 +19,7 @@ package io.apitomy.datamodels.validation.rules.invalid.value;
 import io.apitomy.datamodels.models.Parameter;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Parameter;
 import io.apitomy.datamodels.models.openapi.v3x.v31.OpenApi31Parameter;
+import io.apitomy.datamodels.models.openapi.v3x.v32.OpenApi32Parameter;
 import io.apitomy.datamodels.util.ModelTypeUtil;
 import io.apitomy.datamodels.validation.ValidationRuleMetaData;
 
@@ -48,6 +49,9 @@ public class OasUnknownHeaderParamStyleRule extends AbstractInvalidPropertyValue
         } else if (ModelTypeUtil.isOpenApi31Model(node)) {
             style = ((OpenApi31Parameter) node).getStyle();
             _in = ((OpenApi31Parameter) node).getIn();
+        } else if (ModelTypeUtil.isOpenApi32Model(node)) {
+            style = ((OpenApi32Parameter) node).getStyle();
+            _in = ((OpenApi32Parameter) node).getIn();
         }
         if (hasValue(style)) {
             if (equals(_in, "header")) {

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/bearer-format-usage.json
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/bearer-format-usage.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Bearer Format Usage Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "test",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/bearer-format-usage.json.expected
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/bearer-format-usage.json.expected
@@ -1,0 +1,1 @@
+[SS-017] |medium| {/components/securitySchemes[apiKey]->bearerFormat} :: Security Scheme "Bearer Format" only allowed for HTTP Bearer auth scheme.

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/invalid-header-style.json
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/invalid-header-style.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Invalid Header Style Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "test",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Custom": {
+                "style": "form",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/invalid-header-style.json.expected
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/invalid-header-style.json.expected
@@ -1,0 +1,1 @@
+[HEAD-010] |medium| {/paths[/test]/get/responses[200]/headers[X-Custom]->style} :: Header Style must be "simple".

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/security-requirement-scopes.json
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/security-requirement-scopes.json
@@ -1,0 +1,33 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Security Requirement Scopes Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "test",
+        "security": [
+          {
+            "apiKey": ["read", "write"]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/security-requirement-scopes.json.expected
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/security-requirement-scopes.json.expected
@@ -1,0 +1,1 @@
+[SREQ-002] |medium| {/paths[/test]/get/security[0]->null} :: Security Requirement 'apiKey' scopes must be an empty array because the referenced Security Definition not "oauth2" or "openIdConnect".

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/unknown-param-style.json
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/unknown-param-style.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Unknown Param Style Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test": {
+      "parameters": [
+        {
+          "name": "X-Custom",
+          "in": "header",
+          "style": "label",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "test",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/data-models/src/test/resources/fixtures/validation/openapi/3.2/unknown-param-style.json.expected
+++ b/data-models/src/test/resources/fixtures/validation/openapi/3.2/unknown-param-style.json.expected
@@ -1,0 +1,1 @@
+[PAR-025] |medium| {/paths[/test]/parameters[0]->style} :: Header Parameter Style must be "simple". (Found "label").

--- a/data-models/src/test/resources/fixtures/validation/tests.json
+++ b/data-models/src/test/resources/fixtures/validation/tests.json
@@ -135,6 +135,10 @@
     { "name": "[OpenAPI 3.2] Tag Parent Validation", "test": "openapi/3.2/tag-parent.json" },
     { "name": "[OpenAPI 3.2] OAuth Device Authorization Flow", "test": "openapi/3.2/oauth-device-authorization.json" },
     { "name": "[OpenAPI 3.2] Invalid URL Format", "test": "openapi/3.2/invalid-url-format.json" },
+    { "name": "[OpenAPI 3.2] Invalid Header Style", "test": "openapi/3.2/invalid-header-style.json" },
+    { "name": "[OpenAPI 3.2] Unknown Param Style", "test": "openapi/3.2/unknown-param-style.json" },
+    { "name": "[OpenAPI 3.2] Bearer Format Usage", "test": "openapi/3.2/bearer-format-usage.json" },
+    { "name": "[OpenAPI 3.2] Security Requirement Scopes", "test": "openapi/3.2/security-requirement-scopes.json" },
 
     { "name": "[Issues] Issue 804", "test": "openapi/issues/804/formData-params.json" },
     { "name": "[Issues] Issue 88", "test": "openapi/issues/88/response-def-description.json" },


### PR DESCRIPTION
## Summary

- Added OpenAPI 3.2 version branches to 5 validation rules that were registered for `OPENAPI32`
  but had no code path handling that version, causing them to silently skip validation.
- Fixed `OasSecurityRequirementScopesMustBeEmptyRule` to include OpenAPI 3.2 in the
  `openIdConnect` allowed-types check.
- Added 4 new OpenAPI 3.2 test fixtures (HEAD-010, PAR-025, SS-017, SREQ-002) to verify all
  rules now fire correctly on 3.2 documents.

## Related Issue

Fixes #1161

## Test Plan

- [ ] Build passes (`./build.sh`) — all 1139 tests pass, 0 failures
- [ ] New `[OpenAPI 3.2] Invalid Header Style` test verifies HEAD-010 fires on 3.2
- [ ] New `[OpenAPI 3.2] Unknown Param Style` test verifies PAR-025 fires on 3.2
- [ ] New `[OpenAPI 3.2] Bearer Format Usage` test verifies SS-017 fires on 3.2
- [ ] New `[OpenAPI 3.2] Security Requirement Scopes` test verifies SREQ-002 fires on 3.2
- [ ] All existing validation tests continue to pass