### PR TITLE
fix: clear NODE_AUTH_TOKEN so npm uses OIDC for trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --provenance --access public ./data-models/target/ts/
+        env:
+          NODE_AUTH_TOKEN: ''
 
 
       - name: Slack Notification (Always)


### PR DESCRIPTION
## Summary
- `actions/setup-node` injects a default `NODE_AUTH_TOKEN` when `registry-url` is configured, causing npm to attempt token-based auth instead of the OIDC trusted publishing flow
- This results in a misleading `404 Not Found` error on `npm publish` (see [failed run](https://github.com/Apitomy/apitomy-data-models/actions/runs/29257593328/job/86843074559))
- Explicitly setting `NODE_AUTH_TOKEN: ''` on the publish step forces npm to fall back to OIDC

## Context
- npm publishes have been failing since the workflow was updated after the 3.1.1 release
- The 3.1.1 workflow avoided this by not using `registry-url` and manually configuring `.npmrc`
- Root cause documented in [actions/setup-node#1440](https://github.com/actions/setup-node/issues/1440) and [GitHub Community Discussion #176761](https://github.com/orgs/community/discussions/176761)

## Test plan
- [ ] Merge and trigger a release workflow to verify npm publish succeeds via OIDC
- [ ] If empty string doesn't work, fall back to removing `registry-url` and manually configuring `.npmrc` (the approach that worked for 3.1.1)